### PR TITLE
Use fewer Python versions when linting.

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -14,7 +14,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9']
         os: [ubuntu-latest]
     name: Lint Python
     steps:


### PR DESCRIPTION
3.10 seems to change linter rules in such a way that we can't satisfy all of the linters with the same code.