### PR TITLE
Force-reload plugins only if they persist audio across render calls.

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,10 @@
+# Pedalboard VST/Audio Unit Compatibility List
+
+| Plugin Name                                                          | Author                                                 | Format       | macOS      | Linux                  | Windows             |
+|----------------------------------------------------------------------|--------------------------------------------------------|--------------|------------|------------------------|---------------------|
+| [CHOWTapeModel](https://github.com/jatinchowdhury18/AnalogTapeModel) | [Jatin Chowdhury](https://github.com/jatinchowdhury18) | VST3®        | ✅ Working | ✅ Working              | ✅ Working          | 
+| [CHOWTapeModel](https://github.com/jatinchowdhury18/AnalogTapeModel) | [Jatin Chowdhury](https://github.com/jatinchowdhury18) | Audio Unit   | ✅ Working | ☑️ _No AU support_      | ☑️ _No AU support_  | 
+| [dearVR MICRO](https://www.dear-reality.com/products/dearvr-micro)   | [Dear Reality](https://www.dear-reality.com/)          | VST3®        | ✅ Working | ☑️ _Plugin not offered_ | ❓ Unknown          |
+| [dearVR MICRO](https://www.dear-reality.com/products/dearvr-micro)   | [Dear Reality](https://www.dear-reality.com/)          | Audio Unit   | ✅ Working | ☑️ _Plugin not offered_ | ☑️ _No AU support_  |
+| [RoughRider3](https://www.audiodamage.com/pages/free-downloads)      | [Audio Damage](https://www.audiodamage.com/)           | VST3®        | ✅ Working | ✅ Working              | ❓ Unknown          | 
+| [RoughRider3](https://www.audiodamage.com/pages/free-downloads)      | [Audio Damage](https://www.audiodamage.com/)           | Audio Unit   | ✅ Working | ☑️ _No AU support_      | ☑️ _No AU support_  | 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,28 @@ pip install pedalboard
   - Tested automatically on GitHub with VSTs
   - Platform wheels available for `amd64` (Intel/AMD)
 
+#### Plugin Compatibility
+
+`pedalboard` allows loading VST3® and Audio Unit plugins, which could contain _any_ code.
+Most plugins that have been tested work just fine with `pedalboard`, but some plugins may
+not work with `pedalboard`; at worst, some may even crash the Python interpreter without
+warning and with no ability to catch the error. For an ever-growing compatibility list,
+see [COMPATIBILITY.md](COMPATIBILITY.md).
+
+Most audio plugins are "well-behaved" and conform to a set of conventions for how audio
+plugins are supposed to work, but many do not conform to the VST3® or Audio Unit
+specifications. `pedalboard` attempts to detect some common programming errors in plugins
+and can work around many issues, including automatically detecting plugins that don't
+clear their internal state when asked. Even so, plugins can misbehave without `pedalboard`
+noticing.
+
+If audio is being rendered incorrectly or if audio is "leaking" from one `process()` call
+to the next in an undesired fashion, try:
+
+1. Passing silence to the plugin in between calls to `process()`, to ensure that any
+   reverb tails or other internal state has time to fade to silence
+1. Reloading the plugin every time audio is processed (with `pedalboard.load_plugin`)
+
 ## Examples
 
 A very basic example of how to use `pedalboard`'s built-in plugins:

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -110,6 +110,29 @@ private:
 };
 #endif
 
+enum class ExternalPluginReloadType {
+  /**
+   * Unknown: we need to determine the reload type.
+   */
+  Unknown,
+  
+  /**
+   * Most plugins are of this type: calling .reset() on them will clear their internal state.
+   * This is quick and easy: to start processing a new buffer, all we need to do is call
+   * .reset() and optionally prepareToPlay().
+   */
+  ClearsAudioOnReset,
+
+  /**
+   * This plugin type is a bit more of a pain to deal with; it could be argued that plugins
+   * that don't clear their internal buffers when reset() is called are buggy.
+   * To start processing a new buffer, we'll have to find another way to clear the buffer,
+   * usually by reloading the plugin from scratch and persisting its parameters somehow.
+   */
+  PersistsAudioOnReset,
+};
+
+
 template <typename ExternalPluginType> class ExternalPlugin : public Plugin {
 public:
   ExternalPlugin(std::string &_pathToPluginFile)
@@ -193,8 +216,14 @@ public:
   void reinstantiatePlugin() {
     // If we have an existing plugin, save its state and reload its state later:
     juce::MemoryBlock savedState;
+    std::map<int, float> currentParameters;
+
     if (pluginInstance) {
       pluginInstance->getStateInformation(savedState);
+
+      for (auto *parameter : pluginInstance->getParameters()) {
+        currentParameters[parameter->getParameterIndex()] = parameter->getValue();
+      }
 
       {
         std::lock_guard<std::mutex> lock(EXTERNAL_PLUGIN_MUTEX);
@@ -217,23 +246,71 @@ public:
                                      loadError.toStdString());
       }
 
+      auto mainInputBus = pluginInstance->getBus(true, 0);
+      auto mainOutputBus = pluginInstance->getBus(false, 0);
+
+      if (!mainInputBus) {
+        auto exception = std::invalid_argument(
+            "Plugin '" + pluginInstance->getName().toStdString() +
+            "' does not accept audio input. It may be an instrument plug-in "
+            "and not an audio effect processor.");
+        pluginInstance.reset();
+        throw exception;
+      }
+
+      if (!mainOutputBus) {
+        auto exception = std::invalid_argument(
+            "Plugin '" + pluginInstance->getName().toStdString() +
+            "' does not produce audio output.");
+        pluginInstance.reset();
+        throw exception;
+      }
+
+      if (reloadType == ExternalPluginReloadType::Unknown) {
+        reloadType = detectReloadType();
+        if (reloadType == ExternalPluginReloadType::PersistsAudioOnReset) {
+          // Reload again, as we just passed audio into a plugin that
+          // we know doesn't reset itself cleanly!
+          pluginInstance = pluginFormatManager.createPluginInstance(
+            foundPluginDescription, ExternalLoadSampleRate,
+            ExternalLoadMaximumBlockSize, loadError);
+
+            if (!pluginInstance) {
+              throw pybind11::import_error("Unable to load plugin " +
+                                          pathToPluginFile.toStdString() + ": " +
+                                          loadError.toStdString());
+            }
+        }
+      }
+      
+
       NUM_ACTIVE_EXTERNAL_PLUGINS++;
     }
 
     pluginInstance->setStateInformation(savedState.getData(),
                                         savedState.getSize());
 
-    const juce::dsp::ProcessSpec _lastSpec = lastSpec;
+    for (auto *parameter : pluginInstance->getParameters()) {
+      if (currentParameters.count(parameter->getParameterIndex()) > 0) {
+        parameter->setValue(currentParameters[parameter->getParameterIndex()]);
+      }
+    }
 
-    // Invalidate lastSpec to force us to update the plugin state:
-    lastSpec.numChannels = 0;
-    prepare(_lastSpec);
+    if (lastSpec.numChannels != 0) {
+      const juce::dsp::ProcessSpec _lastSpec = lastSpec;
+      // Invalidate lastSpec to force us to update the plugin state:
+      lastSpec.numChannels = 0;
+      prepare(_lastSpec);
+    }
 
     pluginInstance->reset();
   }
 
   void setNumChannels(int numChannels) {
     if (!pluginInstance)
+      return;
+
+    if (numChannels == 0)
       return;
 
     pluginInstance->disableNonMainBuses();
@@ -258,6 +335,15 @@ public:
       pluginInstance->getBus(false, i)->enable(false);
     }
 
+    if (mainInputBus->getNumberOfChannels() == numChannels &&
+        mainOutputBus->getNumberOfChannels() == numChannels) {
+      return;
+    }
+
+    // Cache these values in case the plugin fails to update:
+    auto previousInputChannelCount = mainInputBus->getNumberOfChannels();
+    auto previousOutputChannelCount = mainOutputBus->getNumberOfChannels();
+
     // Try to change the input and output bus channel counts...
     mainInputBus->setNumberOfChannels(numChannels);
     mainOutputBus->setNumberOfChannels(numChannels);
@@ -266,6 +352,11 @@ public:
     // conclude the plugin doesn't allow this channel count.
     if (mainInputBus->getNumberOfChannels() != numChannels ||
         mainOutputBus->getNumberOfChannels() != numChannels) {
+
+      // Reset the bus configuration to what it was before, so we don't
+      // leave one of the buses smaller than the other:
+      mainInputBus->setNumberOfChannels(previousInputChannelCount);
+      mainOutputBus->setNumberOfChannels(previousOutputChannelCount);
 
       throw std::invalid_argument(
           "Plugin '" + pluginInstance->getName().toStdString() +
@@ -296,98 +387,209 @@ public:
     return mainInputBus->getNumberOfChannels();
   }
 
-  void prepare(const juce::dsp::ProcessSpec &spec) override {
-    if (pluginInstance) {
-      if (lastSpec.sampleRate != spec.sampleRate ||
-          lastSpec.maximumBlockSize < spec.maximumBlockSize ||
-          lastSpec.numChannels != spec.numChannels) {
-        setNumChannels(spec.numChannels);
-        pluginInstance->setRateAndBufferSizeDetails(spec.sampleRate,
-                                                    spec.maximumBlockSize);
-        pluginInstance->prepareToPlay(spec.sampleRate, spec.maximumBlockSize);
-        pluginInstance->setNonRealtime(true);
-        lastSpec = spec;
+  /**
+   * Send some audio through the plugin to detect if the ->reset() call
+   * actually resets internal buffers. This determines how quickly we
+   * can reset the plugin and is only called on instantiation.
+   */
+  ExternalPluginReloadType detectReloadType() {
+    const int numInputChannels = pluginInstance->getMainBusNumInputChannels();
+    const int bufferSize = 512;
+    const float sampleRate = 44100.0f;
+
+    if (numInputChannels == 0) {
+      return ExternalPluginReloadType::Unknown;
+    }
+
+    // Set input and output busses/channels appropriately:
+    setNumChannels(numInputChannels);
+    pluginInstance->setNonRealtime(true);
+    pluginInstance->prepareToPlay(sampleRate, bufferSize);
+
+    // Send in a buffer full of silence to get a baseline noise level:
+    juce::AudioBuffer<float> audioBuffer(numInputChannels, bufferSize);
+    juce::MidiBuffer emptyMidiBuffer;    
+
+    // Process the silent buffer a couple of times to give the plugin time to "warm up"
+    for (int i = 0; i < 5; i++) {
+      audioBuffer.clear();
+      {
+        juce::dsp::AudioBlock<float> block(audioBuffer);
+        juce::dsp::ProcessContextReplacing<float> context(block);
+        process(context);
       }
+    }
+
+    // Measure the noise floor of the plugin:
+    auto noiseFloor = audioBuffer.getMagnitude(0, bufferSize);
+
+    // Reset:
+    pluginInstance->releaseResources();
+    pluginInstance->setNonRealtime(true);
+    pluginInstance->prepareToPlay(sampleRate, bufferSize);
+    
+    juce::Random random;
+  
+    // Send noise into the plugin:
+    for (int i = 0; i < 5; i++) {
+      for (auto i = 0; i < bufferSize; i++) {
+        for (int c = 0; c < numInputChannels; c++) {
+          audioBuffer.setSample(c, i, (random.nextFloat() * 2.0f) - 1.0f);
+        }
+      }
+      juce::dsp::AudioBlock<float> block(audioBuffer);
+      juce::dsp::ProcessContextReplacing<float> context(block);
+      process(context);
+    }
+    
+    auto signalVolume = audioBuffer.getMagnitude(0, bufferSize);
+
+    // Reset again, and send in silence:
+    pluginInstance->releaseResources();
+    pluginInstance->setNonRealtime(true);
+    pluginInstance->prepareToPlay(sampleRate, bufferSize);
+    audioBuffer.clear();
+    {
+      juce::dsp::AudioBlock<float> block(audioBuffer);
+      juce::dsp::ProcessContextReplacing<float> context(block);
+      process(context);
+    }
+    
+    auto magnitudeOfSilentBuffer = audioBuffer.getMagnitude(0, bufferSize);
+
+    // If the silent buffer we passed in post-reset is noticeably louder
+    // than the first buffer we passed in, this plugin probably persists
+    // internal state across calls to releaseResources().
+    bool pluginPersistsAudioOnReset = magnitudeOfSilentBuffer > noiseFloor * 5;
+
+    if (pluginPersistsAudioOnReset) {
+      return ExternalPluginReloadType::PersistsAudioOnReset;  
+    } else {
+      return ExternalPluginReloadType::ClearsAudioOnReset;
     }
   }
 
+  /**
+   * reset() is only called if reset=True is passed.
+   */
   void reset() noexcept override {
     if (pluginInstance) {
-      // Some VSTs don't actually clear their internal state when calling
-      // reset(). Here, we force a reset by reinstantiating the plugin.
-      pluginInstance->reset();
-      reinstantiatePlugin();
+      switch (reloadType) {
+        case ExternalPluginReloadType::ClearsAudioOnReset:
+          pluginInstance->reset();
+          pluginInstance->releaseResources();
+          break;
+          
+        case ExternalPluginReloadType::Unknown:
+        case ExternalPluginReloadType::PersistsAudioOnReset:
+          pluginInstance->releaseResources();
+          reinstantiatePlugin();
+          break;
+        default:
+          throw std::runtime_error("Plugin reload type is an invalid value (" + std::to_string((int) reloadType) +  ") - this likely indicates a programming error or memory corruption.");
+      }
+
+      // Force prepare() to be called again later by invalidating lastSpec:
+      lastSpec.maximumBlockSize = 0;
     }
   }
+
+  /**
+   * prepare() is called on every render call, regardless of if the plugin has been reset.
+   */
+  void prepare(const juce::dsp::ProcessSpec &spec) override {
+    if (!pluginInstance) {
+      return;
+    }
+
+    if (lastSpec.sampleRate != spec.sampleRate ||
+        lastSpec.maximumBlockSize < spec.maximumBlockSize ||
+        lastSpec.numChannels != spec.numChannels) {
+      
+      // Changing the number of channels requires releaseResources to be called:
+      if (lastSpec.numChannels != spec.numChannels) {
+        pluginInstance->releaseResources();
+        setNumChannels(spec.numChannels);
+      }
+
+      pluginInstance->setNonRealtime(true);
+      pluginInstance->prepareToPlay(spec.sampleRate, spec.maximumBlockSize);
+      
+      lastSpec = spec;
+    }
+  }
+
 
   void
   process(const juce::dsp::ProcessContextReplacing<float> &context) override {
+    
     if (pluginInstance) {
       juce::MidiBuffer emptyMidiBuffer;
       if (context.usesSeparateInputAndOutputBlocks()) {
         throw std::runtime_error("Not implemented yet - "
                                  "no support for using separate "
                                  "input and output blocks.");
-      } else {
-        size_t pluginBufferChannelCount = 0;
-        // Iterate through all input busses and add their input channels to our
-        // buffer:
-        for (size_t i = 0;
-             i < static_cast<size_t>(pluginInstance->getBusCount(true)); i++) {
-          if (pluginInstance->getBus(true, i)->isEnabled()) {
-            pluginBufferChannelCount +=
-                pluginInstance->getBus(true, i)->getNumberOfChannels();
-          }
-        }
-
-        juce::dsp::AudioBlock<float> &outputBlock = context.getOutputBlock();
-
-        std::vector<float *> channelPointers(pluginBufferChannelCount);
-
-        for (size_t i = 0; i < outputBlock.getNumChannels(); i++) {
-          channelPointers[i] = outputBlock.getChannelPointer(i);
-        }
-
-        // Depending on the bus layout, we may have to pass extra buffers to the
-        // plugin that we don't use. Use vector here to ensure the memory is
-        // freed via RAII.
-        std::vector<std::vector<float>> dummyChannels;
-        for (size_t i = outputBlock.getNumChannels();
-             i < pluginBufferChannelCount; i++) {
-          std::vector<float> dummyChannel(outputBlock.getNumSamples());
-          channelPointers[i] = dummyChannel.data();
-          dummyChannels.push_back(dummyChannel);
-        }
-
-        if ((size_t)pluginInstance->getMainBusNumInputChannels() !=
-            outputBlock.getNumChannels()) {
-          throw std::invalid_argument(
-              "Plugin '" + pluginInstance->getName().toStdString() +
-              "' was instantiated with " +
-              std::to_string(pluginInstance->getMainBusNumInputChannels()) +
-              "-channel input, but data provided was " +
-              std::to_string(outputBlock.getNumChannels()) + "-channel.");
-        }
-
-        if ((size_t)pluginInstance->getMainBusNumOutputChannels() <
-            outputBlock.getNumChannels()) {
-          throw std::invalid_argument(
-              "Plugin '" + pluginInstance->getName().toStdString() +
-              "' produces " +
-              std::to_string(pluginInstance->getMainBusNumOutputChannels()) +
-              "-channel output, but data provided was " +
-              std::to_string(outputBlock.getNumChannels()) +
-              "-channel. (The number of channels returned must match the "
-              "number of channels passed in.)");
-        }
-
-        // Create an audio buffer that doesn't actually allocate anything, but
-        // just points to the data in the ProcessContext.
-        juce::AudioBuffer<float> audioBuffer(channelPointers.data(),
-                                             pluginBufferChannelCount,
-                                             outputBlock.getNumSamples());
-        pluginInstance->processBlock(audioBuffer, emptyMidiBuffer);
       }
+
+      juce::dsp::AudioBlock<float> &outputBlock = context.getOutputBlock();
+
+      // This should already be true, as prepare() should have been called before this!
+      if ((size_t)pluginInstance->getMainBusNumInputChannels() !=
+          outputBlock.getNumChannels()) {
+        throw std::invalid_argument(
+            "Plugin '" + pluginInstance->getName().toStdString() +
+            "' was instantiated with " +
+            std::to_string(pluginInstance->getMainBusNumInputChannels()) +
+            "-channel input, but data provided was " +
+            std::to_string(outputBlock.getNumChannels()) + "-channel.");
+      }
+
+      if ((size_t)pluginInstance->getMainBusNumOutputChannels() <
+          outputBlock.getNumChannels()) {
+        throw std::invalid_argument(
+            "Plugin '" + pluginInstance->getName().toStdString() +
+            "' produces " +
+            std::to_string(pluginInstance->getMainBusNumOutputChannels()) +
+            "-channel output, but data provided was " +
+            std::to_string(outputBlock.getNumChannels()) +
+            "-channel. (The number of channels returned must match the "
+            "number of channels passed in.)");
+      }
+
+      size_t pluginBufferChannelCount = 0;
+      // Iterate through all input busses and add their input channels to our
+      // buffer:
+      for (size_t i = 0;
+            i < static_cast<size_t>(pluginInstance->getBusCount(true)); i++) {
+        if (pluginInstance->getBus(true, i)->isEnabled()) {
+          pluginBufferChannelCount +=
+              pluginInstance->getBus(true, i)->getNumberOfChannels();
+        }
+      }
+
+      std::vector<float *> channelPointers(pluginBufferChannelCount);
+
+      for (size_t i = 0; i < outputBlock.getNumChannels(); i++) {
+        channelPointers[i] = outputBlock.getChannelPointer(i);
+      }
+
+      // Depending on the bus layout, we may have to pass extra buffers to the
+      // plugin that we don't use. Use vector here to ensure the memory is
+      // freed via RAII.
+      std::vector<std::vector<float>> dummyChannels;
+      for (size_t i = outputBlock.getNumChannels();
+            i < pluginBufferChannelCount; i++) {
+        std::vector<float> dummyChannel(outputBlock.getNumSamples());
+        channelPointers[i] = dummyChannel.data();
+        dummyChannels.push_back(dummyChannel);
+      }
+
+      // Create an audio buffer that doesn't actually allocate anything, but
+      // just points to the data in the ProcessContext.
+      juce::AudioBuffer<float> audioBuffer(channelPointers.data(),
+                                            pluginBufferChannelCount,
+                                            outputBlock.getNumSamples());
+      pluginInstance->processBlock(audioBuffer, emptyMidiBuffer);
     }
   }
 
@@ -415,6 +617,8 @@ private:
   juce::PluginDescription foundPluginDescription;
   juce::AudioPluginFormatManager pluginFormatManager;
   std::unique_ptr<juce::AudioPluginInstance> pluginInstance;
+  
+  ExternalPluginReloadType reloadType = ExternalPluginReloadType::Unknown;
 };
 
 inline void init_external_plugins(py::module &m) {

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -290,11 +290,16 @@ public:
     pluginInstance->setStateInformation(savedState.getData(),
                                         savedState.getSize());
 
-    for (auto *parameter : pluginInstance->getParameters()) {
-      if (currentParameters.count(parameter->getParameterIndex()) > 0) {
-        parameter->setValue(currentParameters[parameter->getParameterIndex()]);
+    // Set all of the parameters twice: we may have meta-parameters that change the
+    // validity of other `setValue` calls. (i.e.: param1 can't be set until param2 is set.)
+    for (int i = 0; i < 2; i++) {
+      for (auto *parameter : pluginInstance->getParameters()) {
+        if (currentParameters.count(parameter->getParameterIndex()) > 0) {
+          parameter->setValue(currentParameters[parameter->getParameterIndex()]);
+        }
       }
     }
+    
 
     if (lastSpec.numChannels != 0) {
       const juce::dsp::ProcessSpec _lastSpec = lastSpec;

--- a/pedalboard/pedalboard.py
+++ b/pedalboard/pedalboard.py
@@ -98,6 +98,15 @@ class Pedalboard(collections.MutableSequence):
     def __getitem__(self, index: int) -> Optional[Plugin]:
         return self.plugins.__getitem__(index)
 
+    def reset(self):
+        """
+        Clear any internal state (e.g.: reverb tails) kept by all of the plugins in this
+        Pedalboard. The values of plugin parameters will remain unchanged. For most plugins,
+        this is a fast operation; for some, this will cause a full re-instantiation of the plugin.
+        """
+        for plugin in self.plugins:
+            plugin.reset()
+
     def process(
         self,
         audio: np.ndarray,

--- a/pedalboard/python_bindings.cpp
+++ b/pedalboard/python_bindings.cpp
@@ -91,6 +91,13 @@ PYBIND11_MODULE(pedalboard_native, m) {
             return nullptr;
           }))
           .def(
+              "reset",
+              &Plugin::reset,
+              "Clear any internal state kept by this plugin (e.g.: reverb "
+              "tails). The values of plugin parameters will remain unchanged. "
+              "For most plugins, this is a fast operation; for some, this will "
+              "cause a full re-instantiation of the plugin.")
+          .def(
               "process",
               [](Plugin *self,
                  const py::array_t<float, py::array::c_style> inputArray,

--- a/pedalboard/python_bindings.cpp
+++ b/pedalboard/python_bindings.cpp
@@ -91,8 +91,7 @@ PYBIND11_MODULE(pedalboard_native, m) {
             return nullptr;
           }))
           .def(
-              "reset",
-              &Plugin::reset,
+              "reset", &Plugin::reset,
               "Clear any internal state kept by this plugin (e.g.: reverb "
               "tails). The values of plugin parameters will remain unchanged. "
               "For most plugins, this is a fast operation; for some, this will "

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -444,6 +444,38 @@ def test_plugin_state_not_cleared_between_invocations_if_reset_is_false(plugin_f
     assert max_volume_of(plugin(silence, sr, reset=False)) > 0.00001
 
 
+@pytest.mark.parametrize("plugin_filename", AVAILABLE_PLUGINS_IN_TEST_ENVIRONMENT)
+def test_explicit_reset(plugin_filename: str):
+    plugin = load_test_plugin(plugin_filename, disable_caching=True)
+
+    sr = 44100
+    noise = np.random.rand(sr, 2)
+    assert max_volume_of(noise) > 0.95
+    silence = np.zeros_like(noise)
+    assert max_volume_of(silence) == 0.0
+
+    assert max_volume_of(plugin(silence, sr, reset=False)) < 0.00001
+    assert max_volume_of(plugin(noise, sr, reset=False)) > 0.00001
+    plugin.reset()
+    assert max_volume_of(plugin(silence, sr, reset=False)) < 0.00001
+
+
+@pytest.mark.parametrize("plugin_filename", AVAILABLE_PLUGINS_IN_TEST_ENVIRONMENT)
+def test_explicit_reset_in_pedalboard(plugin_filename: str):
+    sr = 44100
+    board = pedalboard.Pedalboard([load_test_plugin(plugin_filename, disable_caching=True)], sr)
+    noise = np.random.rand(sr, 2)
+
+    assert max_volume_of(noise) > 0.95
+    silence = np.zeros_like(noise)
+    assert max_volume_of(silence) == 0.0
+
+    assert max_volume_of(board(silence, reset=False)) < 0.00001
+    assert max_volume_of(board(noise, reset=False)) > 0.00001
+    board.reset()
+    assert max_volume_of(board(silence, reset=False)) < 0.00001
+
+
 @pytest.mark.parametrize("value", (True, False))
 def test_wrapped_bool(value: bool):
     wrapped = WrappedBool(value)

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -17,6 +17,7 @@
 
 import os
 import math
+import random
 import platform
 from glob import glob
 
@@ -49,9 +50,10 @@ def get_parameters(plugin_filename: str):
 
 
 TEST_PLUGIN_CACHE = {}
+TEST_PLUGIN_ORIGINAL_PARAMETER_CACHE = {}
 
 
-def load_test_plugin(plugin_filename: str, *args, **kwargs):
+def load_test_plugin(plugin_filename: str, disable_caching: bool = False, *args, **kwargs):
     """
     Load a plugin file from disk, or use an existing instance to save
     on test runtime if we already have one in memory.
@@ -61,11 +63,40 @@ def load_test_plugin(plugin_filename: str, *args, **kwargs):
     """
 
     key = repr((plugin_filename, args, tuple(kwargs.items())))
-    if key not in TEST_PLUGIN_CACHE:
-        TEST_PLUGIN_CACHE[key] = pedalboard.load_plugin(
+    if key not in TEST_PLUGIN_CACHE or disable_caching:
+        plugin = pedalboard.load_plugin(
             os.path.join(TEST_PLUGIN_BASE_PATH, platform.system(), plugin_filename), *args, **kwargs
         )
-    return TEST_PLUGIN_CACHE[key]
+        if disable_caching:
+            return plugin
+        TEST_PLUGIN_CACHE[key] = plugin
+        TEST_PLUGIN_ORIGINAL_PARAMETER_CACHE[key] = {
+            key: getattr(plugin, key) for key in plugin.parameters.keys()
+        }
+
+    # Reset default parameters when loading:
+    plugin = TEST_PLUGIN_CACHE[key]
+    for name in plugin.parameters.keys():
+        setattr(plugin, name, TEST_PLUGIN_ORIGINAL_PARAMETER_CACHE[key][name])
+
+    # Throw some silence in and force a reset:
+    plugin.process(np.zeros((44100, 2)), 44100, reset=True)
+    return plugin
+
+
+# Allow testing with all of the plugins on the local machine:
+if os.environ.get("ENABLE_TESTING_WITH_LOCAL_PLUGINS", False):
+    for plugin_class in pedalboard.AVAILABLE_PLUGIN_CLASSES:
+        for plugin_path in plugin_class.installed_plugins:
+            try:
+                load_test_plugin(plugin_path)
+                AVAILABLE_PLUGINS_IN_TEST_ENVIRONMENT.append(plugin_path)
+            except Exception:
+                pass
+
+
+def max_volume_of(x: np.ndarray) -> float:
+    return np.amax(np.abs(x))
 
 
 def test_at_least_one_plugin_is_available_for_testing():
@@ -90,10 +121,13 @@ def test_initial_parameters(plugin_filename: str):
     }
 
     # Reload the plugin, but set the initial parameters in the load call.
-    plugin = load_test_plugin(plugin_filename, parameters)
+    plugin = load_test_plugin(plugin_filename, parameter_values=parameters)
 
-    for name, value in parameters.items():
-        assert getattr(plugin, name) == value
+    for name, expected in parameters.items():
+        actual = getattr(plugin, name)
+        if math.isnan(actual):
+            continue
+        assert actual == expected, f"Expected attribute {name} to be {expected}, but was {actual}"
 
 
 @pytest.mark.parametrize(
@@ -108,14 +142,15 @@ def test_initial_parameter_validation(plugin_filename: str, parameter_name: str)
     plugin = load_test_plugin(plugin_filename)
     with pytest.raises(ValueError):
         load_test_plugin(
-            plugin_filename, {parameter_name: getattr(plugin, parameter_name).max_value + 100}
+            plugin_filename,
+            parameter_values={parameter_name: getattr(plugin, parameter_name).max_value + 100},
         )
 
 
 @pytest.mark.parametrize("plugin_filename", AVAILABLE_PLUGINS_IN_TEST_ENVIRONMENT)
 def test_initial_parameter_validation_missing(plugin_filename: str):
     with pytest.raises(AttributeError):
-        load_test_plugin(plugin_filename, {"missing_parameter": 123})
+        load_test_plugin(plugin_filename, parameter_values={"missing_parameter": 123})
 
 
 @pytest.mark.parametrize("loader", [pedalboard.load_plugin] + pedalboard.AVAILABLE_PLUGIN_CLASSES)
@@ -134,8 +169,32 @@ def test_plugin_accepts_variable_channel_count(
 ):
     plugin = load_test_plugin(plugin_filename)
     noise = np.random.rand(num_channels, sample_rate)
-    effected = plugin(noise, sample_rate)
-    assert effected.shape == noise.shape
+    try:
+        effected = plugin(noise, sample_rate)
+        assert effected.shape == noise.shape
+    except ValueError as e:
+        if "does not support" not in str(e):
+            raise
+
+
+@pytest.mark.parametrize("plugin_filename", AVAILABLE_PLUGINS_IN_TEST_ENVIRONMENT)
+def test_plugin_accepts_variable_channel_count_without_reloading(plugin_filename: str):
+    plugin = load_test_plugin(plugin_filename)
+    for num_channels, sample_rate in [
+        (1, 48000),
+        (2, 48000),
+        (1, 44100),
+        (2, 44100),
+        (1, 22050),
+        (2, 22050),
+    ]:
+        noise = np.random.rand(num_channels, sample_rate)
+        try:
+            effected = plugin(noise, sample_rate)
+            assert effected.shape == noise.shape
+        except ValueError as e:
+            if "does not support" not in str(e):
+                raise
 
 
 @pytest.mark.parametrize("plugin_filename", AVAILABLE_PLUGINS_IN_TEST_ENVIRONMENT)
@@ -229,6 +288,8 @@ def test_float_parameters(plugin_filename: str, parameter_name: str):
     step_size = parameter_value.step_size or parameter_value.approximate_step_size
     for new_value in np.arange(_min, _max, step_size):
         setattr(plugin, parameter_name, new_value)
+        if math.isnan(getattr(plugin, parameter_name)):
+            continue
         assert math.isclose(new_value, getattr(plugin, parameter_name), abs_tol=step_size * 2)
 
     # Ensure that if we access an attribute that we're not adding to the value,
@@ -308,41 +369,79 @@ def test_string_parameter_valdation(plugin_filename: str, parameter_name: str):
 
 
 @pytest.mark.parametrize("plugin_filename", AVAILABLE_PLUGINS_IN_TEST_ENVIRONMENT)
-def test_plugin_state_cleared_between_invocations(plugin_filename: str):
+def test_plugin_parameters_persist_between_calls(plugin_filename: str):
     plugin = load_test_plugin(plugin_filename)
     sr = 44100
-    noise = np.random.rand(sr)
-    silence = np.zeros_like(noise)
+    noise = np.random.rand(2, sr)
 
-    # Passing zero inputs should return silence
-    effected_silence = plugin(silence, sr)
-    plugin_noise_floor = np.amax(np.abs(effected_silence))
+    # Set random parameter values on the plugin:
+    for name, parameter in plugin.parameters.items():
+        if name == "program":
+            continue
+        if parameter.type == float:
+            low, high, step = parameter.range
+            if not step:
+                step = 0.1
+            if low is None:
+                low = 0.0
+            if high is None:
+                high = 1.0
+            values = [
+                x * step for x in list(range(int(low / step), int(high / step), 1)) + [high / step]
+            ]
+            random_value = random.choice(values)
+        elif parameter.type == bool:
+            random_value = bool(random.random())
+        elif parameter.type == str:
+            if parameter.valid_values:
+                random_value = random.choice(parameter.valid_values)
+            else:
+                random_value = None
+        if random_value is not None:
+            setattr(plugin, name, random_value)
 
-    effected = plugin(noise, sr)
-    assert np.amax(np.abs(effected)) > plugin_noise_floor * 10
+    expected_values = {}
+    for name, parameter in plugin.parameters.items():
+        expected_values[name] = getattr(plugin, name)
 
-    # Calling plugin again shouldn't allow any audio tails
-    # to carry over from previous calls.
-    assert np.allclose(plugin(silence, sr), effected_silence)
+    plugin.process(noise, sr)
+
+    for name, parameter in plugin.parameters.items():
+        assert (
+            getattr(plugin, name) == expected_values[name]
+        ), f"Expected {name} to match saved value"
 
 
 @pytest.mark.parametrize("plugin_filename", AVAILABLE_PLUGINS_IN_TEST_ENVIRONMENT)
-def test_plugin_state_not_cleared_between_invocations(plugin_filename: str):
-    plugin = load_test_plugin(plugin_filename)
+def test_plugin_state_cleared_between_invocations_by_default(plugin_filename: str):
+    plugin = load_test_plugin(plugin_filename, disable_caching=True)
+
     sr = 44100
-    noise = np.random.rand(sr)
+    noise = np.random.rand(sr, 2)
+    assert max_volume_of(noise) > 0.95
     silence = np.zeros_like(noise)
+    assert max_volume_of(silence) == 0.0
 
-    # Passing zero inputs should return silence
-    effected_silence = plugin(silence, sr, reset=False)
-    plugin_noise_floor = np.amax(np.abs(effected_silence))
+    assert max_volume_of(plugin(silence, sr)) < 0.00001
+    assert max_volume_of(plugin(noise, sr)) > 0.00001
+    for _ in range(10):
+        assert max_volume_of(silence) == 0.0
+        assert max_volume_of(plugin(silence, sr)) < 0.00001
 
-    effected = plugin(noise, sr, reset=False)
-    assert np.amax(np.abs(effected)) > plugin_noise_floor * 10
 
-    # Calling plugin again shouldn't allow any audio tails
-    # to carry over from previous calls.
-    assert np.allclose(plugin(silence, sr), effected_silence)
+@pytest.mark.parametrize("plugin_filename", AVAILABLE_PLUGINS_IN_TEST_ENVIRONMENT)
+def test_plugin_state_not_cleared_between_invocations_if_reset_is_false(plugin_filename: str):
+    plugin = load_test_plugin(plugin_filename, disable_caching=True)
+
+    sr = 44100
+    noise = np.random.rand(sr, 2)
+    assert max_volume_of(noise) > 0.95
+    silence = np.zeros_like(noise)
+    assert max_volume_of(silence) == 0.0
+
+    assert max_volume_of(plugin(silence, sr, reset=False)) < 0.00001
+    assert max_volume_of(plugin(noise, sr, reset=False)) > 0.00001
+    assert max_volume_of(plugin(silence, sr, reset=False)) > 0.00001
 
 
 @pytest.mark.parametrize("value", (True, False))


### PR DESCRIPTION
This PR resolves a subtle but nasty bug discovered by @charlesneimog in #25.

**The tl;dr**: VSTs and Audio Units _should_ clear their internal buffer states [if `juce::AudioProcessor::reset()` is called](https://github.com/juce-framework/JUCE/blob/master/modules/juce_audio_processors/processors/juce_AudioProcessor.h#L891-L896). However, this is up to the plugin itself - and in testing, a decent number of plugins don't.

Guidance on VST forums seems to suggest that VST hosts often re-instantiate plugins from scratch (i.e.: call the constructor and discard the old object) whenever it's necessary to _guarantee_ that the plugin invalidates its internal state. Before this PR, we did this. We also saved the plugin's state and reloaded it after re-instantiation, but not all plugins save all of their parameters when their state is dumped. This would cause the values of their parameters to be reset to defaults. To get around this bug, this PR also adds logic to ensure that parameter values are explicitly saved before re-instantiation and re-loaded afterwards.

However, this is quite expensive, and as `pedalboard` resets the plugin _every time_ `process` is called, this slows things down too much. So, this PR introduces a step whenever plugins are loaded to detect if the plugin can be trusted to do the right thing when `reset()` is called:
 - The plugin is loaded with default parameters
 - Some silence is passed into the plugin, and its "noise floor" is measured
 - A burst of full-spectrum noise is passed in, and the output volume is measured
 - The default methods used to reset the plugin are called (`reset()` and `releaseResources()`)
 - Silence is passed in, and the resulting output volume is measured and compared to the noise floor.

If the plugin's output after reset isn't as "clean" as it was when it was first instantiated, `pedalboard` assumes that it can't be trusted to reset its internal buffers, and a flag is set to force the expensive re-instantiation every time we want to clear state.

This PR also includes a `COMPATIBILITY.md`, as solving this bug resulted in having to test `pedalboard` manually with a whole bunch of different VSTs.