### PR TITLE
Add shelving and notch/peak filters.

### DIFF
--- a/pedalboard/plugins/HighShelfFilter.h
+++ b/pedalboard/plugins/HighShelfFilter.h
@@ -62,7 +62,7 @@ inline void init_highshelf(py::module &m) {
              return plugin;
            }),
            py::arg("cutoff_frequency_hz") = 50,
-           py::arg("Q") = 0.707,
+           py::arg("q") = (juce::MathConstants<double>::sqrt2 / 2.0),
            py::arg("gain_factor") = 1.0)
       .def("__repr__",
            [](const HighShelfFilter<float> &plugin) {

--- a/pedalboard/plugins/HighShelfFilter.h
+++ b/pedalboard/plugins/HighShelfFilter.h
@@ -78,7 +78,7 @@ inline void init_highshelf(py::module &m) {
       .def_property("cutoff_frequency_hz",
                     &HighShelfFilter<float>::getCutoffFrequencyHz,
                     &HighShelfFilter<float>::setCutoffFrequencyHz)
-      .def_property("Q", 
+      .def_property("q", 
                     &HighShelfFilter<float>::getQ,
                     &HighShelfFilter<float>::setQ)
       .def_property("gain_factor", 

--- a/pedalboard/plugins/HighShelfFilter.h
+++ b/pedalboard/plugins/HighShelfFilter.h
@@ -1,0 +1,88 @@
+/*
+ * pedalboard
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the GNU Public License, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+#include "../JucePlugin.h"
+
+namespace Pedalboard {
+template <typename SampleType>
+class HighShelfFilter : public JucePlugin<juce::dsp::IIR::Filter<SampleType>> {
+public:
+  void setCutoffFrequencyHz(float f) noexcept { cutoffFrequencyHz = f; }
+  float getCutoffFrequencyHz() const noexcept { return cutoffFrequencyHz; }
+  void setQ(float f) noexcept { Q = f; }
+  float getQ() const noexcept { return Q; }
+  void setGainFactor(float f) noexcept { gainFactor = f; }
+  float getGainFactor() const noexcept { return gainFactor; }
+
+
+  virtual void prepare(const juce::dsp::ProcessSpec &spec) override {
+    JucePlugin<juce::dsp::IIR::Filter<SampleType>>::prepare(spec);
+    this->getDSP().coefficients =
+        juce::dsp::IIR::Coefficients<SampleType>::makeHighShelf(
+            spec.sampleRate, cutoffFrequencyHz, Q, gainFactor);
+  }
+
+private:
+  float cutoffFrequencyHz;
+  float Q;
+  float gainFactor;
+};
+
+inline void init_highshelf(py::module &m) {
+  py::class_<HighShelfFilter<float>, Plugin>(
+      m, "HighShelfFilter",
+      "Apply a High Shelf filter with"
+      "The gain is a scale factor that the high frequencies are multiplied by, so values"
+      "greater than 1.0 will boost the high frequencies, values less than 1.0 will"
+      "attenuate them.")
+      .def(py::init([](float cutoff_frequency_hz, float Q_val, float gainFactorBoost) {
+             auto plugin = new HighShelfFilter<float>();
+             plugin->setCutoffFrequencyHz(cutoff_frequency_hz);
+             plugin->setQ(Q_val);
+             plugin->setGainFactor(gainFactorBoost);
+             return plugin;
+           }),
+           py::arg("cutoff_frequency_hz") = 50,
+           py::arg("Q") = 0.707,
+           py::arg("gain_factor") = 1.0)
+      .def("__repr__",
+           [](const HighShelfFilter<float> &plugin) {
+             std::ostringstream ss;
+             ss << "<pedalboard.HighShelf";
+             ss << " cutoff_frequency_hz=" << plugin.getCutoffFrequencyHz();
+             ss << " Q=" << plugin.getQ();
+             ss << " gain_factor=" << plugin.getGainFactor();
+             ss << " at " << &plugin;
+             ss << ">";
+             return ss.str();
+           })
+      .def_property("cutoff_frequency_hz",
+                    &HighShelfFilter<float>::getCutoffFrequencyHz,
+                    &HighShelfFilter<float>::setCutoffFrequencyHz)
+      .def_property("Q", 
+                    &HighShelfFilter<float>::getQ,
+                    &HighShelfFilter<float>::setQ)
+      .def_property("gain_factor", 
+                    &HighShelfFilter<float>::getGainFactor,
+                    &HighShelfFilter<float>::setGainFactor);
+}
+}; // namespace Pedalboard

--- a/pedalboard/plugins/HighShelfFilter.h
+++ b/pedalboard/plugins/HighShelfFilter.h
@@ -50,7 +50,7 @@ private:
 inline void init_highshelf(py::module &m) {
   py::class_<HighShelfFilter<float>, Plugin>(
       m, "HighShelfFilter",
-      "Apply a High Shelf filter with"
+      "Apply a high-pass shelf filter with variable Q and gain. "
       "The gain is a scale factor that the high frequencies are multiplied by, so values"
       "greater than 1.0 will boost the high frequencies, values less than 1.0 will"
       "attenuate them.")

--- a/pedalboard/plugins/HighShelfFilter.h
+++ b/pedalboard/plugins/HighShelfFilter.h
@@ -69,7 +69,7 @@ inline void init_highshelf(py::module &m) {
              std::ostringstream ss;
              ss << "<pedalboard.HighShelfFilter";
              ss << " cutoff_frequency_hz=" << plugin.getCutoffFrequencyHz();
-             ss << " Q=" << plugin.getQ();
+             ss << " q=" << plugin.getQ();
              ss << " gain_factor=" << plugin.getGainFactor();
              ss << " at " << &plugin;
              ss << ">";

--- a/pedalboard/plugins/HighShelfFilter.h
+++ b/pedalboard/plugins/HighShelfFilter.h
@@ -67,7 +67,7 @@ inline void init_highshelf(py::module &m) {
       .def("__repr__",
            [](const HighShelfFilter<float> &plugin) {
              std::ostringstream ss;
-             ss << "<pedalboard.HighShelf";
+             ss << "<pedalboard.HighShelfFilter";
              ss << " cutoff_frequency_hz=" << plugin.getCutoffFrequencyHz();
              ss << " Q=" << plugin.getQ();
              ss << " gain_factor=" << plugin.getGainFactor();

--- a/pedalboard/plugins/LowShelfFilter.h
+++ b/pedalboard/plugins/LowShelfFilter.h
@@ -67,7 +67,7 @@ inline void init_lowshelf(py::module &m) {
       .def("__repr__",
            [](const LowShelfFilter<float> &plugin) {
              std::ostringstream ss;
-             ss << "<pedalboard.LowShelf";
+             ss << "<pedalboard.LowShelfFilter";
              ss << " cutoff_frequency_hz=" << plugin.getCutoffFrequencyHz();
              ss << " Q=" << plugin.getQ();
              ss << " gain_factor=" << plugin.getGainFactor();

--- a/pedalboard/plugins/LowShelfFilter.h
+++ b/pedalboard/plugins/LowShelfFilter.h
@@ -50,12 +50,10 @@ private:
 inline void init_lowshelf(py::module &m) {
   py::class_<LowShelfFilter<float>, Plugin>(
       m, "LowShelfFilter",
-      "Apply a Low Shelf filter with"
-      "The gain is a scale factor that the high frequencies are multiplied by, so values"
-      "greater than 1.0 will boost the high frequencies, values less than 1.0 will"
-      "attenuate them."
-      "The cutoff frequency will be attenuated by -3dB (i.e.: 0.707x as "
-      "loud).")
+      "Apply a low-pass shelf filter with variable Q and gain. "
+      "The gain is a scale factor that the low frequencies are multiplied by, so values"
+      "greater than 1.0 will boost the low frequencies, values less than 1.0 will"
+      "attenuate them.")
       .def(py::init([](float cutoff_frequency_hz, float Q_val, float gainFactorBoost) {
              auto plugin = new LowShelfFilter<float>();
              plugin->setCutoffFrequencyHz(cutoff_frequency_hz);

--- a/pedalboard/plugins/LowShelfFilter.h
+++ b/pedalboard/plugins/LowShelfFilter.h
@@ -78,7 +78,7 @@ inline void init_lowshelf(py::module &m) {
       .def_property("cutoff_frequency_hz",
                     &LowShelfFilter<float>::getCutoffFrequencyHz,
                     &LowShelfFilter<float>::setCutoffFrequencyHz)
-      .def_property("Q_val", 
+      .def_property("q", 
                     &LowShelfFilter<float>::getQ,
                     &LowShelfFilter<float>::setQ)
       .def_property("gain_factor", 

--- a/pedalboard/plugins/LowShelfFilter.h
+++ b/pedalboard/plugins/LowShelfFilter.h
@@ -1,0 +1,90 @@
+/*
+ * pedalboard
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the GNU Public License, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+#include "../JucePlugin.h"
+
+namespace Pedalboard {
+template <typename SampleType>
+class LowShelfFilter : public JucePlugin<juce::dsp::IIR::Filter<SampleType>> {
+public:
+  void setCutoffFrequencyHz(float f) noexcept { cutoffFrequencyHz = f; }
+  float getCutoffFrequencyHz() const noexcept { return cutoffFrequencyHz; }
+  void setQ(float f) noexcept { Q = f; }
+  float getQ() const noexcept { return Q; }
+  void setGainFactor(float f) noexcept { gainFactor = f; }
+  float getGainFactor() const noexcept { return gainFactor; }
+
+
+  virtual void prepare(const juce::dsp::ProcessSpec &spec) override {
+    JucePlugin<juce::dsp::IIR::Filter<SampleType>>::prepare(spec);
+    this->getDSP().coefficients =
+        juce::dsp::IIR::Coefficients<SampleType>::makeLowShelf(
+            spec.sampleRate, cutoffFrequencyHz, Q, gainFactor);
+  }
+
+private:
+  float cutoffFrequencyHz;
+  float Q;
+  float gainFactor;
+};
+
+inline void init_lowshelf(py::module &m) {
+  py::class_<LowShelfFilter<float>, Plugin>(
+      m, "LowShelfFilter",
+      "Apply a Low Shelf filter with"
+      "The gain is a scale factor that the high frequencies are multiplied by, so values"
+      "greater than 1.0 will boost the high frequencies, values less than 1.0 will"
+      "attenuate them."
+      "The cutoff frequency will be attenuated by -3dB (i.e.: 0.707x as "
+      "loud).")
+      .def(py::init([](float cutoff_frequency_hz, float Q_val, float gainFactorBoost) {
+             auto plugin = new LowShelfFilter<float>();
+             plugin->setCutoffFrequencyHz(cutoff_frequency_hz);
+             plugin->setQ(Q_val);
+             plugin->setGainFactor(gainFactorBoost);
+             return plugin;
+           }),
+           py::arg("cutoff_frequency_hz") = 50,
+           py::arg("Q_val") = 0.707,
+           py::arg("gain_factor") = 1.0)
+      .def("__repr__",
+           [](const LowShelfFilter<float> &plugin) {
+             std::ostringstream ss;
+             ss << "<pedalboard.LowShelf";
+             ss << " cutoff_frequency_hz=" << plugin.getCutoffFrequencyHz();
+             ss << " Q=" << plugin.getQ();
+             ss << " gain_factor=" << plugin.getGainFactor();
+             ss << " at " << &plugin;
+             ss << ">";
+             return ss.str();
+           })
+      .def_property("cutoff_frequency_hz",
+                    &LowShelfFilter<float>::getCutoffFrequencyHz,
+                    &LowShelfFilter<float>::setCutoffFrequencyHz)
+      .def_property("Q_val", 
+                    &LowShelfFilter<float>::getQ,
+                    &LowShelfFilter<float>::setQ)
+      .def_property("gain_factor", 
+                    &LowShelfFilter<float>::getGainFactor,
+                    &LowShelfFilter<float>::setGainFactor);
+}
+}; // namespace Pedalboard

--- a/pedalboard/plugins/LowShelfFilter.h
+++ b/pedalboard/plugins/LowShelfFilter.h
@@ -62,7 +62,7 @@ inline void init_lowshelf(py::module &m) {
              return plugin;
            }),
            py::arg("cutoff_frequency_hz") = 50,
-           py::arg("Q_val") = 0.707,
+           py::arg("q") = (juce::MathConstants<double>::sqrt2 / 2.0),
            py::arg("gain_factor") = 1.0)
       .def("__repr__",
            [](const LowShelfFilter<float> &plugin) {

--- a/pedalboard/plugins/LowShelfFilter.h
+++ b/pedalboard/plugins/LowShelfFilter.h
@@ -69,7 +69,7 @@ inline void init_lowshelf(py::module &m) {
              std::ostringstream ss;
              ss << "<pedalboard.LowShelfFilter";
              ss << " cutoff_frequency_hz=" << plugin.getCutoffFrequencyHz();
-             ss << " Q=" << plugin.getQ();
+             ss << " q=" << plugin.getQ();
              ss << " gain_factor=" << plugin.getGainFactor();
              ss << " at " << &plugin;
              ss << ">";

--- a/pedalboard/plugins/NotchFilter.h
+++ b/pedalboard/plugins/NotchFilter.h
@@ -68,7 +68,7 @@ inline void init_notch(py::module &m) {
       .def_property("cutoff_frequency_hz",
                     &NotchFilter<float>::getCutoffFrequencyHz,
                     &NotchFilter<float>::setCutoffFrequencyHz)
-      .def_property("Q", 
+      .def_property("q", 
                     &NotchFilter<float>::getQ,
                     &NotchFilter<float>::setQ);
 }

--- a/pedalboard/plugins/NotchFilter.h
+++ b/pedalboard/plugins/NotchFilter.h
@@ -46,7 +46,7 @@ private:
 inline void init_notch(py::module &m) {
   py::class_<NotchFilter<float>, Plugin>(
       m, "NotchFilter",
-      "Create a notch filter with a variable Q, set around cutoffFrequencyHz")
+      "Create a notch filter with a variable Q, set around cutoff_frequency_hz.")
       .def(py::init([](float cutoff_frequency_hz, float Q_val) {
              auto plugin = new NotchFilter<float>();
              plugin->setCutoffFrequencyHz(cutoff_frequency_hz);

--- a/pedalboard/plugins/NotchFilter.h
+++ b/pedalboard/plugins/NotchFilter.h
@@ -54,7 +54,7 @@ inline void init_notch(py::module &m) {
              return plugin;
            }),
            py::arg("cutoff_frequency_hz") = 50,
-           py::arg("Q") = 0.707)
+           py::arg("q") = (juce::MathConstants<double>::sqrt2 / 2.0))
       .def("__repr__",
            [](const NotchFilter<float> &plugin) {
              std::ostringstream ss;

--- a/pedalboard/plugins/NotchFilter.h
+++ b/pedalboard/plugins/NotchFilter.h
@@ -1,0 +1,75 @@
+/*
+ * pedalboard
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the GNU Public License, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+#include "../JucePlugin.h"
+
+namespace Pedalboard {
+template <typename SampleType>
+class NotchFilter : public JucePlugin<juce::dsp::IIR::Filter<SampleType>> {
+public:
+  void setCutoffFrequencyHz(float f) noexcept { cutoffFrequencyHz = f; }
+  float getCutoffFrequencyHz() const noexcept { return cutoffFrequencyHz; }
+  void setQ(float f) noexcept { Q = f; }
+  float getQ() const noexcept { return Q; }
+
+  virtual void prepare(const juce::dsp::ProcessSpec &spec) override {
+    JucePlugin<juce::dsp::IIR::Filter<SampleType>>::prepare(spec);
+    this->getDSP().coefficients =
+        juce::dsp::IIR::Coefficients<SampleType>::makeNotch(
+            spec.sampleRate, cutoffFrequencyHz, Q);
+  }
+
+private:
+  float cutoffFrequencyHz;
+  float Q;
+};
+
+inline void init_notch(py::module &m) {
+  py::class_<NotchFilter<float>, Plugin>(
+      m, "NotchFilter",
+      "Create a notch filter with a variable Q, set around cutoffFrequencyHz")
+      .def(py::init([](float cutoff_frequency_hz, float Q_val) {
+             auto plugin = new NotchFilter<float>();
+             plugin->setCutoffFrequencyHz(cutoff_frequency_hz);
+             plugin->setQ(Q_val);
+             return plugin;
+           }),
+           py::arg("cutoff_frequency_hz") = 50,
+           py::arg("Q") = 0.707)
+      .def("__repr__",
+           [](const NotchFilter<float> &plugin) {
+             std::ostringstream ss;
+             ss << "<pedalboard.NotchFilter";
+             ss << " cutoff_frequency_hz=" << plugin.getCutoffFrequencyHz();
+             ss << " Q=" << plugin.getQ();
+             ss << " at " << &plugin;
+             ss << ">";
+             return ss.str();
+             })
+      .def_property("cutoff_frequency_hz",
+                    &NotchFilter<float>::getCutoffFrequencyHz,
+                    &NotchFilter<float>::setCutoffFrequencyHz)
+      .def_property("Q", 
+                    &NotchFilter<float>::getQ,
+                    &NotchFilter<float>::setQ);
+}
+}; // namespace Pedalboard

--- a/pedalboard/plugins/NotchFilter.h
+++ b/pedalboard/plugins/NotchFilter.h
@@ -60,7 +60,7 @@ inline void init_notch(py::module &m) {
              std::ostringstream ss;
              ss << "<pedalboard.NotchFilter";
              ss << " cutoff_frequency_hz=" << plugin.getCutoffFrequencyHz();
-             ss << " Q=" << plugin.getQ();
+             ss << " q=" << plugin.getQ();
              ss << " at " << &plugin;
              ss << ">";
              return ss.str();

--- a/pedalboard/plugins/PeakingFilter.h
+++ b/pedalboard/plugins/PeakingFilter.h
@@ -63,7 +63,7 @@ inline void init_peaking(py::module &m) {
            }),
            py::arg("centre_frequency_hz") = 50,
            py::arg("Q") = 0.0,
-           py::arg("gain_factor") = .707)
+           py::arg("gain_factor") = (juce::MathConstants<double>::sqrt2 / 2.0))
       .def("__repr__",
            [](const PeakFilter<float> &plugin) {
              std::ostringstream ss;

--- a/pedalboard/plugins/PeakingFilter.h
+++ b/pedalboard/plugins/PeakingFilter.h
@@ -69,7 +69,7 @@ inline void init_peaking(py::module &m) {
              std::ostringstream ss;
              ss << "<pedalboard.PeakFilter";
              ss << " centre_frequency_hz=" << plugin.getCentreFrequencyHz();
-             ss << " Q=" << plugin.getQ();
+             ss << " q=" << plugin.getQ();
              ss << " gain_factor=" << plugin.getGainFactor();
              ss << " at " << &plugin;
              ss << ">";

--- a/pedalboard/plugins/PeakingFilter.h
+++ b/pedalboard/plugins/PeakingFilter.h
@@ -78,7 +78,7 @@ inline void init_peaking(py::module &m) {
       .def_property("centre_frequency_hz",
                     &PeakingFilter<float>::getCentreFrequencyHz,
                     &PeakingFilter<float>::setCentreFrequencyHz)
-      .def_property("Q", 
+      .def_property("q", 
                     &PeakingFilter<float>::getQ,
                     &PeakingFilter<float>::setQ)
       .def_property("gain_factor", 

--- a/pedalboard/plugins/PeakingFilter.h
+++ b/pedalboard/plugins/PeakingFilter.h
@@ -67,7 +67,7 @@ inline void init_peaking(py::module &m) {
       .def("__repr__",
            [](const PeakingFilter<float> &plugin) {
              std::ostringstream ss;
-             ss << "<pedalboard.PeakingFilter";
+             ss << "<pedalboard.PeakFilter";
              ss << " centre_frequency_hz=" << plugin.getCentreFrequencyHz();
              ss << " Q=" << plugin.getQ();
              ss << " gain_factor=" << plugin.getGainFactor();

--- a/pedalboard/plugins/PeakingFilter.h
+++ b/pedalboard/plugins/PeakingFilter.h
@@ -1,0 +1,88 @@
+/*
+ * pedalboard
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the GNU Public License, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+#include "../JucePlugin.h"
+
+namespace Pedalboard {
+template <typename SampleType>
+class PeakingFilter : public JucePlugin<juce::dsp::IIR::Filter<SampleType>> {
+public:
+  void setCentreFrequencyHz(float f) noexcept { centreFrequencyHz = f; }
+  float getCentreFrequencyHz() const noexcept { return centreFrequencyHz; }
+  void setQ(float f) noexcept { Q = f; }
+  float getQ() const noexcept { return Q; }
+  void setGainFactor(float f) noexcept { gainFactor = f; }
+  float getGainFactor() const noexcept { return gainFactor; }
+
+
+  virtual void prepare(const juce::dsp::ProcessSpec &spec) override {
+    JucePlugin<juce::dsp::IIR::Filter<SampleType>>::prepare(spec);
+    this->getDSP().coefficients =
+        juce::dsp::IIR::Coefficients<SampleType>::makePeakFilter(
+            spec.sampleRate, centreFrequencyHz, Q, gainFactor);
+  }
+
+private:
+  float centreFrequencyHz;
+  float Q;
+  float gainFactor;
+};
+
+inline void init_peaking(py::module &m) {
+  py::class_<PeakingFilter<float>, Plugin>(
+      m, "PeakingFilter",
+      "Apply a Peaking filter."
+      "The gain is a scale factor that the high frequencies are multiplied by, so values"
+      "greater than 1.0 will boost the high frequencies, values less than 1.0 will"
+      "attenuate them.  Centers the band around centreFrequencyHz")
+      .def(py::init([](float centre_frequency_hz, float Q_val, float gainFactorBoost) {
+             auto plugin = new PeakingFilter<float>();
+             plugin->setCentreFrequencyHz(centre_frequency_hz);
+             plugin->setQ(Q_val);
+             plugin->setGainFactor(gainFactorBoost);
+             return plugin;
+           }),
+           py::arg("centre_frequency_hz") = 50,
+           py::arg("Q") = 0.0,
+           py::arg("gain_factor") = .707)
+      .def("__repr__",
+           [](const PeakingFilter<float> &plugin) {
+             std::ostringstream ss;
+             ss << "<pedalboard.PeakingFilter";
+             ss << " centre_frequency_hz=" << plugin.getCentreFrequencyHz();
+             ss << " Q=" << plugin.getQ();
+             ss << " gain_factor=" << plugin.getGainFactor();
+             ss << " at " << &plugin;
+             ss << ">";
+             return ss.str();
+           })
+      .def_property("centre_frequency_hz",
+                    &PeakingFilter<float>::getCentreFrequencyHz,
+                    &PeakingFilter<float>::setCentreFrequencyHz)
+      .def_property("Q", 
+                    &PeakingFilter<float>::getQ,
+                    &PeakingFilter<float>::setQ)
+      .def_property("gain_factor", 
+                    &PeakingFilter<float>::getGainFactor,
+                    &PeakingFilter<float>::setGainFactor);
+}
+}; // namespace Pedalboard

--- a/pedalboard/plugins/PeakingFilter.h
+++ b/pedalboard/plugins/PeakingFilter.h
@@ -65,7 +65,7 @@ inline void init_peaking(py::module &m) {
            py::arg("Q") = 0.0,
            py::arg("gain_factor") = .707)
       .def("__repr__",
-           [](const PeakingFilter<float> &plugin) {
+           [](const PeakFilter<float> &plugin) {
              std::ostringstream ss;
              ss << "<pedalboard.PeakFilter";
              ss << " centre_frequency_hz=" << plugin.getCentreFrequencyHz();

--- a/pedalboard/python_bindings.cpp
+++ b/pedalboard/python_bindings.cpp
@@ -38,10 +38,14 @@ namespace py = pybind11;
 #include "plugins/Distortion.h"
 #include "plugins/Gain.h"
 #include "plugins/HighpassFilter.h"
+#include "plugins/HighShelfFilter.h"
 #include "plugins/LadderFilter.h"
 #include "plugins/Limiter.h"
 #include "plugins/LowpassFilter.h"
+#include "plugins/LowShelfFilter.h"
 #include "plugins/NoiseGate.h"
+#include "plugins/NotchFilter.h"
+#include "plugins/PeakingFilter.h"
 #include "plugins/Phaser.h"
 #include "plugins/Reverb.h"
 
@@ -138,10 +142,14 @@ PYBIND11_MODULE(pedalboard_native, m) {
   init_distortion(m);
   init_gain(m);
   init_highpass(m);
+  init_highshelf(m);
   init_ladderfilter(m);
   init_limiter(m);
   init_lowpass(m);
+  init_lowshelf(m);
   init_noisegate(m);
+  init_notch(m);
+  init_peaking(m);
   init_phaser(m);
   init_reverb(m);
 

--- a/pedalboard/python_bindings.cpp
+++ b/pedalboard/python_bindings.cpp
@@ -45,7 +45,7 @@ namespace py = pybind11;
 #include "plugins/LowShelfFilter.h"
 #include "plugins/NoiseGate.h"
 #include "plugins/NotchFilter.h"
-#include "plugins/PeakingFilter.h"
+#include "plugins/PeakFilter.h"
 #include "plugins/Phaser.h"
 #include "plugins/Reverb.h"
 

--- a/pedalboard/python_bindings.cpp
+++ b/pedalboard/python_bindings.cpp
@@ -149,7 +149,7 @@ PYBIND11_MODULE(pedalboard_native, m) {
   init_lowshelf(m);
   init_noisegate(m);
   init_notch(m);
-  init_peaking(m);
+  init_peak(m);
   init_phaser(m);
   init_reverb(m);
 


### PR DESCRIPTION
 add-dsp-filters: Added four new filter types to PedalBoard

Problem

There were no High shelf, Low Shelf, Notch, or Peaking filters included within Pedalboard.  This was very easy to add using the coefficients within Juce

Solution

Added new files within the plugin folder that instantiate the High Shelf, Low Shelf, Notch and Peaking filters as well as updated the python_bindings.cpp file to reflect these changes

Result

Users will now be able to use a LowShelfFilter, HighShelfFilter, NotchFilter, and PeakingFilter within Pedalboard as Pedalboard objects

Changes to be committed:
	new file:   pedalboard/plugins/HighShelfFilter.h
	new file:   pedalboard/plugins/LowShelfFilter.h
	new file:   pedalboard/plugins/NotchFilter.h
	new file:   pedalboard/plugins/PeakingFilter.h
	modified:   pedalboard/python_bindings.cpp