### PR TITLE
Compensate for plugin latency.

### DIFF
--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -621,8 +621,8 @@ public:
       // only tell Pedalboard to use the last _n_ samples.
       long usableSamplesProduced =
           samplesProvided - pluginInstance->getLatencySamples();
-      return (int)std::min(usableSamplesProduced,
-                           (long)outputBlock.getNumSamples());
+      return static_cast<int>(
+          std::min(usableSamplesProduced, (long)outputBlock.getNumSamples()));
     }
 
     return 0;

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -514,6 +514,7 @@ public:
 
       // Force prepare() to be called again later by invalidating lastSpec:
       lastSpec.maximumBlockSize = 0;
+      samplesProvided = 0;
     }
   }
 
@@ -543,8 +544,8 @@ public:
     }
   }
 
-  void
-  process(const juce::dsp::ProcessContextReplacing<float> &context) override {
+  int process(
+      const juce::dsp::ProcessContextReplacing<float> &context) override {
 
     if (pluginInstance) {
       juce::MidiBuffer emptyMidiBuffer;
@@ -614,7 +615,17 @@ public:
                                            pluginBufferChannelCount,
                                            outputBlock.getNumSamples());
       pluginInstance->processBlock(audioBuffer, emptyMidiBuffer);
+      samplesProvided += outputBlock.getNumSamples();
+
+      // To compensate for any latency added by the plugin,
+      // only tell Pedalboard to use the last _n_ samples.
+      long usableSamplesProduced =
+          samplesProvided - pluginInstance->getLatencySamples();
+      return (int)std::min(usableSamplesProduced,
+                           (long)outputBlock.getNumSamples());
     }
+
+    return 0;
   }
 
   std::vector<juce::AudioProcessorParameter *> getParameters() const {
@@ -634,6 +645,12 @@ public:
     return nullptr;
   }
 
+  virtual int getLatencyHint() override {
+    if (!pluginInstance)
+      return 0;
+    return pluginInstance->getLatencySamples();
+  }
+
 private:
   constexpr static int ExternalLoadSampleRate = 44100,
                        ExternalLoadMaximumBlockSize = 8192;
@@ -641,6 +658,8 @@ private:
   juce::PluginDescription foundPluginDescription;
   juce::AudioPluginFormatManager pluginFormatManager;
   std::unique_ptr<juce::AudioPluginInstance> pluginInstance;
+
+  long samplesProvided = 0;
 
   ExternalPluginReloadType reloadType = ExternalPluginReloadType::Unknown;
 };

--- a/pedalboard/JucePlugin.h
+++ b/pedalboard/JucePlugin.h
@@ -58,12 +58,13 @@ public:
     }
   }
 
-  void process(
-      const juce::dsp::ProcessContextReplacing<float> &context) override final {
+  int process(
+      const juce::dsp::ProcessContextReplacing<float> &context) override {
     dspBlock.process(context);
+    return context.getOutputBlock().getNumSamples();
   }
 
-  void reset() override final { dspBlock.reset(); }
+  void reset() override { dspBlock.reset(); }
 
   DSPType &getDSP() { return dspBlock; };
 

--- a/pedalboard/Plugin.h
+++ b/pedalboard/Plugin.h
@@ -28,12 +28,47 @@ class Plugin {
 public:
   virtual ~Plugin(){};
 
+  /**
+   * Prepare the data structures that will be necessary for this plugin to
+   * process audio at the provided sample rate, maximum block size, and number
+   * of channels.
+   */
   virtual void prepare(const juce::dsp::ProcessSpec &spec) = 0;
 
-  virtual void
+  /**
+   * Process a single buffer of audio through this plugin.
+   * Returns the number of samples that were output.
+   *
+   * If less than a whole buffer of audio was output, the samples that
+   * were produced should be right-aligned in the buffer
+   * (i.e.: they should come last).
+   */
+  virtual int
   process(const juce::dsp::ProcessContextReplacing<float> &context) = 0;
 
+  /**
+   * Reset this plugin's state, clearing any internal buffers or delay lines.
+   */
   virtual void reset() = 0;
+
+  /**
+   * Get the number of samples of latency introduced by this plugin.
+   * This is the number of samples that must be provided to the plugin
+   * before meaningful output will be returned.
+   * Pedalboard will automatically compensate for this latency when processing
+   * by using the return value from the process() call, but this hint can
+   * make processing more efficient.
+   *
+   * This function will only be called after prepare(), so it can take into
+   * account variables like the current sample rate, maximum block size, and
+   * other plugin parameters.
+   * 
+   * Returning a value from getLatencyHint() that is larger than necessary will
+   * allocate that many extra samples during processing, increasing memory usage.
+   * Returning a value that is too small will cause memory to be reallocated
+   * during rendering, impacting rendering speed.
+   */
+  virtual int getLatencyHint() { return 0; }
 
   // A mutex to gate access to this plugin, as its internals may not be
   // thread-safe. Note: use std::lock or std::scoped_lock when locking multiple

--- a/pedalboard/Plugin.h
+++ b/pedalboard/Plugin.h
@@ -62,11 +62,11 @@ public:
    * This function will only be called after prepare(), so it can take into
    * account variables like the current sample rate, maximum block size, and
    * other plugin parameters.
-   * 
+   *
    * Returning a value from getLatencyHint() that is larger than necessary will
-   * allocate that many extra samples during processing, increasing memory usage.
-   * Returning a value that is too small will cause memory to be reallocated
-   * during rendering, impacting rendering speed.
+   * allocate that many extra samples during processing, increasing memory
+   * usage. Returning a value that is too small will cause memory to be
+   * reallocated during rendering, impacting rendering speed.
    */
   virtual int getLatencyHint() { return 0; }
 

--- a/pedalboard/RubberbandPlugin.h
+++ b/pedalboard/RubberbandPlugin.h
@@ -1,85 +1,191 @@
+/*
+ * pedalboard
+ * Copyright 2022 Spotify AB
+ *
+ * Licensed under the GNU Public License, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "../vendors/rubberband/rubberband/RubberBandStretcher.h"
 #include "Plugin.h"
 
 using namespace RubberBand;
 
 namespace Pedalboard {
-class RubberbandPlugin : public Plugin
+
 /*
-Base class for rubberband plugins.
-*/
-{
+ * Base class for all Rubber Band-derived plugins.
+ */
+class RubberbandPlugin : public Plugin {
 public:
   virtual ~RubberbandPlugin(){};
 
-  void process(
+  virtual void prepare(const juce::dsp::ProcessSpec &spec) override {
+    bool specChanged = lastSpec.sampleRate != spec.sampleRate ||
+                       lastSpec.maximumBlockSize < spec.maximumBlockSize ||
+                       spec.numChannels != lastSpec.numChannels;
+
+    if (!rbPtr || specChanged) {
+      auto stretcherOptions = RubberBandStretcher::OptionProcessRealTime |
+                              RubberBandStretcher::OptionThreadingNever |
+                              RubberBandStretcher::OptionChannelsTogether |
+                              RubberBandStretcher::OptionPitchHighQuality;
+      rbPtr = std::make_unique<RubberBandStretcher>(
+          spec.sampleRate, spec.numChannels, stretcherOptions);
+      rbPtr->setMaxProcessSize(spec.maximumBlockSize);
+
+      lastSpec = spec;
+      reset();
+    }
+  }
+
+  int process(
       const juce::dsp::ProcessContextReplacing<float> &context) override final {
-    if (rbPtr) {
-      auto inBlock = context.getInputBlock();
-      auto outBlock = context.getOutputBlock();
+    if (!rbPtr) {
+      throw std::runtime_error("Rubber Band plugin failed to instantiate.");
+    }
 
-      auto len = inBlock.getNumSamples();
-      auto numChannels = inBlock.getNumChannels();
+    auto ioBlock = context.getOutputBlock();
+    auto numChannels = ioBlock.getNumChannels();
 
-      jassert(len == outBlock.getNumSamples());
-      jassert(numChannels == outBlock.getNumChannels());
+    if (numChannels > MAX_CHANNEL_COUNT) {
+      throw std::runtime_error(
+          "Pitch shifting or time stretching plugins support a maximum of " +
+          std::to_string(MAX_CHANNEL_COUNT) + " channels.");
+    }
 
-      const float **inChannels =
-          (const float **)alloca(numChannels * sizeof(float *));
-      float **outChannels = (float **)alloca(numChannels * sizeof(float *));
+    float *ioChannels[MAX_CHANNEL_COUNT] = {};
+
+    // for (size_t i = 0; i < numChannels; i++) {
+    //   ioChannels[i] = ioBlock.getChannelPointer(i);
+    // }
+
+    // Push all of the input samples we have into RubberBand:
+    // rbPtr->process(ioChannels, ioBlock.getNumSamples(), false);
+    // printf("Pushed %d samples into Rubber Band.\n", ioBlock.getNumSamples());
+    // int availableSamples = rbPtr->available();
+
+    int samplesProcessed = 0;
+    int samplesWritten = 0;
+    while (samplesProcessed < ioBlock.getNumSamples() || rbPtr->available()) {
+      int samplesRequired = rbPtr->getSamplesRequired();
+      int inputChunkLength = std::min(
+          (int)(ioBlock.getNumSamples() - samplesProcessed), samplesRequired);
 
       for (size_t i = 0; i < numChannels; i++) {
-        inChannels[i] = inBlock.getChannelPointer(i);
-        outChannels[i] = outBlock.getChannelPointer(i);
+        ioChannels[i] = ioBlock.getChannelPointer(i) + samplesProcessed;
       }
 
-      // Rubberband expects all channel data with one float array per channel
-      processSamples(inChannels, outChannels, len, numChannels);
+      rbPtr->process(ioChannels, inputChunkLength, false);
+      samplesProcessed += inputChunkLength;
+
+      int samplesAvailable = rbPtr->available();
+      int freeSpace = ioBlock.getNumSamples() - samplesWritten;
+      int outputChunkLength = std::min(freeSpace, samplesAvailable);
+
+      // Avoid overwriting input that hasn't yet been passed to Rubber Band:
+      if (samplesWritten + outputChunkLength > samplesProcessed) {
+        outputChunkLength = samplesProcessed - samplesWritten;
+      }
+
+      for (size_t i = 0; i < numChannels; i++) {
+        ioChannels[i] = ioBlock.getChannelPointer(i) + samplesWritten;
+      }
+      samplesWritten += rbPtr->retrieve(ioChannels, outputChunkLength);
+      if (samplesWritten == ioBlock.getNumSamples())
+        break;
     }
+
+    if (samplesWritten > 0 && samplesWritten < ioBlock.getNumSamples()) {
+      // Right-align the output samples in the buffer:
+      int offset = ioBlock.getNumSamples() - samplesWritten;
+      for (size_t i = 0; i < numChannels; i++) {
+        float *channelBufferSource = ioBlock.getChannelPointer(i);
+        float *channelBufferDestination = channelBufferSource + offset;
+        std::memmove((char *)channelBufferDestination,
+                     (char *)channelBufferSource,
+                     sizeof(float) * samplesWritten);
+      }
+    }
+
+    return samplesWritten;
+
+    // Don't produce any output for this input if RubberBand isn't ready.
+    // We can do this here because RubberBand buffers audio internally;
+    // this might not be a safe technique to use with other plugins, as
+    // their output sample buffers may overflow if passed more than
+    // maximumBlockSize.
+
+    // if (rbPtr->available() < (int) ioBlock.getNumSamples() + getLatency()) {
+    //   printf("Need %d samples, but Rubber Band only had %d samples
+    //   available.\n", ioBlock.getNumSamples() + getLatency(),
+    //   rbPtr->available()); return 0;
+    // } else {
+    //   // Pull the next chunk of audio data out of RubberBand:
+    //   int returned = rbPtr->retrieve(ioChannels, ioBlock.getNumSamples());
+    //   printf("Sent %d samples into Rubber Band, and took %d samples back
+    //   out.\n", ioBlock.getNumSamples(), returned); return returned;
+    // }
+
+    // // ...but only actually ask Rubberband for at most the number of samples
+    // we
+    // // can handle:
+    // int samplesToPull = ioBlock.getNumSamples();
+    // if (samplesToPull > availableSamples)
+    //   samplesToPull = availableSamples;
+
+    // // If we don't have enough samples to fill a full buffer,
+    // // right-align the samples that we do have (i..e: start with silence).
+    // int missingSamples = ioBlock.getNumSamples() - availableSamples;
+    // if (missingSamples > 0) {
+    //   for (size_t c = 0; c < numChannels; c++) {
+    //     // Clear the start of the buffer so that we start
+    //     // the buffer with silence:
+    //     std::fill_n(ioChannels[c], missingSamples, 0.0);
+
+    //     // Move the output buffer pointer forward so that
+    //     // RubberBandStretcher::retrieve(...) places its
+    //     // output at the end of the buffer:
+    //     ioChannels[c] += missingSamples;
+    //   }
+    // }
+
+    // // Pull the next audio data out of Rubberband:
+    // int pulled = rbPtr->retrieve(ioChannels, samplesToPull);
+    // printf("Pulled %d samples out of Rubber Band (%d were available).\n",
+    // pulled, availableSamples); return pulled;
   }
 
   void reset() override final {
     if (rbPtr) {
       rbPtr->reset();
     }
+    initialSamplesRequired = 0;
   }
 
-private:
-  void processSamples(const float *const *inBlock, float **outBlock,
-                      size_t samples, size_t numChannels) {
-    // Push all of the input samples into RubberBand:
-    rbPtr->process(inBlock, samples, false);
+  virtual int getLatencyHint() override {
+    if (!rbPtr)
+      return 0;
 
-    // Figure out how many samples RubberBand is ready to give to us:
-    int availableSamples = rbPtr->available();
+    initialSamplesRequired =
+        std::max(initialSamplesRequired,
+                 (int)(rbPtr->getSamplesRequired() + rbPtr->getLatency() + lastSpec.maximumBlockSize));
 
-    // ...but only actually ask Rubberband for at most the number of samples we
-    // can handle:
-    int samplesToPull = samples;
-    if (samplesToPull > availableSamples)
-      samplesToPull = availableSamples;
-
-    // If we don't have enough samples to fill a full buffer,
-    // right-align the samples that we do have (i..e: start with silence).
-    int missingSamples = samples - availableSamples;
-    if (missingSamples > 0) {
-      for (size_t c = 0; c < numChannels; c++) {
-        // Clear the start of the buffer so that we start
-        // the buffer with silence:
-        std::fill_n(outBlock[c], missingSamples, 0.0);
-
-        // Move the output buffer pointer forward so that
-        // RubberBandStretcher::retrieve(...) places its
-        // output at the end of the buffer:
-        outBlock[c] += missingSamples;
-      }
-    }
-
-    // Pull the next audio data out of Rubberband:
-    rbPtr->retrieve(outBlock, samplesToPull);
+    return initialSamplesRequired;
   }
 
 protected:
   std::unique_ptr<RubberBandStretcher> rbPtr;
+  int initialSamplesRequired = 0;
+  static constexpr int MAX_CHANNEL_COUNT = 8;
 };
 }; // namespace Pedalboard

--- a/pedalboard/plugins/DelayLine.h
+++ b/pedalboard/plugins/DelayLine.h
@@ -1,0 +1,69 @@
+/*
+ * pedalboard
+ * Copyright 2022 Spotify AB
+ *
+ * Licensed under the GNU Public License, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../JucePlugin.h"
+
+namespace Pedalboard {
+
+/**
+ * A dummy plugin that buffers audio data internally, used to test Pedalboard's
+ * automatic delay compensation.
+ */
+class DelayLine : public JucePlugin<juce::dsp::DelayLine<
+                      float, juce::dsp::DelayLineInterpolationTypes::None>> {
+public:
+  virtual ~DelayLine(){};
+
+  virtual void reset() override {
+    getDSP().reset();
+    samplesProvided = 0;
+  }
+
+  virtual int
+  process(const juce::dsp::ProcessContextReplacing<float> &context) override {
+    getDSP().process(context);
+    int blockSize = context.getInputBlock().getNumSamples();
+    samplesProvided += blockSize;
+
+    return std::min((int)blockSize,
+                    std::max(0, (int)(samplesProvided - getDSP().getDelay())));
+  }
+
+  virtual int getLatencyHint() override {
+    return getDSP().getDelay();
+  }
+
+private:
+  int samplesProvided = 0;
+};
+
+inline void init_delay_line(py::module &m) {
+  py::class_<DelayLine, Plugin>(
+      m, "DelayLine",
+      "A dummy plugin that delays input audio for the given number of samples "
+      "before passing it back to the output. Used internally to test "
+      "Pedalboard's automatic latency compensation. Probably not useful as a "
+      "real effect.")
+      .def(py::init([](int samples) {
+             auto dl = new DelayLine();
+             dl->getDSP().setMaximumDelayInSamples(samples);
+             dl->getDSP().setDelay(samples);
+             return dl;
+           }),
+           py::arg("samples") = 44100);
+}
+}; // namespace Pedalboard

--- a/pedalboard/plugins/DelayLine.h
+++ b/pedalboard/plugins/DelayLine.h
@@ -43,9 +43,7 @@ public:
                     std::max(0, (int)(samplesProvided - getDSP().getDelay())));
   }
 
-  virtual int getLatencyHint() override {
-    return getDSP().getDelay();
-  }
+  virtual int getLatencyHint() override { return getDSP().getDelay(); }
 
 private:
   int samplesProvided = 0;

--- a/pedalboard/process.h
+++ b/pedalboard/process.h
@@ -162,7 +162,8 @@ py::array_t<T> copyJuceBufferIntoPyArray(const juce::AudioBuffer<T> juceBuffer,
       outputArray = py::array_t<T>({numChannels, outputSampleCount});
       break;
     default:
-      throw std::runtime_error("Internal error: got unexpected channel layout.");
+      throw std::runtime_error(
+          "Internal error: got unexpected channel layout.");
     }
   } else {
     outputArray = py::array_t<T>(outputSampleCount);

--- a/pedalboard/process.h
+++ b/pedalboard/process.h
@@ -283,7 +283,7 @@ process<float>(const py::array_t<float, py::array::c_style> inputArray,
                        /* keepExistingContent= */ true,
                        /* clearExtraSpace= */ true);
     }
-    
+
     // Actually run the plugins over the ioBuffer, in small chunks, to minimize
     // memory usage:
     int startOfOutputInBuffer = 0;
@@ -353,7 +353,7 @@ process<float>(const py::array_t<float, py::array::c_style> inputArray,
           // Only do this if reset=True was passed, as we can use that
           // as a proxy for the user's intent to call `process` again.
           intendedOutputBufferSize += missingSamples;
-          
+
           if (intendedOutputBufferSize > ioBuffer.getNumSamples()) {
             ioBuffer.setSize(ioBuffer.getNumChannels(),
                              intendedOutputBufferSize,
@@ -366,8 +366,7 @@ process<float>(const py::array_t<float, py::array::c_style> inputArray,
 
     // Trim the output buffer down to size; this operation should be free.
     jassert(intendedOutputBufferSize <= ioBuffer.getNumSamples());
-    ioBuffer.setSize(ioBuffer.getNumChannels(),
-                     intendedOutputBufferSize,
+    ioBuffer.setSize(ioBuffer.getNumChannels(), intendedOutputBufferSize,
                      /* keepExistingContent= */ true,
                      /* clearExtraSpace= */ true,
                      /* avoidReallocating= */ true);

--- a/pedalboard/process.h
+++ b/pedalboard/process.h
@@ -134,6 +134,9 @@ copyPyArrayIntoJuceBuffer(const py::array_t<T, py::array::c_style> inputArray) {
       ioBuffer.copyFrom(
           i, 0, static_cast<T *>(inputInfo.ptr) + (numSamples * i), numSamples);
     }
+    break;
+  default:
+    throw std::runtime_error("Internal error: got unexpected channel layout.");
   }
 
   return ioBuffer;
@@ -158,6 +161,8 @@ py::array_t<T> copyJuceBufferIntoPyArray(const juce::AudioBuffer<T> juceBuffer,
     case ChannelLayout::NotInterleaved:
       outputArray = py::array_t<T>({numChannels, outputSampleCount});
       break;
+    default:
+      throw std::runtime_error("Internal error: got unexpected channel layout.");
     }
   } else {
     outputArray = py::array_t<T>(outputSampleCount);
@@ -188,6 +193,8 @@ py::array_t<T> copyJuceBufferIntoPyArray(const juce::AudioBuffer<T> juceBuffer,
                 &outputBasePointer[outputSampleCount * i]);
     }
     break;
+  default:
+    throw std::runtime_error("Internal error: got unexpected channel layout.");
   }
 
   return outputArray;

--- a/pedalboard/process.h
+++ b/pedalboard/process.h
@@ -365,7 +365,8 @@ process<float>(const py::array_t<float, py::array::c_style> inputArray,
       }
     }
 
-    // Trim the output buffer down to size; this operation should be allocation-free.
+    // Trim the output buffer down to size; this operation should be
+    // allocation-free.
     jassert(intendedOutputBufferSize <= ioBuffer.getNumSamples());
     ioBuffer.setSize(ioBuffer.getNumChannels(), intendedOutputBufferSize,
                      /* keepExistingContent= */ true,

--- a/pedalboard/python_bindings.cpp
+++ b/pedalboard/python_bindings.cpp
@@ -35,6 +35,7 @@ namespace py = pybind11;
 #include "plugins/Chorus.h"
 #include "plugins/Compressor.h"
 #include "plugins/Convolution.h"
+#include "plugins/DelayLine.h"
 #include "plugins/Distortion.h"
 #include "plugins/Gain.h"
 #include "plugins/HighpassFilter.h"
@@ -147,4 +148,8 @@ PYBIND11_MODULE(pedalboard_native, m) {
   init_reverb(m);
 
   init_external_plugins(m);
+
+  // Internal plugins for testing, debugging, etc:
+  py::module internal = m.def_submodule("_internal");
+  init_delay_line(internal);
 };

--- a/tests/test_latency_compensation.py
+++ b/tests/test_latency_compensation.py
@@ -1,0 +1,31 @@
+#! /usr/bin/env python
+#
+# Copyright 2022 Spotify AB
+#
+# Licensed under the GNU Public License, Version 3.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.gnu.org/licenses/gpl-3.0.html
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+import numpy as np
+from pedalboard_native._internal import DelayLine
+
+
+@pytest.mark.parametrize("sample_rate", [22050, 44100, 48000])
+@pytest.mark.parametrize("buffer_size", [128, 8192, 65536])
+@pytest.mark.parametrize("latency_seconds", [0.25, 1, 2, 10])
+def test_latency_compensation(sample_rate, buffer_size, latency_seconds):
+    num_seconds = 10.0
+    noise = np.random.rand(int(num_seconds * sample_rate))
+    plugin = DelayLine(int(latency_seconds * sample_rate))
+    output = plugin.process(noise, sample_rate, buffer_size=buffer_size)
+    np.testing.assert_allclose(output, noise)

--- a/tests/test_pitch_shift.py
+++ b/tests/test_pitch_shift.py
@@ -17,10 +17,10 @@
 
 import pytest
 import numpy as np
-from pedalboard import PitchShift
+from pedalboard import Pedalboard, PitchShift
 
 
-@pytest.mark.parametrize("scale", [0.5, 1.0, 2.0])
+@pytest.mark.parametrize("scale", [1 / 2, 1.0, 2.0])
 @pytest.mark.parametrize("fundamental_hz", [440, 880])
 @pytest.mark.parametrize("sample_rate", [22050, 44100, 48000])
 def test_pitch_shift(scale, fundamental_hz, sample_rate):
@@ -31,3 +31,34 @@ def test_pitch_shift(scale, fundamental_hz, sample_rate):
     output = plugin.process(sine_wave, sample_rate)
 
     assert np.all(np.isfinite(output))
+
+
+@pytest.mark.parametrize("scale", [0.01, 65.0])
+def test_pitch_shift_extremes_throws_errors(scale):
+    with pytest.raises(ValueError):
+        PitchShift(scale)
+
+
+@pytest.mark.parametrize("scale", [1 / 64, 1 / 8, 1 / 2, 2, 8, 64])
+@pytest.mark.parametrize("sample_rate", [22050, 44100, 48000])
+@pytest.mark.parametrize("buffer_size", [32, 512, 8192])
+def test_pitch_shift_extremes(scale, sample_rate, buffer_size):
+    noise = np.random.rand(int(5.0 * sample_rate))
+    plugin = PitchShift(scale)
+    output = plugin.process(noise, sample_rate, buffer_size=buffer_size)
+    assert np.all(np.isfinite(output))
+
+
+@pytest.mark.parametrize("scale", [1.0])
+@pytest.mark.parametrize("sample_rate", [22050, 44100, 48000])
+@pytest.mark.parametrize("buffer_size", [512, 8192])
+def test_pitch_shift_latency_compensation(scale, sample_rate, buffer_size):
+    num_seconds = 10.0
+    fundamental_hz = 440.0
+    samples = np.arange(num_seconds * sample_rate)
+    sine_wave = np.sin(2 * np.pi * fundamental_hz * samples / sample_rate)
+    plugin = Pedalboard([PitchShift(scale), PitchShift(1 / scale)])
+    output = plugin.process(sine_wave, sample_rate, buffer_size=buffer_size)
+    np.testing.assert_allclose(
+        sine_wave[sample_rate:-sample_rate], output[sample_rate:-sample_rate], rtol=0.01, atol=0.01
+    )


### PR DESCRIPTION
Now that we have the `PitchShift` plugin, users of Pedalboard need to manually compensate for the latency added when shifting pitch up or down. This PR fixes that by making Pedalboard latency-aware - automatically compensating when a given plugin returns too few samples in a block.