### PR TITLE
Updated JUCE to version 6.1.4

### DIFF
--- a/pedalboard/JuceHeader.h
+++ b/pedalboard/JuceHeader.h
@@ -32,7 +32,7 @@
 #include <juce_graphics/juce_graphics.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 
-#define JUCE_PROJUCER_VERSION 0x60008
+#define JUCE_PROJUCER_VERSION 0x60104
 
 #if JUCE_PROJUCER_VERSION < JUCE_VERSION
 /** If you've hit this error then the version of the Projucer that was used to

--- a/pedalboard/JuceHeader.h
+++ b/pedalboard/JuceHeader.h
@@ -31,16 +31,3 @@
 #include <juce_events/juce_events.h>
 #include <juce_graphics/juce_graphics.h>
 #include <juce_gui_basics/juce_gui_basics.h>
-
-#define JUCE_PROJUCER_VERSION 0x60104
-
-#if JUCE_PROJUCER_VERSION < JUCE_VERSION
-/** If you've hit this error then the version of the Projucer that was used to
-   generate this project is older than the version of the JUCE modules being
-   included. To fix this error, re-save your project using the latest version of
-   the Projucer or, if you aren't using the Projucer to manage your project,
-    remove the JUCE_PROJUCER_VERSION define from the AppConfig.h file.
-*/
-#error                                                                         \
-    "This project was last saved using an outdated version of the Projucer! Re-save this project with the latest version to fix this error."
-#endif


### PR DESCRIPTION
update-juce: Checked out the latest version of JUCE

Problem
In order to work on [this issue](https://github.com/spotify/pedalboard/issues/11), an update of JUCE is first needed. The discussion there outlines why. 

Solution
I simply updated the JUCE submodule to the latest stable master commit (their commit message is aptly "JUCE version 6.1.4"). I made sure to detach the HEAD in order to prevent automatically updating in the future. 

Comments
Running tox, the tests on my end seem to be all good. I was unable to run lint tests but this isn't a concern for this specific PR. Lint seems to be concerned with syntactical and stylistic problems but the only thing this PR is doing is updating JUCE. Moving forward I will need to sort out this lint issue.

P.S. This is my first PR to any open source project! It's quite a trivial one, but I look forward to contributing more. Let me know if I did anything wrong and thank you for your patience with my learning in advance.