### PR TITLE
Normalize sharps and flats in parameter names.

### DIFF
--- a/pedalboard/pedalboard.py
+++ b/pedalboard/pedalboard.py
@@ -495,9 +495,16 @@ def to_python_parameter_name(parameter: _AudioProcessorParameter) -> Optional[st
     if not parameter.name and not parameter.label:
         return None
 
-    name = parameter.name.lower().strip()
+    name = parameter.name
     if parameter.label and not parameter.label.startswith(":"):
-        name = "{} {}".format(name, parameter.label.lower())
+        name = "{} {}".format(name, parameter.label)
+    return normalize_python_parameter_name(name)
+
+
+def normalize_python_parameter_name(name: str) -> str:
+    name = name.lower().strip()
+    # Special case: some plugins expose parameters with "#"/"♯" or "b"/"♭" in their names.
+    name = name.replace("#", "_sharp").replace("♯", "_sharp").replace("♭", "_flat")
     # Replace all non-alphanumeric characters with underscores
     name = [
         c if (c.isalpha() or c.isnumeric()) and c.isprintable() and ord(c) < 128 else "_"

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -25,7 +25,11 @@ import platform
 from glob import glob
 from pathlib import Path
 
-from pedalboard.pedalboard import WrappedBool, strip_common_float_suffixes
+from pedalboard.pedalboard import (
+    WrappedBool,
+    strip_common_float_suffixes,
+    normalize_python_parameter_name,
+)
 import pytest
 import pedalboard
 import numpy as np
@@ -572,3 +576,16 @@ def test_wrapped_bool(value: bool):
 def test_wrapped_bool_requires_bool():
     with pytest.raises(TypeError):
         assert WrappedBool(None)
+
+
+@pytest.mark.parametrize(
+    "_input,expected",
+    [
+        ("C#", "c_sharp"),
+        ("B♭", "b_flat"),
+        ("Azimuth (º)", "azimuth"),
+        ("Normal String", "normal_string"),
+    ],
+)
+def test_parameter_name_normalization(_input: str, expected: str):
+    assert normalize_python_parameter_name(_input) == expected


### PR DESCRIPTION
Fixes #57.