### PR TITLE
Add --recurse-submodules to git clone in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ We'd love to get patches from you!
 To get your environment set up to build `pedalboard`, you'll need a working C++ compiler on your machine (`xcode-select --install` on macOS should do it). Try:
 
 ```shell
-git clone git@github.com:spotify/pedalboard.git
+git clone --recurse-submodules --shallow-submodules git@github.com:spotify/pedalboard.git
 cd pedalboard
 pip3 install pybind11
 pip3 install .


### PR DESCRIPTION
The instructions as written don't check out the `JUCE` subtree, so I tweaked 'em.

I also added `--shallow-submodules` because that speeds up checking out the huge JUCE module considerably, though that step is still rather slow.