### PR TITLE
Throw an error message if plugin.parameters is assigned to.

### DIFF
--- a/pedalboard/pedalboard.py
+++ b/pedalboard/pedalboard.py
@@ -142,6 +142,16 @@ def looks_like_float(s: str) -> bool:
         return False
 
 
+class ReadOnlyDictWrapper(dict):
+    def __setitem__(self, name, value):
+        raise TypeError(
+            "The .parameters dictionary on a Plugin instance returns "
+            "a read-only dictionary of its parameters. To change a "
+            "parameter, set the parameter on the plugin directly as "
+            f"an attribute. (`my_plugin.{name} = {value}`)"
+        )
+
+
 def wrap_type(base_type):
     class WeakTypeWrapper(base_type):
         """
@@ -490,7 +500,9 @@ class ExternalPlugin(object):
 
     @property
     def parameters(self) -> Dict[str, AudioProcessorParameter]:
-        return self._get_parameters()
+        # Return a read-only version of this dictionary,
+        # to prevent people from trying to assign to it.
+        return ReadOnlyDictWrapper(self._get_parameters())
 
     def _get_parameters(self):
         if not hasattr(self, "__python_parameter_cache__"):

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -147,6 +147,16 @@ def test_all_parameters_are_accessible_as_properties(plugin_filename: str):
 
 
 @pytest.mark.parametrize("plugin_filename", AVAILABLE_PLUGINS_IN_TEST_ENVIRONMENT)
+def test_parameters_cant_be_assigned_to_directly(plugin_filename: str):
+    plugin = load_test_plugin(plugin_filename)
+    assert plugin.parameters
+    for parameter_name in plugin.parameters.keys():
+        current_value = getattr(plugin, parameter_name)
+        with pytest.raises(TypeError):
+            plugin.parameters[parameter_name] = current_value
+
+
+@pytest.mark.parametrize("plugin_filename", AVAILABLE_PLUGINS_IN_TEST_ENVIRONMENT)
 def test_all_parameters_have_accessors(plugin_filename: str):
     plugin = load_test_plugin(plugin_filename)
     assert plugin.parameters


### PR DESCRIPTION
@charlesneimog tripped over an unclear part of the Pedalboard API - namely, assigning to the `parameters` dictionary (returned by `ExternalPlugin`) is possible to do without raising an error, but is a no-op. This PR changes `parameters` to be a `ReadOnlyDictWrapper`, which throws a descriptive `TypeError` if an item is set.