### PR TITLE
Download third-party VSTs for testing on GitHub Actions.

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -90,6 +90,11 @@ jobs:
         if: runner.os == 'Windows'
       - name: Build pedalboard locally
         run: python setup.py install
+      - name: Install VSTs for testing
+        env:
+          GCS_ASSET_BUCKET_NAME: ${{ secrets.GCS_ASSET_BUCKET_NAME }}
+          GCS_READER_SERVICE_ACCOUNT_KEY: ${{ secrets.GCS_READER_SERVICE_ACCOUNT_KEY }}
+        run: python ./tests/download_test_plugins.py
       - name: Run tests
         if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.6'
         run: pytest -v --cov-report term --cov-fail-under=${{ env.MINIMUM_COVERAGE_PERCENTAGE }} --cov=pedalboard

--- a/pedalboard/pedalboard.py
+++ b/pedalboard/pedalboard.py
@@ -296,7 +296,6 @@ class AudioProcessorParameter(object):
         self.max_value = None
         self.step_size = None
         self.approximate_step_size = None
-        self.valid_values = list(self.ranges.values())
         self.type = str
 
         if all(looks_like_float(v) for v in self.ranges.values()):
@@ -315,15 +314,14 @@ class AudioProcessorParameter(object):
                 self.approximate_step_size = sum(first_derivative_steps) / len(
                     first_derivative_steps
                 )
-        elif len(self.valid_values) == 2 and (
-            TRUE_BOOLEANS & {v.lower() for v in self.valid_values}
-        ):
+        elif len(self.ranges) == 2 and (TRUE_BOOLEANS & {v.lower() for v in self.ranges.values()}):
             self.type = bool
             self.ranges = {k: v.lower() in TRUE_BOOLEANS for k, v in self.ranges.items()}
             self.min_value = False
             self.max_value = True
             self.step_size = 1
 
+        self.valid_values = list(self.ranges.values())
         self.range = self.min_value, self.max_value, self.step_size
         self._value_to_raw_value_ranges = {value: _range for _range, value in self.ranges.items()}
 

--- a/pedalboard/pedalboard.py
+++ b/pedalboard/pedalboard.py
@@ -246,6 +246,12 @@ FloatWithParameter = wrap_type(float)
 BooleanWithParameter = wrap_type(WrappedBool)
 
 
+# Some plugins, on some platforms (TAL Reverb 3 on Ubuntu, so far) seem to
+# expose every possible MIDI CC value as a separate parameter
+# (i.e.: MIDI CC [0-16]|[0-128], resulting in 2,048 parameters).
+# This hugely delays load times and adds complexity to the interface.
+PARAMETER_NAME_SUBSTRINGS_TO_IGNORE = {"MIDI CC "}
+
 TRUE_BOOLEANS = {"on", "yes", "true", "enabled"}
 
 
@@ -532,6 +538,10 @@ class ExternalPlugin(object):
 
         parameters = {}
         for cpp_parameter in self._parameters:
+            if any(
+                [substr in cpp_parameter.name for substr in PARAMETER_NAME_SUBSTRINGS_TO_IGNORE]
+            ):
+                continue
             if cpp_parameter.name not in self.__python_parameter_cache__:
                 self.__python_parameter_cache__[cpp_parameter.name] = AudioProcessorParameter(
                     self, cpp_parameter.name

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,3 +12,5 @@ interrogate
 numpy
 sox
 tensorflow==2.5.0
+google-cloud-storage
+tqdm

--- a/tests/download_test_plugins.py
+++ b/tests/download_test_plugins.py
@@ -1,0 +1,46 @@
+"""
+This script is intended to run on GitHub Actions to download plugin files
+that we can't embed in the repository itself, but we still want to use for
+testing purposes.
+"""
+
+import os
+import json
+from tqdm import tqdm
+import platform
+from google.cloud import storage
+from google.oauth2 import service_account
+
+
+def main():
+    GCS_ASSET_BUCKET_NAME = os.environ.get("GCS_ASSET_BUCKET_NAME")
+    if not GCS_ASSET_BUCKET_NAME:
+        raise ValueError("Missing GCS_ASSET_BUCKET_NAME environment variable!")
+
+    GCS_READER_SERVICE_ACCOUNT_KEY = os.environ.get("GCS_READER_SERVICE_ACCOUNT_KEY")
+    if not GCS_READER_SERVICE_ACCOUNT_KEY:
+        raise ValueError("Missing GCS_READER_SERVICE_ACCOUNT_KEY environment variable!")
+
+    json_acct_info = json.loads(GCS_READER_SERVICE_ACCOUNT_KEY)
+    credentials = service_account.Credentials.from_service_account_info(json_acct_info)
+    client = storage.Client(credentials=credentials)
+
+    target_filepath = os.path.join(".", "tests", "plugins", platform.system())
+    bucket = client.bucket(GCS_ASSET_BUCKET_NAME)
+    prefix = f"test-plugins/{platform.system()}"
+
+    # Manually iterate here instead of just calling gsutil on the command line as
+    # GSUtil on Windows is not 100% guaranteed to install properly on GitHub Actions.
+    print("Downloading test plugin files from Google Cloud Storage...")
+    for blob in tqdm(list(bucket.list_blobs(prefix=prefix))):
+        local_path = os.path.join(target_filepath, blob.name.replace(prefix + "/", ""))
+        if local_path.endswith("/"):
+            os.makedirs(local_path, exist_ok=True)
+        else:
+            os.makedirs(os.path.dirname(local_path), exist_ok=True)
+            blob.download_to_filename(local_path)
+    print("Done!")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -44,7 +44,11 @@ if os.getenv("CIBW_TEST_REQUIRES") or os.getenv("CI"):
 
 def get_parameters(plugin_filename: str):
     try:
-        return load_test_plugin(plugin_filename).parameters
+        return {
+            k: v
+            for k, v in load_test_plugin(plugin_filename).parameters.items()
+            if "midi_cc_" not in k
+        }
     except ImportError:
         return {}
 

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -417,10 +417,11 @@ def test_plugin_parameters_persist_between_calls(plugin_filename: str):
                 random_value = random.choice(parameter.valid_values)
             else:
                 random_value = None
-        if random_value is not None:
-            print(
-                f"Setting parameter {name} to random value: {random_value} ({type(random_value)})"
-            )
+        if (
+            random_value is not None
+            and "bypass" not in name.lower()
+            and "preset" not in name.lower()
+        ):
             setattr(plugin, name, random_value)
 
     expected_values = {}

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -418,6 +418,9 @@ def test_plugin_parameters_persist_between_calls(plugin_filename: str):
             else:
                 random_value = None
         if random_value is not None:
+            print(
+                f"Setting parameter {name} to random value: {random_value} ({type(random_value)})"
+            )
             setattr(plugin, name, random_value)
 
     expected_values = {}

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -44,11 +44,7 @@ if os.getenv("CIBW_TEST_REQUIRES") or os.getenv("CI"):
 
 def get_parameters(plugin_filename: str):
     try:
-        return {
-            k: v
-            for k, v in load_test_plugin(plugin_filename).parameters.items()
-            if "midi_cc_" not in k
-        }
+        return load_test_plugin(plugin_filename).parameters
     except ImportError:
         return {}
 


### PR DESCRIPTION
We can't embed non-open-source plugins in this repo itself (as we do with the excellent and GPLv3-licensed [CHOWTapeModel](https://github.com/jatinchowdhury18/AnalogTapeModel)) - but we do want to do automated testing with more than just a single plugin.

This PR:
 - adds a `download_test_plugins.py` script that is basically just `gsutil -m cp -r gs://our-public-bucket ./tests/plugins`, but unlike `gsutil`, guaranteed to install easily on Windows
 - adds the appropriate step to our GitHub Action to download plugins before starting tests
 - that's it! the plugin files are downloaded into the location our other plugin files live in: they'll be picked up by the test runner automatically.

Both GCS bucket name that we download the files from and the dedicated service account key we use are stored as encrypted GitHub environment variables and not printed to the log. The files might as well be public (and are, for the most part, freely downloadable from other sources) but keeping these variables secret is a good idea for now.

Note that I expect CI to fail on this PR, as many of the plugins downloaded by this PR trip over bugs that are resolved in https://github.com/spotify/pedalboard/pull/27.