### PR TITLE
Ensure that Python identifiers for parameters only contain ASCII.

### DIFF
--- a/pedalboard/pedalboard.py
+++ b/pedalboard/pedalboard.py
@@ -466,7 +466,7 @@ def to_python_parameter_name(parameter: _AudioProcessorParameter) -> Optional[st
     if parameter.label and not parameter.label.startswith(":"):
         name = "{} {}".format(name, parameter.label.lower())
     # Replace all non-alphanumeric characters with underscores
-    name = [c if c.isalpha() or c.isnumeric() else "_" for c in name]
+    name = [c if (c.isalpha() or c.isnumeric()) and c.isascii() else "_" for c in name]
     # Remove any double-underscores:
     name = [a for a, b in zip(name, name[1:]) if a != b or b != "_"] + [name[-1]]
     # Remove any leading or trailing underscores:

--- a/pedalboard/pedalboard.py
+++ b/pedalboard/pedalboard.py
@@ -20,7 +20,6 @@ import weakref
 from functools import update_wrapper
 from contextlib import contextmanager
 from typing import List, Optional, Dict, Union, Tuple, Iterable
-from curses.ascii import isascii  # needed for Python 3.6 compatibility
 
 import numpy as np
 
@@ -467,7 +466,7 @@ def to_python_parameter_name(parameter: _AudioProcessorParameter) -> Optional[st
     if parameter.label and not parameter.label.startswith(":"):
         name = "{} {}".format(name, parameter.label.lower())
     # Replace all non-alphanumeric characters with underscores
-    name = [c if (c.isalpha() or c.isnumeric()) and isascii(c) else "_" for c in name]
+    name = [c if (c.isalpha() or c.isnumeric()) and c.isprintable() and ord(c) < 128 else "_" for c in name]
     # Remove any double-underscores:
     name = [a for a, b in zip(name, name[1:]) if a != b or b != "_"] + [name[-1]]
     # Remove any leading or trailing underscores:

--- a/pedalboard/pedalboard.py
+++ b/pedalboard/pedalboard.py
@@ -467,8 +467,7 @@ def to_python_parameter_name(parameter: _AudioProcessorParameter) -> Optional[st
         name = "{} {}".format(name, parameter.label.lower())
     # Replace all non-alphanumeric characters with underscores
     name = [
-        c
-        if (c.isalpha() or c.isnumeric()) and c.isprintable() and ord(c) < 128 else "_"
+        c if (c.isalpha() or c.isnumeric()) and c.isprintable() and ord(c) < 128 else "_"
         for c in name
     ]
     # Remove any double-underscores:

--- a/pedalboard/pedalboard.py
+++ b/pedalboard/pedalboard.py
@@ -466,7 +466,11 @@ def to_python_parameter_name(parameter: _AudioProcessorParameter) -> Optional[st
     if parameter.label and not parameter.label.startswith(":"):
         name = "{} {}".format(name, parameter.label.lower())
     # Replace all non-alphanumeric characters with underscores
-    name = [c if (c.isalpha() or c.isnumeric()) and c.isprintable() and ord(c) < 128 else "_" for c in name]
+    name = [
+        c
+        if (c.isalpha() or c.isnumeric()) and c.isprintable() and ord(c) < 128 else "_"
+        for c in name
+    ]
     # Remove any double-underscores:
     name = [a for a, b in zip(name, name[1:]) if a != b or b != "_"] + [name[-1]]
     # Remove any leading or trailing underscores:

--- a/pedalboard/pedalboard.py
+++ b/pedalboard/pedalboard.py
@@ -20,6 +20,7 @@ import weakref
 from functools import update_wrapper
 from contextlib import contextmanager
 from typing import List, Optional, Dict, Union, Tuple, Iterable
+from curses.ascii import isascii  # needed for Python 3.6 compatibility
 
 import numpy as np
 
@@ -466,7 +467,7 @@ def to_python_parameter_name(parameter: _AudioProcessorParameter) -> Optional[st
     if parameter.label and not parameter.label.startswith(":"):
         name = "{} {}".format(name, parameter.label.lower())
     # Replace all non-alphanumeric characters with underscores
-    name = [c if (c.isalpha() or c.isnumeric()) and c.isascii() else "_" for c in name]
+    name = [c if (c.isalpha() or c.isnumeric()) and isascii(c) else "_" for c in name]
     # Remove any double-underscores:
     name = [a for a, b in zip(name, name[1:]) if a != b or b != "_"] + [name[-1]]
     # Remove any leading or trailing underscores:


### PR DESCRIPTION
Fixes #20. The particular plugin in question seems to render the º symbol using an unknown character encoding, and I haven't found a good heuristic or combination of transformations that actually returns a º. Instead, this solves the more immediate problem of the Python attribute being an invalid identifier:

```
# Before this PR:
setattr(dearVR, 'azimuth_ￂﾰ', -50)

# After this PR:
dearVR.azimuth = -50
```