### PR TITLE
Fix audio glitches when running VST3 or AU plugins whose reported latency exceeds buffer size.

### DIFF
--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -620,7 +620,7 @@ public:
       // To compensate for any latency added by the plugin,
       // only tell Pedalboard to use the last _n_ samples.
       long usableSamplesProduced =
-          samplesProvided - pluginInstance->getLatencySamples();
+          std::max(0L, samplesProvided - pluginInstance->getLatencySamples());
       return static_cast<int>(
           std::min(usableSamplesProduced, (long)outputBlock.getNumSamples()));
     }

--- a/pedalboard/process.h
+++ b/pedalboard/process.h
@@ -317,6 +317,12 @@ process<float>(const py::array_t<float, py::array::c_style> inputArray,
         juce::dsp::ProcessContextReplacing<float> context(ioBlock);
 
         int outputSamples = plugin->process(context);
+        if (outputSamples < 0) {
+          throw std::runtime_error(
+            "A plugin returned a negative number of output samples! "
+            "This is an internal Pedalboard error and should be reported."
+          );
+        }
         pluginSamplesReceived += outputSamples;
 
         int missingSamples = blockSize - outputSamples;

--- a/pedalboard/process.h
+++ b/pedalboard/process.h
@@ -319,9 +319,8 @@ process<float>(const py::array_t<float, py::array::c_style> inputArray,
         int outputSamples = plugin->process(context);
         if (outputSamples < 0) {
           throw std::runtime_error(
-            "A plugin returned a negative number of output samples! "
-            "This is an internal Pedalboard error and should be reported."
-          );
+              "A plugin returned a negative number of output samples! "
+              "This is an internal Pedalboard error and should be reported.");
         }
         pluginSamplesReceived += outputSamples;
 

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -603,7 +603,7 @@ def test_parameter_name_normalization(_input: str, expected: str):
 
 
 @pytest.mark.skipif(not plugin_named("CHOWTapeModel"), reason="Missing CHOWTapeModel plugin.")
-@pytest.mark.parametrize("buffer_size", [128, 8192, 65536])
+@pytest.mark.parametrize("buffer_size", [16, 128, 8192, 65536])
 @pytest.mark.parametrize("oversampling", [1, 2, 4, 8, 16])
 def test_external_plugin_latency_compensation(buffer_size: int, oversampling: int):
     """


### PR DESCRIPTION
Title says it all - a subtle bug slipped through thanks to negative numbers being returned from a function that should only ever return positive numbers. Thanks @drubinstein for the inspiration to check this.