### PR TITLE
Enable linux docker builds on Apple Silicon

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -188,7 +188,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel>=2.0.0a4
-
+      - name: Set up QEMU for aarch64 on Linux
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -195,7 +195,7 @@ jobs:
           CIBW_TEST_REQUIRES: -r test-requirements.txt
           CIBW_TEST_COMMAND: "pytest {project}/tests"
           CIBW_ARCHS: auto64 # Only support building 64-bit wheels. It's 2021!
-          CIBW_ARCHS_LINUX: aarch64 # Useful for building linux images with Apple Silicon
+          CIBW_ARCHS_LINUX: auto64 aarch64 # Useful for building linux images with Apple Silicon
           CIBW_SKIP: '*27* *35*' # Ignore Python 2.x, 3.5
           CIBW_ARCHS_MACOS: x86_64 universal2 # Support Apple Silicon
           # on macOS and with Python 3.10: building NumPy from source fails without these options:

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -227,6 +227,9 @@ jobs:
           CIBW_TEST_REQUIRES: -r test-requirements.txt
           CIBW_TEST_COMMAND: "pytest {project}/tests"
           CIBW_BUILD: ${{ matrix.build }}
+          CIBW_ARCHS: auto64 # Only support building 64-bit wheels. It's 2022!
+          CIBW_ARCHS_LINUX: auto64 aarch64 # Useful for building linux images with Apple Silicon
+          CIBW_ARCHS_MACOS: x86_64 universal2 # Support Apple Silicon
           # on macOS and with Python 3.10: building NumPy from source fails without these options:
           CIBW_ENVIRONMENT: NPY_BLAS_ORDER="" NPY_LAPACK_ORDER=""
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: pip install auditwheel-symbols && (auditwheel repair -w {dest_dir} {wheel} || auditwheel-symbols --manylinux 2010 {wheel})

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -174,18 +174,46 @@ jobs:
     # if: github.event_name == 'release' && github.event.action == 'published'
     strategy:
       matrix:
-        python-version: ['3.8']
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    name: Build wheels on ${{ matrix.os }}
+        include:
+        - { os: macos-latest, build: cp36-macosx_x86_64 }
+        - { os: macos-latest, build: cp37-macosx_x86_64 }
+        - { os: macos-latest, build: cp38-macosx_universal2 }
+        - { os: macos-latest, build: cp39-macosx_universal2 }
+        - { os: macos-latest, build: cp310-macosx_universal2 }
+        - { os: macos-latest, build: pp37-macosx_x86_64 }
+        - { os: macos-latest, build: pp38-macosx_x86_64 }
+        - { os: windows-latest, build: cp36-win_amd64 }
+        - { os: windows-latest, build: cp37-win_amd64 }
+        - { os: windows-latest, build: cp38-win_amd64 }
+        - { os: windows-latest, build: cp39-win_amd64 }
+        - { os: windows-latest, build: cp39-win_arm64 }
+        - { os: windows-latest, build: cp310-win_amd64 }
+        - { os: windows-latest, build: cp310-win_arm64 }
+        - { os: windows-latest, build: pp37-win_amd64 }
+        - { os: windows-latest, build: pp38-win_amd64 }
+        - { os: ubuntu-latest, build: cp36-manylinux_x86_64 }
+        - { os: ubuntu-latest, build: cp36-manylinux_aarch64 }
+        - { os: ubuntu-latest, build: cp37-manylinux_x86_64 }
+        - { os: ubuntu-latest, build: cp37-manylinux_aarch64 }
+        - { os: ubuntu-latest, build: cp38-manylinux_x86_64 }
+        - { os: ubuntu-latest, build: cp38-manylinux_aarch64 }
+        - { os: ubuntu-latest, build: cp39-manylinux_x86_64 }
+        - { os: ubuntu-latest, build: cp39-manylinux_aarch64 }
+        - { os: ubuntu-latest, build: cp310-manylinux_x86_64 }
+        - { os: ubuntu-latest, build: cp310-manylinux_aarch64 }
+        - { os: ubuntu-latest, build: pp37-manylinux_x86_64 }
+        - { os: ubuntu-latest, build: pp37-manylinux_aarch64 }
+        - { os: ubuntu-latest, build: pp38-manylinux_x86_64 }
+        - { os: ubuntu-latest, build: pp38-manylinux_aarch64 }
+    name: Build wheels for ${{ matrix.build }}
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-
       # Used to host cibuildwheel, so version doesn't really matter
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.8"
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel>=2.0.0a4
       - name: Set up QEMU for aarch64 on Linux
@@ -198,10 +226,7 @@ jobs:
         env:
           CIBW_TEST_REQUIRES: -r test-requirements.txt
           CIBW_TEST_COMMAND: "pytest {project}/tests"
-          CIBW_ARCHS: auto64 # Only support building 64-bit wheels. It's 2021!
-          CIBW_ARCHS_LINUX: auto64 aarch64 # Useful for building linux images with Apple Silicon
-          CIBW_SKIP: '*27* *35*' # Ignore Python 2.x, 3.5
-          CIBW_ARCHS_MACOS: x86_64 universal2 # Support Apple Silicon
+          CIBW_BUILD: ${{ matrix.build }}
           # on macOS and with Python 3.10: building NumPy from source fails without these options:
           CIBW_ENVIRONMENT: NPY_BLAS_ORDER="" NPY_LAPACK_ORDER=""
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: pip install auditwheel-symbols && (auditwheel repair -w {dest_dir} {wheel} || auditwheel-symbols --manylinux 2010 {wheel})
@@ -219,7 +244,6 @@ jobs:
           # so we can't run post-wheel-build tests there.
           # Also testing any pypy versions fails, as TensorFlow isn't pypy compatible.
           CIBW_TEST_SKIP: "*manylinux* *pp* *-macosx_universal2:arm64"
-
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -171,7 +171,7 @@ jobs:
     needs: [lint-python, lint-cpp]
     runs-on: ${{ matrix.os }}
     continue-on-error: false
-    # if: github.event_name == 'release' && github.event.action == 'published'
+    if: github.event_name == 'release' && github.event.action == 'published'
     strategy:
       matrix:
         include:
@@ -203,7 +203,7 @@ jobs:
         - { os: ubuntu-latest, build: pp37-manylinux_aarch64 }
         - { os: ubuntu-latest, build: pp38-manylinux_x86_64 }
         - { os: ubuntu-latest, build: pp38-manylinux_aarch64 }
-    name: Build wheels for ${{ matrix.build }}
+    name: Build wheel for ${{ matrix.build }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -186,9 +186,7 @@ jobs:
         - { os: windows-latest, build: cp37-win_amd64 }
         - { os: windows-latest, build: cp38-win_amd64 }
         - { os: windows-latest, build: cp39-win_amd64 }
-        - { os: windows-latest, build: cp39-win_arm64 }
         - { os: windows-latest, build: cp310-win_amd64 }
-        - { os: windows-latest, build: cp310-win_arm64 }
         - { os: windows-latest, build: pp37-win_amd64 }
         - { os: windows-latest, build: pp38-win_amd64 }
         - { os: ubuntu-latest, build: cp36-manylinux_x86_64 }

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -195,6 +195,7 @@ jobs:
           CIBW_TEST_REQUIRES: -r test-requirements.txt
           CIBW_TEST_COMMAND: "pytest {project}/tests"
           CIBW_ARCHS: auto64 # Only support building 64-bit wheels. It's 2021!
+          CIBW_ARCHS_LINUX: aarch64 # Useful for building linux images with Apple Silicon
           CIBW_SKIP: '*27* *35*' # Ignore Python 2.x, 3.5
           CIBW_ARCHS_MACOS: x86_64 universal2 # Support Apple Silicon
           # on macOS and with Python 3.10: building NumPy from source fails without these options:

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -171,7 +171,7 @@ jobs:
     needs: [lint-python, lint-cpp]
     runs-on: ${{ matrix.os }}
     continue-on-error: false
-    if: github.event_name == 'release' && github.event.action == 'published'
+    # if: github.event_name == 'release' && github.event.action == 'published'
     strategy:
       matrix:
         python-version: ['3.8']

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pedalboard)
 ![Supported Platforms](https://img.shields.io/badge/platforms-macOS%20%7C%20Windows%20%7C%20Linux-green)
-![Apple Silicon supported](https://img.shields.io/badge/Apple%20Silicon-supported-brightgreen)
+![Apple Silicon support for macOS and Linux (Docker)](https://img.shields.io/badge/Apple%20Silicon-macOS%20and%20Linux-brightgreen)
 ![PyPI - Wheel](https://img.shields.io/pypi/wheel/pedalboard)
 [![Test Badge](https://github.com/spotify/pedalboard/actions/workflows/all.yml/badge.svg)](https://github.com/spotify/pedalboard/actions/workflows/all.yml)
 ![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/psobot/8736467e9952991ef44a67915ee7c762/raw/coverage.json)
@@ -54,7 +54,7 @@ If you are new to Python, follow [INSTALLATION.md](https://github.com/spotify/pe
 - Linux
   - Tested heavily in production use cases at Spotify
   - Tested automatically on GitHub with VSTs
-  - Platform `manylinux` wheels built for `x86_64`
+  - Platform `manylinux` wheels built for `x86_64` (Intel/AMD) and `aarch64` (ARM/Apple Silicon)
   - Most Linux VSTs require a relatively modern Linux installation (with glibc > 2.27)
 - macOS
   - Tested manually with VSTs and Audio Units
@@ -63,7 +63,7 @@ If you are new to Python, follow [INSTALLATION.md](https://github.com/spotify/pe
   - Compatible with a wide range of VSTs and Audio Units
 - Windows
   - Tested automatically on GitHub with VSTs
-  - Platform wheels available for `amd64` (x86-84, Intel/AMD)
+  - Platform wheels available for `amd64` (x86-64, Intel/AMD)
 
 #### Plugin Compatibility
 


### PR DESCRIPTION
Currently the output from `pip install pedalboard` when run from a linux-based docker container running on an Apple Silicon host returns the following error:
```
ERROR: Could not find a version that satisfies the requirement pedalboard (from versions: none)
```

This change should fix that error. Please verify this works because I wasn't able to test (not having access to the github actions runner, etc).