### PR TITLE
Allow persisting plugin state (reverb tails, etc) between calls to render() if reset=False.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ board = Pedalboard([vst, Reverb()], sample_rate=sample_rate)
 effected = board(audio)
 ```
 
-For more examples, see [the _Pedalboard Demo_ Colab notebook example](https://colab.research.google.com/drive/1bHjhJj1aCoOlXKl_lOfG99Xs3qWVrhch).
+For more examples, see:
+ - [the `examples` folder of this repository](https://github.com/spotify/pedalboard/tree/master/examples)
+ - [the _Pedalboard Demo_ Colab notebook](https://colab.research.google.com/drive/1bHjhJj1aCoOlXKl_lOfG99Xs3qWVrhch)
 
 ## Contributing
 

--- a/examples/add_reverb_to_file.py
+++ b/examples/add_reverb_to_file.py
@@ -1,0 +1,132 @@
+"""
+Add reverb to an audio file using Pedalboard.
+
+The audio file is read in chunks, using nearly no memory.
+This should be one of the fastest possible ways to add reverb to a file.
+On my laptop, this runs about 32x faster than real-time (i.e.: processes a 60-second file in <2 seconds.)
+"""
+
+import sys
+import warnings
+import argparse
+import numpy as np
+from tqdm import tqdm
+import soundfile as sf
+from tqdm.std import TqdmWarning
+from pedalboard import Reverb
+
+
+BUFFER_SIZE_SAMPLES = 1024
+NOISE_FLOOR = 1e-4
+
+
+def get_num_frames(f: sf.SoundFile) -> int:
+    # On some platforms and formats, f.frames == -1L.
+    # Check for this bug and work around it:
+    if f.frames > 2 ** 32:
+        f.seek(0)
+        last_position = f.tell()
+        while True:
+            # Seek through the file in chunks, returning
+            # if the file pointer stops advancing.
+            f.seek(1024 * 1024 * 1024, sf.SEEK_CUR)
+            new_position = f.tell()
+            if new_position == last_position:
+                return new_position
+            else:
+                last_position = new_position
+    else:
+        return f.frames
+
+
+def main():
+    warnings.filterwarnings("ignore", category=TqdmWarning)
+
+    parser = argparse.ArgumentParser(description="Add reverb to an audio file.")
+    parser.add_argument("input_file", help="The input file to add reverb to.")
+    parser.add_argument(
+        "--output-file",
+        help=(
+            "The name of the output file to write to. If not provided, {input_file}.reverb.wav will"
+            " be used."
+        ),
+        default=None,
+    )
+
+    # Instantiate the Reverb object early so we can read its defaults for the argparser --help:
+    reverb = Reverb()
+
+    parser.add_argument("--room-size", type=float, default=reverb.room_size)
+    parser.add_argument("--damping", type=float, default=reverb.damping)
+    parser.add_argument("--wet-level", type=float, default=reverb.wet_level)
+    parser.add_argument("--dry-level", type=float, default=reverb.dry_level)
+    parser.add_argument("--width", type=float, default=reverb.width)
+    parser.add_argument("--freeze-mode", type=float, default=reverb.freeze_mode)
+
+    parser.add_argument(
+        "--cut-reverb-tail",
+        action="store_true",
+        help=(
+            "If passed, remove the reverb tail to the end of the file. "
+            "The output file will be identical in length to the input file."
+        ),
+    )
+    args = parser.parse_args()
+
+    for arg in ('room_size', 'damping', 'wet_level', 'dry_level', 'width', 'freeze_mode'):
+        setattr(reverb, arg, getattr(args, arg))
+
+    if not args.output_file:
+        args.output_file = args.input_file + ".reverb.wav"
+
+    sys.stderr.write(f"Opening {args.input_file}...\n")
+
+    with sf.SoundFile(args.input_file) as input_file:
+        sys.stderr.write(f"Writing to {args.output_file}...\n")
+        with sf.SoundFile(
+            args.output_file,
+            'w',
+            samplerate=input_file.samplerate,
+            channels=input_file.channels,
+        ) as output_file:
+            length = get_num_frames(input_file)
+            length_seconds = length / input_file.samplerate
+            sys.stderr.write(f"Adding reverb to {length_seconds:.2f} seconds of audio...\n")
+            with tqdm(
+                total=length_seconds,
+                desc="Adding reverb...",
+                bar_format=(
+                    "{percentage:.0f}%|{bar}| {n:.2f}/{total:.2f} seconds processed"
+                    " [{elapsed}<{remaining}, {rate:.2f}x]"
+                ),
+                # Avoid a formatting error that occurs if
+                # TQDM tries to print before we've processed a block
+                delay=1000,
+            ) as t:
+                for dry_chunk in input_file.blocks(BUFFER_SIZE_SAMPLES, frames=length):
+                    # Actually call Pedalboard here:
+                    # (reset=False is necessary to allow the reverb tail to
+                    # continue from one chunk to the next.)
+                    effected_chunk = reverb.process(
+                        dry_chunk, sample_rate=input_file.samplerate, reset=False
+                    )
+                    # print(effected_chunk.shape, np.amax(np.abs(effected_chunk)))
+                    output_file.write(effected_chunk)
+                    t.update(len(dry_chunk) / input_file.samplerate)
+                    t.refresh()
+            if not args.cut_reverb_tail:
+                while True:
+                    # Pull audio from the effect until there's nothing left:
+                    effected_chunk = reverb.process(
+                        np.zeros((BUFFER_SIZE_SAMPLES, input_file.channels), np.float32),
+                        sample_rate=input_file.samplerate,
+                        reset=False,
+                    )
+                    if np.amax(np.abs(effected_chunk)) < NOISE_FLOOR:
+                        break
+                    output_file.write(effected_chunk)
+    sys.stderr.write("Done!\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/add_reverb_to_file.py
+++ b/examples/add_reverb_to_file.py
@@ -4,6 +4,8 @@ Add reverb to an audio file using Pedalboard.
 The audio file is read in chunks, using nearly no memory.
 This should be one of the fastest possible ways to add reverb to a file.
 On my laptop, this runs about 32x faster than real-time (i.e.: processes a 60-second file in <2 seconds.)
+
+Requirements: `pip install pysoundfile tqdm pedalboard`
 """
 
 import sys

--- a/examples/add_reverb_to_file.py
+++ b/examples/add_reverb_to_file.py
@@ -2,24 +2,28 @@
 Add reverb to an audio file using Pedalboard.
 
 The audio file is read in chunks, using nearly no memory.
-This should be one of the fastest possible ways to add reverb to a file.
-On my laptop, this runs about 32x faster than real-time
-(i.e.: processes a 60-second file in <2 seconds.)
+This should be one of the fastest possible ways to add reverb to a file
+while also using as little memory as possible.
+
+On my laptop, this runs about 58x faster than real-time
+(i.e.: processes a 60-second file in ~1 second.)
 
 Requirements: `pip install pysoundfile tqdm pedalboard`
 """
 
+import argparse
+import os
 import sys
 import warnings
-import argparse
+
 import numpy as np
-from tqdm import tqdm
 import soundfile as sf
+from tqdm import tqdm
 from tqdm.std import TqdmWarning
+
 from pedalboard import Reverb
 
-
-BUFFER_SIZE_SAMPLES = 1024
+BUFFER_SIZE_SAMPLES = 1024 * 16
 NOISE_FLOOR = 1e-4
 
 
@@ -67,6 +71,13 @@ def main():
     parser.add_argument("--freeze-mode", type=float, default=reverb.freeze_mode)
 
     parser.add_argument(
+        "-y",
+        "--overwrite",
+        action="store_true",
+        help="If passed, overwrite the output file if it already exists.",
+    )
+
+    parser.add_argument(
         "--cut-reverb-tail",
         action="store_true",
         help=(
@@ -86,6 +97,10 @@ def main():
 
     with sf.SoundFile(args.input_file) as input_file:
         sys.stderr.write(f"Writing to {args.output_file}...\n")
+        if os.path.isfile(args.output_file) and not args.overwrite:
+            raise ValueError(
+                f"Output file {args.output_file} already exists! (Pass -y to overwrite.)"
+            )
         with sf.SoundFile(
             args.output_file,
             'w',

--- a/examples/add_reverb_to_file.py
+++ b/examples/add_reverb_to_file.py
@@ -3,7 +3,8 @@ Add reverb to an audio file using Pedalboard.
 
 The audio file is read in chunks, using nearly no memory.
 This should be one of the fastest possible ways to add reverb to a file.
-On my laptop, this runs about 32x faster than real-time (i.e.: processes a 60-second file in <2 seconds.)
+On my laptop, this runs about 32x faster than real-time
+(i.e.: processes a 60-second file in <2 seconds.)
 
 Requirements: `pip install pysoundfile tqdm pedalboard`
 """

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -299,7 +299,7 @@ public:
   void prepare(const juce::dsp::ProcessSpec &spec) override {
     if (pluginInstance) {
       if (lastSpec.sampleRate != spec.sampleRate ||
-          lastSpec.maximumBlockSize != spec.maximumBlockSize ||
+          lastSpec.maximumBlockSize < spec.maximumBlockSize ||
           lastSpec.numChannels != spec.numChannels) {
         setNumChannels(spec.numChannels);
         pluginInstance->setRateAndBufferSizeDetails(spec.sampleRate,

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -291,11 +291,16 @@ public:
 
   void prepare(const juce::dsp::ProcessSpec &spec) override {
     if (pluginInstance) {
-      setNumChannels(spec.numChannels);
-      pluginInstance->setRateAndBufferSizeDetails(spec.sampleRate,
-                                                  spec.maximumBlockSize);
-      pluginInstance->prepareToPlay(spec.sampleRate, spec.maximumBlockSize);
-      pluginInstance->setNonRealtime(true);
+      if (lastSpec.sampleRate != spec.sampleRate ||
+          lastSpec.maximumBlockSize != spec.maximumBlockSize ||
+          spec.numChannels != lastSpec.numChannels) {
+        setNumChannels(spec.numChannels);
+        pluginInstance->setRateAndBufferSizeDetails(spec.sampleRate,
+                                                    spec.maximumBlockSize);
+        pluginInstance->prepareToPlay(spec.sampleRate, spec.maximumBlockSize);
+        pluginInstance->setNonRealtime(true);
+        lastSpec = spec;
+      }
     }
   }
 

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -222,7 +222,7 @@ public:
 
     pluginInstance->setStateInformation(savedState.getData(),
                                         savedState.getSize());
-    
+
     const juce::dsp::ProcessSpec _lastSpec = lastSpec;
 
     // Invalidate lastSpec to force us to update the plugin state:

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -222,6 +222,13 @@ public:
 
     pluginInstance->setStateInformation(savedState.getData(),
                                         savedState.getSize());
+    
+    const juce::dsp::ProcessSpec _lastSpec = lastSpec;
+
+    // Invalidate lastSpec to force us to update the plugin state:
+    lastSpec.numChannels = 0;
+    prepare(_lastSpec);
+
     pluginInstance->reset();
   }
 
@@ -293,7 +300,7 @@ public:
     if (pluginInstance) {
       if (lastSpec.sampleRate != spec.sampleRate ||
           lastSpec.maximumBlockSize != spec.maximumBlockSize ||
-          spec.numChannels != lastSpec.numChannels) {
+          lastSpec.numChannels != spec.numChannels) {
         setNumChannels(spec.numChannels);
         pluginInstance->setRateAndBufferSizeDetails(spec.sampleRate,
                                                     spec.maximumBlockSize);

--- a/pedalboard/JucePlugin.h
+++ b/pedalboard/JucePlugin.h
@@ -51,7 +51,7 @@ public:
 
   void prepare(const juce::dsp::ProcessSpec &spec) override {
     if (lastSpec.sampleRate != spec.sampleRate ||
-        lastSpec.maximumBlockSize != spec.maximumBlockSize ||
+        lastSpec.maximumBlockSize < spec.maximumBlockSize ||
         spec.numChannels != lastSpec.numChannels) {
       dspBlock.prepare(spec);
       lastSpec = spec;

--- a/pedalboard/JucePlugin.h
+++ b/pedalboard/JucePlugin.h
@@ -50,7 +50,12 @@ public:
   virtual ~JucePlugin(){};
 
   void prepare(const juce::dsp::ProcessSpec &spec) override {
-    dspBlock.prepare(spec);
+    if (lastSpec.sampleRate != spec.sampleRate ||
+        lastSpec.maximumBlockSize != spec.maximumBlockSize ||
+        spec.numChannels != lastSpec.numChannels) {
+      dspBlock.prepare(spec);
+      lastSpec = spec;
+    }
   }
 
   void process(

--- a/pedalboard/Plugin.h
+++ b/pedalboard/Plugin.h
@@ -41,6 +41,6 @@ public:
   std::mutex mutex;
 
 protected:
-  juce::dsp::ProcessSpec lastSpec;
+  juce::dsp::ProcessSpec lastSpec = {0};
 };
 } // namespace Pedalboard

--- a/pedalboard/Plugin.h
+++ b/pedalboard/Plugin.h
@@ -39,5 +39,8 @@ public:
   // thread-safe. Note: use std::lock or std::scoped_lock when locking multiple
   // plugins to avoid deadlocking.
   std::mutex mutex;
+
+protected:
+  juce::dsp::ProcessSpec lastSpec;
 };
 } // namespace Pedalboard

--- a/pedalboard/pedalboard.py
+++ b/pedalboard/pedalboard.py
@@ -103,6 +103,7 @@ class Pedalboard(collections.MutableSequence):
         audio: np.ndarray,
         sample_rate: Optional[float] = None,
         buffer_size: Optional[int] = None,
+        reset: bool = True,
     ) -> np.ndarray:
         if sample_rate is not None and not isinstance(sample_rate, (int, float)):
             raise TypeError("sample_rate must be None, an integer, or a floating-point number.")
@@ -121,7 +122,7 @@ class Pedalboard(collections.MutableSequence):
             )
 
         # pyBind11 makes a copy of self.plugins when passing it into process.
-        kwargs = {"sample_rate": effective_sample_rate, "plugins": self.plugins}
+        kwargs = {"sample_rate": effective_sample_rate, "plugins": self.plugins, "reset": reset}
         if buffer_size:
             kwargs["buffer_size"] = buffer_size
         return process(audio, **kwargs)

--- a/pedalboard/process.h
+++ b/pedalboard/process.h
@@ -38,10 +38,10 @@ template <typename SampleType>
 py::array_t<float>
 process(const py::array_t<SampleType, py::array::c_style> inputArray,
         double sampleRate, const std::vector<Plugin *> &plugins,
-        unsigned int bufferSize) {
+        unsigned int bufferSize, bool reset) {
   const py::array_t<float, py::array::c_style> float32InputArray =
       inputArray.attr("astype")("float32");
-  return process(float32InputArray, sampleRate, plugins, bufferSize);
+  return process(float32InputArray, sampleRate, plugins, bufferSize, reset);
 }
 
 /**
@@ -50,9 +50,9 @@ process(const py::array_t<SampleType, py::array::c_style> inputArray,
 template <typename SampleType>
 py::array_t<float>
 processSingle(const py::array_t<SampleType, py::array::c_style> inputArray,
-              double sampleRate, Plugin &plugin, unsigned int bufferSize) {
+              double sampleRate, Plugin &plugin, unsigned int bufferSize, bool reset) {
   std::vector<Plugin *> plugins{&plugin};
-  return process<SampleType>(inputArray, sampleRate, plugins, bufferSize);
+  return process<SampleType>(inputArray, sampleRate, plugins, bufferSize, reset);
 }
 
 /**
@@ -64,7 +64,7 @@ template <>
 py::array_t<float>
 process<float>(const py::array_t<float, py::array::c_style> inputArray,
                double sampleRate, const std::vector<Plugin *> &plugins,
-               unsigned int bufferSize) {
+               unsigned int bufferSize, bool reset) {
   // Numpy/Librosa convention is (num_samples, num_channels)
   py::buffer_info inputInfo = inputArray.request();
 
@@ -152,10 +152,12 @@ process<float>(const py::array_t<float, py::array::c_style> inputArray,
           std::make_unique<std::scoped_lock<std::mutex>>(plugin->mutex));
     }
 
-    for (auto *plugin : plugins) {
-      if (plugin == nullptr)
-        continue;
-      plugin->reset();
+    if (reset) {
+      for (auto *plugin : plugins) {
+        if (plugin == nullptr)
+          continue;
+        plugin->reset();
+      }
     }
 
     juce::dsp::ProcessSpec spec;

--- a/pedalboard/process.h
+++ b/pedalboard/process.h
@@ -50,9 +50,11 @@ process(const py::array_t<SampleType, py::array::c_style> inputArray,
 template <typename SampleType>
 py::array_t<float>
 processSingle(const py::array_t<SampleType, py::array::c_style> inputArray,
-              double sampleRate, Plugin &plugin, unsigned int bufferSize, bool reset) {
+              double sampleRate, Plugin &plugin, unsigned int bufferSize,
+              bool reset) {
   std::vector<Plugin *> plugins{&plugin};
-  return process<SampleType>(inputArray, sampleRate, plugins, bufferSize, reset);
+  return process<SampleType>(inputArray, sampleRate, plugins, bufferSize,
+                             reset);
 }
 
 /**

--- a/pedalboard/python_bindings.cpp
+++ b/pedalboard/python_bindings.cpp
@@ -54,20 +54,20 @@ PYBIND11_MODULE(pedalboard_native, m) {
         "Run a 32-bit floating point audio buffer through a list of Pedalboard "
         "plugins.",
         py::arg("input_array"), py::arg("sample_rate"), py::arg("plugins"),
-        py::arg("buffer_size") = DEFAULT_BUFFER_SIZE);
+        py::arg("buffer_size") = DEFAULT_BUFFER_SIZE, py::arg("reset") = true);
 
   m.def("process", process<double>,
         "Run a 64-bit floating point audio buffer through a list of Pedalboard "
         "plugins. The buffer will be converted to 32-bit for processing.",
         py::arg("input_array"), py::arg("sample_rate"), py::arg("plugins"),
-        py::arg("buffer_size") = DEFAULT_BUFFER_SIZE);
+        py::arg("buffer_size") = DEFAULT_BUFFER_SIZE, py::arg("reset") = true);
 
   m.def("process", processSingle<float>,
         "Run a 32-bit floating point audio buffer through a single Pedalboard "
         "plugin. (Note: if calling this multiple times with multiple plugins, "
         "consider passing a list of plugins instead.)",
         py::arg("input_array"), py::arg("sample_rate"), py::arg("plugin"),
-        py::arg("buffer_size") = DEFAULT_BUFFER_SIZE);
+        py::arg("buffer_size") = DEFAULT_BUFFER_SIZE, py::arg("reset") = true);
 
   m.def("process", processSingle<double>,
         "Run a 64-bit floating point audio buffer through a single Pedalboard "
@@ -75,7 +75,7 @@ PYBIND11_MODULE(pedalboard_native, m) {
         "consider passing a list of plugins instead.) The buffer will be "
         "converted to 32-bit for processing.",
         py::arg("input_array"), py::arg("sample_rate"), py::arg("plugin"),
-        py::arg("buffer_size") = DEFAULT_BUFFER_SIZE);
+        py::arg("buffer_size") = DEFAULT_BUFFER_SIZE, py::arg("reset") = true);
 
   auto plugin =
       py::class_<Plugin>(m, "Plugin",
@@ -94,24 +94,26 @@ PYBIND11_MODULE(pedalboard_native, m) {
               "process",
               [](Plugin *self,
                  const py::array_t<float, py::array::c_style> inputArray,
-                 double sampleRate, unsigned int bufferSize) {
-                return process(inputArray, sampleRate, {self}, bufferSize);
+                 double sampleRate, unsigned int bufferSize, bool reset) {
+                return process(inputArray, sampleRate, {self}, bufferSize,
+                               reset);
               },
               "Run a 32-bit floating point audio buffer through this plugin."
               "(Note: if calling this multiple times with multiple plugins, "
               "consider using pedalboard.process(...) instead.)",
               py::arg("input_array"), py::arg("sample_rate"),
-              py::arg("buffer_size") = DEFAULT_BUFFER_SIZE)
+              py::arg("buffer_size") = DEFAULT_BUFFER_SIZE,
+              py::arg("reset") = true)
 
           .def(
               "process",
               [](Plugin *self,
                  const py::array_t<double, py::array::c_style> inputArray,
-                 double sampleRate, unsigned int bufferSize) {
+                 double sampleRate, unsigned int bufferSize, bool reset) {
                 const py::array_t<float, py::array::c_style> float32InputArray =
                     inputArray.attr("astype")("float32");
                 return process(float32InputArray, sampleRate, {self},
-                               bufferSize);
+                               bufferSize, reset);
               },
               "Run a 64-bit floating point audio buffer through this plugin."
               "(Note: if calling this multiple times with multiple plugins, "
@@ -119,7 +121,8 @@ PYBIND11_MODULE(pedalboard_native, m) {
               "will be "
               "converted to 32-bit for processing.",
               py::arg("input_array"), py::arg("sample_rate"),
-              py::arg("buffer_size") = DEFAULT_BUFFER_SIZE);
+              py::arg("buffer_size") = DEFAULT_BUFFER_SIZE,
+              py::arg("reset") = true);
   plugin.attr("__call__") = plugin.attr("process");
 
   init_chorus(m);

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -312,10 +312,10 @@ def test_plugin_state_cleared_between_invocations(plugin_filename: str):
     plugin = load_test_plugin(plugin_filename)
     sr = 44100
     noise = np.random.rand(sr)
-    slience = np.zeros_like(noise)
+    silence = np.zeros_like(noise)
 
-    # Passing zero inputs should return
-    effected_silence = plugin(slience, sr)
+    # Passing zero inputs should return silence
+    effected_silence = plugin(silence, sr)
     plugin_noise_floor = np.amax(np.abs(effected_silence))
 
     effected = plugin(noise, sr)
@@ -323,7 +323,26 @@ def test_plugin_state_cleared_between_invocations(plugin_filename: str):
 
     # Calling plugin again shouldn't allow any audio tails
     # to carry over from previous calls.
-    assert np.allclose(plugin(slience, sr), effected_silence)
+    assert np.allclose(plugin(silence, sr), effected_silence)
+
+
+@pytest.mark.parametrize("plugin_filename", AVAILABLE_PLUGINS_IN_TEST_ENVIRONMENT)
+def test_plugin_state_not_cleared_between_invocations(plugin_filename: str):
+    plugin = load_test_plugin(plugin_filename)
+    sr = 44100
+    noise = np.random.rand(sr)
+    silence = np.zeros_like(noise)
+
+    # Passing zero inputs should return silence
+    effected_silence = plugin(silence, sr, reset=False)
+    plugin_noise_floor = np.amax(np.abs(effected_silence))
+
+    effected = plugin(noise, sr, reset=False)
+    assert np.amax(np.abs(effected)) > plugin_noise_floor * 10
+
+    # Calling plugin again shouldn't allow any audio tails
+    # to carry over from previous calls.
+    assert np.allclose(plugin(silence, sr), effected_silence)
 
 
 @pytest.mark.parametrize("value", (True, False))

--- a/tests/test_native_module.py
+++ b/tests/test_native_module.py
@@ -116,3 +116,24 @@ def test_plugin_state_not_cleared_between_invocations(reset: bool):
         assert effected_silence_noise_floor == 0.0
     else:
         assert effected_silence_noise_floor > 0.25
+
+
+def test_plugin_state_not_cleared_if_passed_smaller_buffer():
+    """
+    Ensure that if `reset` is False, a smaller buffer size can be
+    passed without clearing the plugin's internal state:
+    """
+    reverb = Reverb()
+    sr = 44100
+    noise = np.random.rand(sr)
+    silence = np.zeros_like(noise)
+
+    # Assert that reverb adds nothing if no signal was present already:
+    assert np.amax(np.abs(reverb(silence, sr, reset=False))) == 0.0
+
+    # Pass in noise followed by silence, but less silence:
+    reverb(noise, sr, reset=False)
+    effected_silence = reverb(silence[: int(len(silence) / 2)], sr, reset=False)
+    effected_silence_noise_floor = np.amax(np.abs(effected_silence))
+
+    assert effected_silence_noise_floor > 0.25


### PR DESCRIPTION
Pedalboard currently clears any internal plugin state by calling `Plugin::reset` every time it processes a new buffer of audio. This is great for the batch use case (as it keeps output consistent) but prevents Pedalboard from being used to process audio incrementally. (i.e.: adding reverb to a buffer in chunks is currently not possible, as the state inside the reverb plugin would be reset between each chunk of audio, cutting off the reverb tail.)

This PR adds a new `reset: bool` flag, which defaults to `True`. If set to `False`, Pedalboard will avoid resetting the plugin instance between renders, which allows its usage on chunks of audio (or even in real-time). This is risky, however, as the same plugin object can't be used in multiple pedalboards if `reset=False`.

After this change, it's now possible to process audio even without loading the whole file into memory with something like:
```python3
import soundfile as sf
from pedalboard import Pedalboard, Compressor, Reverb

with sf.SoundFile("./my-hour-long-audio.wav") as input_file, sf.SoundFile(
    "./output.wav",
    "w",
    samplerate=input_file.samplerate,
    channels=input_file.channels
) as output_file:
    board = Pedalboard([Compressor(), Reverb()], sample_rate=input_file.samplerate)

    # Only load and process 1,024 samples at a time to keep memory usage super low:
    for block in input_file.blocks(1024):
        output_file.write(board.process(block, reset=False)) # reset=False is crucial here!
```

This PR also includes a tiny optimization: `prepare` is no longer called on each plugin unless the number of input channels, sample rate, or size of each sample buffer changes. This should remove a tiny amount of overhead from successive calls to `process`, as plugins no longer need to be re-initialized.