### PR TITLE
read SoundFile object because getting frames

### DIFF
--- a/examples/add_reverb_to_file.py
+++ b/examples/add_reverb_to_file.py
@@ -30,6 +30,7 @@ NOISE_FLOOR = 1e-4
 def get_num_frames(f: sf.SoundFile) -> int:
     # On some platforms and formats, f.frames == -1L.
     # Check for this bug and work around it:
+    f.read()
     if f.frames > 2 ** 32:
         f.seek(0)
         last_position = f.tell()


### PR DESCRIPTION
by browsing soundfile's code I noticed that reading the file before getting the frames was needed.

I still get some errors though: apparently `delay` is not a recognized argument for tqdm.