### PR TITLE
Clarify Rubber Band's license as GPLv2-or-newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,6 @@ Not yet, either - although the underlying framework (JUCE) supports passing MIDI
 `pedalboard` is licensed under the [GNU General Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html), because:
  - The core audio processing code is pulled from JUCE 6, which is [dual-licensed under a commercial license and the GPLv3](https://juce.com/juce-6-licence).
  - The VST3 SDK, bundled with JUCE, is owned by [Steinberg® Media Technologies GmbH](https://www.steinberg.net/en/home.html) and licensed under the GPLv3.
- - The `PitchShift` plugin uses [the Rubber Band Library](https://github.com/breakfastquay/rubberband), which is licensed under the GPLv2.
+ - The `PitchShift` plugin uses [the Rubber Band Library](https://github.com/breakfastquay/rubberband), which is [dual-licensed under a commercial license](https://breakfastquay.com/technology/license.html) and the GPLv2 (or newer).
 
 _VST is a registered trademark of Steinberg Media Technologies GmbH._


### PR DESCRIPTION
Should reduce licensing confusion.

Reference issue #60 for licensing discussion.