### PR TITLE
Fix __repr__ returning None for some plugins.

### DIFF
--- a/pedalboard/pedalboard.py
+++ b/pedalboard/pedalboard.py
@@ -335,6 +335,10 @@ class AudioProcessorParameter(object):
                         self.max_value,
                         self.approximate_step_size,
                     )
+                else:
+                    return "{} value={} range=({}, {}, ?)>".format(
+                        cpp_repr_value, self.string_value, self.min_value, self.max_value
+                    )
             elif self.type is str:
                 return '{} value="{}" ({} valid string value{})>'.format(
                     cpp_repr_value,


### PR DESCRIPTION
One code path results in a `__repr__` of `None`, which throws a `TypeError`. This was observed in production when testing with [TAL-Reverb-2](https://tal-software.com/products/tal-reverb). (In the future, we should change the test suite on GitHub Actions to download some non-public and non-open-source plugin binaries for testing to catch stuff like this without having to run the test suite locally.)