### PR TITLE
Add MP3Compressor plugin.

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -35,7 +35,7 @@ jobs:
           pip install wheel
           pip install -r test-requirements.txt
       - name: Lint Python code
-        run: flake8 . --count --ignore=W503,E203 --exclude .git,dist,doc,build --show-source --statistics --max-line-length 100
+        run: flake8 . --count --ignore=W503,E203 --exclude .git,dist,doc,build,vendors --show-source --statistics --max-line-length 100
       - name: Check Python formatting
         run: black pedalboard tests --line-length 100 --experimental-string-processing --diff --check
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "JUCE"]
 	path = JUCE
 	url = https://github.com/juce-framework/JUCE.git
-[submodule "pedalboard/vendors/rubberband"]
+[submodule "vendors/rubberband"]
 	path = vendors/rubberband
 	url = https://github.com/BreakfastQuay/Rubberband.git
 [submodule "vendors/lame"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "pedalboard/vendors/rubberband"]
 	path = vendors/rubberband
 	url = https://github.com/BreakfastQuay/Rubberband.git
+[submodule "vendors/lame"]
+	path = vendors/lame
+	url = https://github.com/lameproject/lame.git

--- a/README.md
+++ b/README.md
@@ -234,11 +234,13 @@ Not yet! The underlying framework (JUCE) supports VST and AU instruments just fi
 Not yet, either - although the underlying framework (JUCE) supports passing MIDI to plugins, so this would also be possible to add.
 
 ## License
-`pedalboard` is Copyright 2021 Spotify AB.
+`pedalboard` is Copyright 2021-2022 Spotify AB.
 
-`pedalboard` is licensed under the [GNU General Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html), because:
- - The core audio processing code is pulled from JUCE 6, which is [dual-licensed under a commercial license and the GPLv3](https://juce.com/juce-6-licence).
- - The VST3 SDK, bundled with JUCE, is owned by [Steinberg® Media Technologies GmbH](https://www.steinberg.net/en/home.html) and licensed under the GPLv3.
+`pedalboard` is licensed under the [GNU General Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html). `pedalboard` includes a number of libraries that are statically compiled, and which carry the following licenses:
+
+ - The core audio processing code is pulled from [JUCE 6](https://juce.com/), which is [dual-licensed under a commercial license and the GPLv3](https://juce.com/juce-6-licence).
+ - The [VST3 SDK](https://github.com/steinbergmedia/vst3sdk), bundled with JUCE, is owned by [Steinberg® Media Technologies GmbH](https://www.steinberg.net/en/home.html) and licensed under the GPLv3.
  - The `PitchShift` plugin uses [the Rubber Band Library](https://github.com/breakfastquay/rubberband), which is [dual-licensed under a commercial license](https://breakfastquay.com/technology/license.html) and the GPLv2 (or newer).
+ - The `MP3Compressor` plugin uses [`libmp3lame` from the LAME project](https://lame.sourceforge.io/), which is [licensed under the LGPLv2](https://github.com/lameproject/lame/blob/master/README) and [upgraded to the GPLv3 for inclusion in this project (as permitted by the LGPLv2)](https://www.gnu.org/licenses/gpl-faq.html#AllCompatibility).
 
 _VST is a registered trademark of Steinberg Media Technologies GmbH._

--- a/pedalboard/pedalboard.py
+++ b/pedalboard/pedalboard.py
@@ -628,6 +628,7 @@ try:
             super().__init__(path_to_plugin_file)
             self.__set_initial_parameter_values__(parameter_values)
 
+
 except ImportError:
     # We may be on a system that doesn't have native VST3Plugin support.
     pass
@@ -643,6 +644,7 @@ try:
         ):
             super().__init__(path_to_plugin_file)
             self.__set_initial_parameter_values__(parameter_values)
+
 
 except ImportError:
     # We may be on a system that doesn't have native AudioUnitPlugin support.

--- a/pedalboard/plugins/MP3Compressor.h
+++ b/pedalboard/plugins/MP3Compressor.h
@@ -1,0 +1,303 @@
+/*
+ * pedalboard
+ * Copyright 2022 Spotify AB
+ *
+ * Licensed under the GNU Public License, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../Plugin.h"
+#include <lame.h>
+
+namespace Pedalboard {
+
+/*
+ * A small C++ wrapper around the C-based LAME MP3 encoding functions.
+ * Used mostly to avoid leaking memory.
+ */
+class EncoderWrapper {
+public:
+  EncoderWrapper() { lame = lame_init(); }
+  ~EncoderWrapper() { reset(); }
+
+  operator bool() const { return lame != nullptr; }
+
+  void reset() {
+    lame_close(lame);
+    lame = nullptr;
+  }
+
+  lame_t getContext() {
+    if (!lame)
+      lame = lame_init();
+    return lame;
+  }
+
+private:
+  lame_t lame;
+};
+
+/*
+ * A small C++ wrapper around the C-based LAME MP3 decoding functions.
+ * Used mostly to avoid leaking memory.
+ */
+class DecoderWrapper {
+public:
+  DecoderWrapper() { hip = hip_decode_init(); }
+  ~DecoderWrapper() { reset(); }
+  operator bool() const { return hip != nullptr; }
+
+  void reset() {
+    hip_decode_exit(hip);
+    hip = nullptr;
+  }
+
+  hip_t getContext() {
+    if (!hip)
+      hip = hip_decode_init();
+    return hip;
+  }
+
+private:
+  hip_t hip;
+};
+
+void lame_throw_error_handler(const char *format, va_list ap) {
+  int errorLength = 512;
+  char errorBuffer[errorLength + 1];
+  snprintf(errorBuffer, errorLength, format, ap);
+  throw std::runtime_error("MP3 encoder threw an error: " +
+                           std::string(errorBuffer));
+}
+
+class MP3Compressor : public Plugin {
+public:
+  virtual ~MP3Compressor(){};
+
+  void setVBRQuality(float newLevel) {
+    if (newLevel < 0 || newLevel > 10) {
+      throw std::runtime_error("VBR quality must be greater than 0 and less "
+                               "than 10. (Higher numbers are lower quality.)");
+    }
+
+    vbrLevel = newLevel;
+    encoder.reset();
+  }
+
+  float getVBRQuality() const { return vbrLevel; }
+
+  virtual void prepare(const juce::dsp::ProcessSpec &spec) override {
+    bool specChanged = lastSpec.sampleRate != spec.sampleRate ||
+                       lastSpec.maximumBlockSize < spec.maximumBlockSize ||
+                       lastSpec.numChannels != spec.numChannels;
+    if (!lame || specChanged) {
+      reset();
+
+      lame_set_errorf(encoder.getContext(), lame_throw_error_handler);
+
+      if (lame_set_in_samplerate(encoder.getContext(), spec.sampleRate) != 0) {
+        throw std::runtime_error(
+            "MP3 encoder failed to set input sample rate.");
+      }
+
+      if (lame_set_out_samplerate(encoder.getContext(), spec.sampleRate) != 0) {
+        throw std::runtime_error(
+            "MP3 encoder failed to set output sample rate.");
+      }
+
+      if (lame_set_num_channels(encoder.getContext(), spec.numChannels) != 0) {
+        throw std::runtime_error(
+            "MP3 encoder failed to set number of channels.");
+      }
+
+      // TODO: handle when the output sample rate doesn't match one of the
+      // expected rates from encoder.
+
+      if (lame_set_VBR(encoder.getContext(), vbr_default) != 0) {
+        throw std::runtime_error(
+            "MP3 encoder failed to set variable bit rate flag.");
+      }
+
+      if (lame_set_VBR_quality(encoder.getContext(), vbrLevel) != 0) {
+        throw std::runtime_error(
+            "MP3 encoder failed to set variable bit rate quality to " +
+            std::to_string(vbrLevel) + "!");
+      }
+
+      int ret = lame_init_params(encoder.getContext());
+      if (ret != 0) {
+        throw std::runtime_error(
+            "MP3 encoder failed to initialize MP3 encoder! (error " +
+            std::to_string(ret) + ")");
+      }
+
+      // Why + 528 + 1? Pulled directly from the libmp3lame code; not 100% sure.
+      // Values have been confirmed empirically, however.
+      encoderInStreamLatency =
+          lame_get_encoder_delay(encoder.getContext()) + 528 + 1;
+
+      int outputBufferSize = (16384 + spec.maximumBlockSize) * sizeof(short);
+      for (int i = 0; i < 2; i++) {
+        outputBuffers[i].setSize(outputBufferSize);
+        outputBuffers[i].fillWith(0);
+      }
+
+      outputBufferLastSample = 0;
+
+      lastSpec = spec;
+    }
+  }
+
+  int process(
+      const juce::dsp::ProcessContextReplacing<float> &context) override final {
+
+    auto ioBlock = context.getOutputBlock();
+    for (int i = 0; i < ioBlock.getNumSamples();
+         i += MAX_MP3_FRAME_SIZE_SAMPLES) {
+      jassert(ioBlock.getNumChannels() == 2);
+
+      unsigned char mp3Buffer[MAX_MP3_FRAME_SIZE_BYTES];
+
+      int frameSize =
+          std::min(MAX_MP3_FRAME_SIZE_SAMPLES, ioBlock.getNumSamples() - i);
+
+      int numBytesEncoded = lame_encode_buffer_ieee_float(
+          encoder.getContext(), ioBlock.getChannelPointer(0) + i,
+          ioBlock.getChannelPointer(1) + i, frameSize, mp3Buffer,
+          MAX_MP3_FRAME_SIZE_BYTES);
+
+      if (numBytesEncoded < 0) {
+        throw std::runtime_error("MP3 encoder failed to encode with error " +
+                                 std::to_string(numBytesEncoded) + ".");
+      }
+
+      samplesInEncodingBuffer += frameSize;
+
+      // Decode frames from the buffer as soon as we get them:
+      if (numBytesEncoded > 0) {
+        int samplesDecoded = hip_decode(
+            decoder.getContext(), mp3Buffer, numBytesEncoded,
+            (short *)outputBuffers[0].getData() + outputBufferLastSample,
+            (short *)outputBuffers[1].getData() + outputBufferLastSample);
+        outputBufferLastSample += samplesDecoded;
+        samplesInEncodingBuffer -= samplesDecoded;
+        if (encodingLatency == 0) {
+          encodingLatency = samplesInEncodingBuffer;
+        }
+      }
+    }
+
+    int samplesToOutput = std::min(ioBlock.getNumSamples(),
+                                   (unsigned long)outputBufferLastSample);
+    samplesProduced += samplesToOutput;
+    int offsetInOutputBuffer = 0;
+    if (samplesToOutput < ioBlock.getNumSamples()) {
+      offsetInOutputBuffer = ioBlock.getNumSamples() - samplesToOutput;
+    }
+
+    for (int c = 0; c < ioBlock.getNumChannels(); c++) {
+      juce::AudioDataConverters::convertInt16LEToFloat(
+          (short *)outputBuffers[c].getData(),
+          ioBlock.getChannelPointer(c) + offsetInOutputBuffer, samplesToOutput);
+    }
+
+    // Move the remaining content in the output buffer to the left hand side:
+    int numSamplesRemaining =
+        std::max(0L, outputBufferLastSample - samplesToOutput);
+    if (numSamplesRemaining) {
+      for (int c = 0; c < ioBlock.getNumChannels(); c++) {
+        std::memmove((short *)outputBuffers[c].getData(),
+                     (short *)outputBuffers[c].getData() + samplesToOutput,
+                     numSamplesRemaining * sizeof(short));
+      }
+    }
+    outputBufferLastSample = numSamplesRemaining;
+
+    long usableSamplesProduced = std::max(
+        0L, samplesProduced - (encodingLatency + encoderInStreamLatency));
+    int samplesInBuffer = static_cast<int>(
+        std::min(usableSamplesProduced, (long)samplesToOutput));
+    return samplesInBuffer;
+  }
+
+  void reset() override final {
+    encoder.reset();
+    decoder.reset();
+
+    outputBuffers[0].fillWith(0);
+    outputBuffers[1].fillWith(0);
+
+    outputBufferLastSample = 0;
+    samplesProduced = 0;
+    samplesInEncodingBuffer = 0;
+    encodingLatency = 0;
+    encoderInStreamLatency = 0;
+  }
+
+protected:
+  virtual int getLatencyHint() override {
+    if (encodingLatency == 0) {
+      // If we haven't started encoding yet, over-estimate
+      // our latency bounds, as we'll almost always have a fairly large buffer.
+      return encoderInStreamLatency + MAX_MP3_FRAME_SIZE_SAMPLES;
+    }
+    return encoderInStreamLatency + encodingLatency;
+  }
+
+private:
+  float vbrLevel = 2.0;
+
+  EncoderWrapper encoder;
+  DecoderWrapper decoder;
+
+  static constexpr unsigned long MAX_MP3_FRAME_SIZE_BYTES = 4096;
+  static constexpr unsigned long MAX_MP3_FRAME_SIZE_SAMPLES = 1152;
+
+  // This should really be an AudioBuffer<short>, but JUCE doesn't offer that.
+  // TODO: This should be numChannels to support more than mono and stereo
+  // audio!
+  juce::MemoryBlock outputBuffers[2];
+  long outputBufferLastSample = 0;
+  long samplesProduced = 0;
+  long samplesInEncodingBuffer = 0;
+
+  // We have two latency numbers to consider here: the amount of latency between
+  // supplying samples to LAME and getting samples back, and then the amount of
+  // latency within the stream coming out of LAME itself.
+  long encodingLatency = 0;
+  long encoderInStreamLatency = 0;
+};
+
+inline void init_mp3_compressor(py::module &m) {
+  py::class_<MP3Compressor, Plugin>(
+      m, "MP3Compressor",
+      "Apply an MP3 compressor to the audio to reduce its quality.")
+      .def(py::init([](float vbr_quality) {
+             auto plugin = new MP3Compressor();
+             plugin->setVBRQuality(vbr_quality);
+             return plugin;
+           }),
+           py::arg("vbr_quality") = 2.0)
+      .def("__repr__",
+           [](const MP3Compressor &plugin) {
+             std::ostringstream ss;
+             ss << "<pedalboard.MP3Compressor";
+             ss << " vbr_quality=" << plugin.getVBRQuality();
+             ss << " at " << &plugin;
+             ss << ">";
+             return ss.str();
+           })
+      .def_property("vbr_quality", &MP3Compressor::getVBRQuality,
+                    &MP3Compressor::setVBRQuality);
+}
+
+}; // namespace Pedalboard

--- a/pedalboard/plugins/MP3Compressor.h
+++ b/pedalboard/plugins/MP3Compressor.h
@@ -223,7 +223,7 @@ public:
 
       delete[] silence;
 
-      if (numBytesEncoded != 0) {
+      if (numBytesEncoded < 0) {
         throw std::runtime_error("Failed to prime MP3 encoder!");
       }
 

--- a/pedalboard/plugins/MP3Compressor.h
+++ b/pedalboard/plugins/MP3Compressor.h
@@ -155,7 +155,7 @@ public:
       const juce::dsp::ProcessContextReplacing<float> &context) override final {
 
     auto ioBlock = context.getOutputBlock();
-    for (int i = 0; i < ioBlock.getNumSamples();
+    for (size_t i = 0; i < ioBlock.getNumSamples();
          i += MAX_MP3_FRAME_SIZE_SAMPLES) {
       jassert(ioBlock.getNumChannels() == 2);
 
@@ -191,7 +191,7 @@ public:
     }
 
     int samplesToOutput = std::min(ioBlock.getNumSamples(),
-                                   (unsigned long)outputBufferLastSample);
+                                   (size_t)outputBufferLastSample);
     samplesProduced += samplesToOutput;
     int offsetInOutputBuffer = 0;
     if (samplesToOutput < ioBlock.getNumSamples()) {
@@ -253,8 +253,8 @@ private:
   EncoderWrapper encoder;
   DecoderWrapper decoder;
 
-  static constexpr unsigned long MAX_MP3_FRAME_SIZE_BYTES = 4096;
-  static constexpr unsigned long MAX_MP3_FRAME_SIZE_SAMPLES = 1152;
+  static constexpr size_t MAX_MP3_FRAME_SIZE_BYTES = 8192;
+  static constexpr size_t MAX_MP3_FRAME_SIZE_SAMPLES = 1152;
 
   // This should really be an AudioBuffer<short>, but JUCE doesn't offer that.
   // TODO: This should be numChannels to support more than mono and stereo

--- a/pedalboard/plugins/MP3Compressor.h
+++ b/pedalboard/plugins/MP3Compressor.h
@@ -99,7 +99,7 @@ public:
    * Returns the number of samples copied.
    */
   int copyToRightSideOf(juce::dsp::AudioBlock<float> outputBlock) {
-    int samplesToOutput = std::min(outputBlock.getNumSamples(), lastSample);
+    int samplesToOutput = std::min((unsigned long) outputBlock.getNumSamples(), lastSample);
 
     if (samplesToOutput) {
       int offsetInOutputBuffer = 0;

--- a/pedalboard/plugins/MP3Compressor.h
+++ b/pedalboard/plugins/MP3Compressor.h
@@ -99,7 +99,7 @@ public:
     bool specChanged = lastSpec.sampleRate != spec.sampleRate ||
                        lastSpec.maximumBlockSize < spec.maximumBlockSize ||
                        lastSpec.numChannels != spec.numChannels;
-    if (!lame || specChanged) {
+    if (!encoder || specChanged) {
       reset();
 
       lame_set_errorf(encoder.getContext(), lame_throw_error_handler);

--- a/pedalboard/plugins/MP3Compressor.h
+++ b/pedalboard/plugins/MP3Compressor.h
@@ -99,7 +99,8 @@ public:
    * Returns the number of samples copied.
    */
   int copyToRightSideOf(juce::dsp::AudioBlock<float> outputBlock) {
-    int samplesToOutput = std::min((unsigned long) outputBlock.getNumSamples(), lastSample);
+    int samplesToOutput =
+        std::min((unsigned long)outputBlock.getNumSamples(), lastSample);
 
     if (samplesToOutput) {
       int offsetInOutputBuffer = 0;

--- a/pedalboard/plugins/MP3Compressor.h
+++ b/pedalboard/plugins/MP3Compressor.h
@@ -200,6 +200,8 @@ public:
   
       // Constants copied from the LAME documentation:
       mp3Buffer.ensureSize((int) (1.25 * MAX_LAME_MP3_BUFFER_SIZE_SAMPLES) + 7200);
+
+      // TODO: Find a tighter bound for this output buffer.
       outputBuffer.setSize(32768 + spec.maximumBlockSize * 2);
 
       // Feed in some silence at the start so that LAME buffers up enough samples
@@ -221,6 +223,10 @@ public:
         mp3Buffer.getSize());
 
       delete[] silence;
+
+      if (numBytesEncoded != 0) {
+        throw std::runtime_error("Failed to prime MP3 encoder!");
+      }
 
       encoderInStreamLatency += samplesToAdd;
       lastSpec = spec;

--- a/pedalboard/plugins/MP3Compressor.h
+++ b/pedalboard/plugins/MP3Compressor.h
@@ -16,7 +16,11 @@
  */
 
 #include "../Plugin.h"
+
+extern "C" {
 #include <lame.h>
+}
+
 
 namespace Pedalboard {
 
@@ -71,14 +75,6 @@ private:
   hip_t hip;
 };
 
-void lame_throw_error_handler(const char *format, va_list ap) {
-  int errorLength = 512;
-  char errorBuffer[errorLength + 1];
-  snprintf(errorBuffer, errorLength, format, ap);
-  throw std::runtime_error("MP3 encoder threw an error: " +
-                           std::string(errorBuffer));
-}
-
 class MP3Compressor : public Plugin {
 public:
   virtual ~MP3Compressor(){};
@@ -101,8 +97,6 @@ public:
                        lastSpec.numChannels != spec.numChannels;
     if (!encoder || specChanged) {
       reset();
-
-      lame_set_errorf(encoder.getContext(), lame_throw_error_handler);
 
       if (lame_set_in_samplerate(encoder.getContext(), spec.sampleRate) != 0) {
         throw std::runtime_error(

--- a/pedalboard/process.h
+++ b/pedalboard/process.h
@@ -75,7 +75,8 @@ detectChannelLayout(const py::array_t<T, py::array::c_style> inputArray) {
           "Unable to determine channel layout from shape!");
     }
   } else {
-    throw std::runtime_error("Number of input dimensions must be 1 or 2 (got " + std::to_string(inputInfo.ndim) + ").");
+    throw std::runtime_error("Number of input dimensions must be 1 or 2 (got " +
+                             std::to_string(inputInfo.ndim) + ").");
   }
 }
 
@@ -104,7 +105,8 @@ copyPyArrayIntoJuceBuffer(const py::array_t<T, py::array::c_style> inputArray) {
       throw std::runtime_error("Unable to determine shape of audio input!");
     }
   } else {
-    throw std::runtime_error("Number of input dimensions must be 1 or 2 (got " + std::to_string(inputInfo.ndim) + ").");
+    throw std::runtime_error("Number of input dimensions must be 1 or 2 (got " +
+                             std::to_string(inputInfo.ndim) + ").");
   }
 
   if (numChannels == 0) {

--- a/pedalboard/process.h
+++ b/pedalboard/process.h
@@ -75,7 +75,7 @@ detectChannelLayout(const py::array_t<T, py::array::c_style> inputArray) {
           "Unable to determine channel layout from shape!");
     }
   } else {
-    throw std::runtime_error("Number of input dimensions must be 1 or 2.");
+    throw std::runtime_error("Number of input dimensions must be 1 or 2 (got " + std::to_string(inputInfo.ndim) + ").");
   }
 }
 
@@ -104,7 +104,7 @@ copyPyArrayIntoJuceBuffer(const py::array_t<T, py::array::c_style> inputArray) {
       throw std::runtime_error("Unable to determine shape of audio input!");
     }
   } else {
-    throw std::runtime_error("Number of input dimensions must be 1 or 2.");
+    throw std::runtime_error("Number of input dimensions must be 1 or 2 (got " + std::to_string(inputInfo.ndim) + ").");
   }
 
   if (numChannels == 0) {

--- a/pedalboard/python_bindings.cpp
+++ b/pedalboard/python_bindings.cpp
@@ -43,6 +43,7 @@ namespace py = pybind11;
 #include "plugins/LadderFilter.h"
 #include "plugins/Limiter.h"
 #include "plugins/LowpassFilter.h"
+#include "plugins/MP3Compressor.h"
 #include "plugins/NoiseGate.h"
 #include "plugins/Phaser.h"
 #include "plugins/PitchShift.h"
@@ -144,6 +145,7 @@ PYBIND11_MODULE(pedalboard_native, m) {
   init_ladderfilter(m);
   init_limiter(m);
   init_lowpass(m);
+  init_mp3_compressor(m);
   init_noisegate(m);
   init_phaser(m);
   init_pitch_shift(m);

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ else:
     LAME_FLAGS.append(f"-include{LAME_CONFIG_FILE}")
 ALL_CFLAGS.extend(LAME_FLAGS)
 ALL_SOURCE_PATHS += list(Path("vendors/lame/libmp3lame").glob("*.c"))
+ALL_SOURCE_PATHS += list(Path("vendors/lame/libmp3lame/vector").glob("*.c"))
 ALL_SOURCE_PATHS += list(Path("vendors/lame/mpglib").glob("*.c"))
 ALL_INCLUDES += [
     'vendors/lame/include/',

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,9 @@ LAME_FLAGS = ["-DHAVE_MPGLIB"]
 LAME_CONFIG_FILE = str(Path("vendors/lame_config.h").resolve())
 if platform.system() == "Windows":
     LAME_FLAGS.append(f"/FI{LAME_CONFIG_FILE}")
+    # Enable native assembly instructions via NASM for x86
+    # If we enable Windows-on-ARM builds, this should be disabled.
+    LAME_FLAGS.append(f"-DHAVE_NASM")
 else:
     LAME_FLAGS.append(f"-include{LAME_CONFIG_FILE}")
 ALL_CFLAGS.extend(LAME_FLAGS)

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ ALL_COMPILER_FLAGS = [
 ]
 ALL_INCLUDES = []
 ALL_LINK_ARGS = []
+ALL_CFLAGS = []
 ALL_CPPFLAGS = []
 ALL_LIBRARIES = []
 ALL_SOURCE_PATHS = []
@@ -89,37 +90,7 @@ ALL_SOURCE_PATHS += list(Path("vendors/rubberband/single").glob("*.cpp"))
 
 # LAME/mpglib:
 # (man, this code is portable)
-ALL_COMPILER_FLAGS.extend(
-    [
-        "-DSIZEOF_DOUBLE=8",
-        "-DSIZEOF_FLOAT=4",
-        "-DSIZEOF_INT=4",
-        "-DSIZEOF_LONG=4",
-        "-DSIZEOF_LONG_DOUBLE=12",
-        "-DSIZEOF_SHORT=2",
-        "-DSIZEOF_UNSIGNED_INT=4",
-        "-DSIZEOF_UNSIGNED_LONG=4",
-        "-DSIZEOF_UNSIGNED_SHORT=2",
-        "-DSTDC_HEADERS",
-        "-DHAVE_ERRNO_H",
-        "-DHAVE_FCNTL_H",
-        "-DHAVE_LIMITS_H",
-        "-DPROTOTYPES=1",
-        "-DHAVE_STRCHR",
-        "-DHAVE_MEMCPY",
-        "-DHAVE_MPGLIB",
-        # Some data types are defined in config.h, which we don't include:
-        "-Dieee754_float32_t=float",
-        "-Duint8_t=u_int8_t",
-        "-Duint16_t=u_int16_t",
-        "-Duint32_t=u_int32_t",
-        "-Duint64_t=u_int64_t",
-        "-Dint8_t=char",
-        "-Dint16_t=short",
-        "-Dint32_t=int",
-        "-Dint64_t=(long long)",
-    ]
-)
+ALL_CFLAGS.extend(["-includevendors/lame_config.h", "-DHAVE_MPGLIB"])
 ALL_SOURCE_PATHS += list(Path("vendors/lame/libmp3lame").glob("*.c"))
 ALL_SOURCE_PATHS += list(Path("vendors/lame/mpglib").glob("*.c"))
 ALL_INCLUDES += [
@@ -255,6 +226,7 @@ def patch_compile(original_compile):
         elif ext in ('.c',):
             # We're compiling C code, remove the -std= arg:
             extra_postargs = [arg for arg in extra_postargs if 'std=' not in arg]
+            _cc_args = cc_args + ALL_CFLAGS
 
         return original_compile(obj, src, ext, _cc_args, extra_postargs, *args, **kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -110,14 +110,14 @@ ALL_COMPILER_FLAGS.extend(
         "-DHAVE_MPGLIB",
         # Some data types are defined in config.h, which we don't include:
         "-Dieee754_float32_t=float",
-        "-Duint8_t=unsigned char",
-        "-Duint16_t=unsigned short",
-        "-Duint32_t=unsigned int",
-        "-Duint64_t=unsigned long long",
-        "-Dint8_t=signed char",
-        "-Dint16_t=signed short",
-        "-Dint32_t=signed int",
-        "-Dint64_t=signed long long",
+        "-Duint8_t=u_int8_t",
+        "-Duint16_t=u_int16_t",
+        "-Duint32_t=u_int32_t",
+        "-Duint64_t=u_int64_t",
+        "-Dint8_t=char",
+        "-Dint16_t=short",
+        "-Dint32_t=int",
+        "-Dint64_t=(long long)",
     ]
 )
 ALL_SOURCE_PATHS += list(Path("vendors/lame/libmp3lame").glob("*.c"))

--- a/setup.py
+++ b/setup.py
@@ -93,9 +93,7 @@ LAME_FLAGS = ["-DHAVE_MPGLIB"]
 LAME_CONFIG_FILE = str(Path("vendors/lame_config.h").resolve())
 if platform.system() == "Windows":
     LAME_FLAGS.append(f"/FI{LAME_CONFIG_FILE}")
-    # Enable native assembly instructions via NASM for x86
-    # If we enable Windows-on-ARM builds, this should be disabled.
-    LAME_FLAGS.append(f"-DHAVE_NASM")
+    LAME_FLAGS.append(f"-DHAVE_XMMINTRIN_H")
 else:
     LAME_FLAGS.append(f"-include{LAME_CONFIG_FILE}")
 ALL_CFLAGS.extend(LAME_FLAGS)

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ LAME_FLAGS = ["-DHAVE_MPGLIB"]
 LAME_CONFIG_FILE = str(Path("vendors/lame_config.h").resolve())
 if platform.system() == "Windows":
     LAME_FLAGS.append(f"/FI{LAME_CONFIG_FILE}")
-    LAME_FLAGS.append(f"-DHAVE_XMMINTRIN_H")
+    LAME_FLAGS.append("-DHAVE_XMMINTRIN_H")
 else:
     LAME_FLAGS.append(f"-include{LAME_CONFIG_FILE}")
 ALL_CFLAGS.extend(LAME_FLAGS)

--- a/setup.py
+++ b/setup.py
@@ -159,11 +159,6 @@ UnixCCompiler.language_map[".mm"] = "objc++"
 # Add all Pedalboard C++ sources:
 ALL_SOURCE_PATHS += list(Path("pedalboard").glob("**/*.cpp"))
 
-# Rubber Band pitch shifter/time stretcher
-
-
-# LAME MP3 encoder:
-
 if platform.system() == "Darwin":
     MACOS_FRAMEWORKS = [
         'Accelerate',

--- a/setup.py
+++ b/setup.py
@@ -110,8 +110,14 @@ ALL_COMPILER_FLAGS.extend(
         "-DHAVE_MPGLIB",
         # Some data types are defined in config.h, which we don't include:
         "-Dieee754_float32_t=float",
-        "-Duint32_t=u_int32_t",
-        "-Duint16_t=u_int16_t",
+        "-Duint8_t=unsigned char",
+        "-Duint16_t=unsigned short",
+        "-Duint32_t=unsigned int",
+        "-Duint64_t=unsigned long long",
+        "-Dint8_t=signed char",
+        "-Dint16_t=signed short",
+        "-Dint32_t=signed int",
+        "-Dint64_t=signed long long",
     ]
 )
 ALL_SOURCE_PATHS += list(Path("vendors/lame/libmp3lame").glob("*.c"))
@@ -241,6 +247,7 @@ else:
 
 def patch_compile(original_compile):
     def new_compile(obj, src, ext, cc_args, extra_postargs, *args, **kwargs):
+        print(f"\n\nIn new_compile with obj={obj}, src={src}, ext={ext}, cc_args={cc_args}, extra_postargs={extra_postargs}")
         _cc_args = cc_args
 
         if ext in ('.cpp', '.cxx', '.cc', '.mm'):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,7 +6,7 @@ pybind11>=2.6.0
 setuptools>=42
 wheel
 flake8
-black==21.12b0
+black==21.7b0
 interrogate
 
 numpy

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,6 +12,6 @@ interrogate
 numpy
 sox
 typing-extensions>=3.10.0.0
-tensorflow==2.8.0-rc0; python_version < '3.10' and platform.machine != 'arm64'
+tensorflow~=2.6.2; python_version < '3.10' and platform.machine != 'arm64'
 google-cloud-storage
 tqdm

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,12 +6,11 @@ pybind11>=2.6.0
 setuptools>=42
 wheel
 flake8
-black
+black==21.12b0
 interrogate
 
 numpy
 sox
-typing-extensions>=3.10.0.0
 tensorflow~=2.6.2; python_version < '3.10' and platform.machine != 'arm64'
 google-cloud-storage
 tqdm

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -21,7 +21,7 @@ from pedalboard import HighpassFilter, LowpassFilter
 
 
 def rms(x: np.ndarray) -> float:
-    return np.sqrt(np.mean(x**2))
+    return np.sqrt(np.mean(x ** 2))
 
 
 def normalized(x: np.ndarray) -> np.ndarray:

--- a/tests/test_mp3_compressor.py
+++ b/tests/test_mp3_compressor.py
@@ -31,3 +31,22 @@ def test_mp3_compressor(vbr_quality: float, sample_rate: int):
 
     compressed = MP3Compressor(vbr_quality)(stereo_sine_wave, sample_rate)
     np.testing.assert_allclose(stereo_sine_wave, compressed, atol=0.25)
+
+
+@pytest.mark.parametrize("vbr_quality", [0.0, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9.5])
+@pytest.mark.parametrize("sample_rate", [44100, 48000])
+def test_mp3_compressor_invariant_to_buffer_size(vbr_quality: float, sample_rate: int):
+    num_seconds = 10.0
+    fundamental_hz = 440
+    samples = np.arange(num_seconds * sample_rate)
+    sine_wave = np.sin(2 * np.pi * fundamental_hz * samples / sample_rate)
+    stereo_sine_wave = np.stack([sine_wave, sine_wave])
+
+    compressed_different_buffer_sizes = [
+        MP3Compressor(vbr_quality)(stereo_sine_wave, sample_rate, buffer_size=buffer_size)
+        for buffer_size in (32, 128, 1024, 1152, 8192, 65536)
+    ]
+
+    # These should all be the same, so any two should be the same:
+    for a, b in zip(compressed_different_buffer_sizes, compressed_different_buffer_sizes[:1]):
+        np.testing.assert_allclose(a, b, atol=0.25)

--- a/tests/test_mp3_compressor.py
+++ b/tests/test_mp3_compressor.py
@@ -1,0 +1,33 @@
+#! /usr/bin/env python
+#
+# Copyright 2021 Spotify AB
+#
+# Licensed under the GNU Public License, Version 3.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.gnu.org/licenses/gpl-3.0.html
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+import numpy as np
+from pedalboard import MP3Compressor
+
+
+@pytest.mark.parametrize("vbr_quality", [0.0, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9.5])
+@pytest.mark.parametrize("sample_rate", [44100, 48000])
+def test_mp3_compressor(vbr_quality: float, sample_rate: int):
+    num_seconds = 10.0
+    fundamental_hz = 440
+    samples = np.arange(num_seconds * sample_rate)
+    sine_wave = np.sin(2 * np.pi * fundamental_hz * samples / sample_rate)
+    stereo_sine_wave = np.stack([sine_wave, sine_wave])
+
+    compressed = MP3Compressor(vbr_quality)(stereo_sine_wave, sample_rate)
+    np.testing.assert_allclose(stereo_sine_wave, compressed, atol=0.25)

--- a/tests/test_mp3_compressor.py
+++ b/tests/test_mp3_compressor.py
@@ -43,7 +43,9 @@ def test_mp3_compressor(vbr_quality: float, sample_rate: int, num_channels: int)
 @pytest.mark.parametrize("vbr_quality", [0.0, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9.5])
 @pytest.mark.parametrize("sample_rate", [44100, 48000])
 @pytest.mark.parametrize("num_channels", [1, 2])
-def test_mp3_compressor_invariant_to_buffer_size(vbr_quality: float, sample_rate: int, num_channels: int):
+def test_mp3_compressor_invariant_to_buffer_size(
+    vbr_quality: float, sample_rate: int, num_channels: int
+):
     num_seconds = 10.0
     fundamental_hz = 440
     samples = np.arange(num_seconds * sample_rate)

--- a/tests/test_mp3_compressor.py
+++ b/tests/test_mp3_compressor.py
@@ -19,34 +19,43 @@ import pytest
 import numpy as np
 from pedalboard import MP3Compressor
 
-
-@pytest.mark.parametrize("vbr_quality", [0.0, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9.5])
-@pytest.mark.parametrize("sample_rate", [44100, 48000])
-def test_mp3_compressor(vbr_quality: float, sample_rate: int):
-    num_seconds = 10.0
-    fundamental_hz = 440
-    samples = np.arange(num_seconds * sample_rate)
-    sine_wave = np.sin(2 * np.pi * fundamental_hz * samples / sample_rate)
-    stereo_sine_wave = np.stack([sine_wave, sine_wave])
-
-    compressed = MP3Compressor(vbr_quality)(stereo_sine_wave, sample_rate)
-    np.testing.assert_allclose(stereo_sine_wave, compressed, atol=0.25)
+# For the range of VBR quality levels supported by LAME,
+# all output samples will match all input samples within
+# this range. Not bad for a 25-year-old codec!
+MP3_ABSOLUTE_TOLERANCE = 0.25
 
 
 @pytest.mark.parametrize("vbr_quality", [0.0, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9.5])
 @pytest.mark.parametrize("sample_rate", [44100, 48000])
-def test_mp3_compressor_invariant_to_buffer_size(vbr_quality: float, sample_rate: int):
+@pytest.mark.parametrize("num_channels", [1, 2])
+def test_mp3_compressor(vbr_quality: float, sample_rate: int, num_channels: int):
     num_seconds = 10.0
     fundamental_hz = 440
     samples = np.arange(num_seconds * sample_rate)
     sine_wave = np.sin(2 * np.pi * fundamental_hz * samples / sample_rate)
-    stereo_sine_wave = np.stack([sine_wave, sine_wave])
+    if num_channels == 2:
+        sine_wave = np.stack([sine_wave, sine_wave])
+
+    compressed = MP3Compressor(vbr_quality)(sine_wave, sample_rate)
+    np.testing.assert_allclose(sine_wave, compressed, atol=MP3_ABSOLUTE_TOLERANCE)
+
+
+@pytest.mark.parametrize("vbr_quality", [0.0, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9.5])
+@pytest.mark.parametrize("sample_rate", [44100, 48000])
+@pytest.mark.parametrize("num_channels", [1, 2])
+def test_mp3_compressor_invariant_to_buffer_size(vbr_quality: float, sample_rate: int, num_channels: int):
+    num_seconds = 10.0
+    fundamental_hz = 440
+    samples = np.arange(num_seconds * sample_rate)
+    sine_wave = np.sin(2 * np.pi * fundamental_hz * samples / sample_rate)
+    if num_channels == 2:
+        sine_wave = np.stack([sine_wave, sine_wave])
 
     compressed_different_buffer_sizes = [
-        MP3Compressor(vbr_quality)(stereo_sine_wave, sample_rate, buffer_size=buffer_size)
+        MP3Compressor(vbr_quality)(sine_wave, sample_rate, buffer_size=buffer_size)
         for buffer_size in (32, 128, 1024, 1152, 8192, 65536)
     ]
 
     # These should all be the same, so any two should be the same:
     for a, b in zip(compressed_different_buffer_sizes, compressed_different_buffer_sizes[:1]):
-        np.testing.assert_allclose(a, b, atol=0.25)
+        np.testing.assert_allclose(a, b, atol=MP3_ABSOLUTE_TOLERANCE)

--- a/tests/test_mp3_compressor.py
+++ b/tests/test_mp3_compressor.py
@@ -25,17 +25,24 @@ from pedalboard import MP3Compressor
 MP3_ABSOLUTE_TOLERANCE = 0.25
 
 
-@pytest.mark.parametrize("vbr_quality", [0.0, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9.5])
-@pytest.mark.parametrize("sample_rate", [44100, 48000])
-@pytest.mark.parametrize("num_channels", [1, 2])
-def test_mp3_compressor(vbr_quality: float, sample_rate: int, num_channels: int):
-    num_seconds = 10.0
-    fundamental_hz = 440
+def generate_sine_at(
+    sample_rate: float,
+    fundamental_hz: float = 440.0,
+    num_seconds: float = 3.0,
+    num_channels: int = 1,
+) -> np.ndarray:
     samples = np.arange(num_seconds * sample_rate)
     sine_wave = np.sin(2 * np.pi * fundamental_hz * samples / sample_rate)
     if num_channels == 2:
         sine_wave = np.stack([sine_wave, sine_wave])
+    return sine_wave
 
+
+@pytest.mark.parametrize("vbr_quality", [0.0, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9.5])
+@pytest.mark.parametrize("sample_rate", [44100, 48000])
+@pytest.mark.parametrize("num_channels", [1, 2])
+def test_mp3_compressor(vbr_quality: float, sample_rate: int, num_channels: int):
+    sine_wave = generate_sine_at(sample_rate, num_channels=num_channels)
     compressed = MP3Compressor(vbr_quality)(sine_wave, sample_rate)
     np.testing.assert_allclose(sine_wave, compressed, atol=MP3_ABSOLUTE_TOLERANCE)
 
@@ -46,18 +53,40 @@ def test_mp3_compressor(vbr_quality: float, sample_rate: int, num_channels: int)
 def test_mp3_compressor_invariant_to_buffer_size(
     vbr_quality: float, sample_rate: int, num_channels: int
 ):
-    num_seconds = 10.0
-    fundamental_hz = 440
-    samples = np.arange(num_seconds * sample_rate)
-    sine_wave = np.sin(2 * np.pi * fundamental_hz * samples / sample_rate)
-    if num_channels == 2:
-        sine_wave = np.stack([sine_wave, sine_wave])
+    sine_wave = generate_sine_at(sample_rate, num_channels=num_channels)
 
     compressed_different_buffer_sizes = [
         MP3Compressor(vbr_quality)(sine_wave, sample_rate, buffer_size=buffer_size)
-        for buffer_size in (32, 128, 1024, 1152, 8192, 65536)
+        for buffer_size in (1, 32, 128, 1024, 1152, 8192, 65536)
     ]
 
     # These should all be the same, so any two should be the same:
     for a, b in zip(compressed_different_buffer_sizes, compressed_different_buffer_sizes[:1]):
         np.testing.assert_allclose(a, b, atol=MP3_ABSOLUTE_TOLERANCE)
+
+
+@pytest.mark.parametrize("vbr_quality", [2])
+@pytest.mark.parametrize(
+    "sample_rate", [48000, 44100, 32000, 24000, 22050, 16000, 12000, 11025, 8000]
+)
+@pytest.mark.parametrize("num_channels", [1, 2])
+@pytest.mark.parametrize("buffer_size", [32, 8192])
+def test_mp3_compressor_arbitrary_sample_rate(
+    vbr_quality: float,
+    sample_rate: int,
+    num_channels: int,
+    buffer_size: int,
+):
+    sine_wave = generate_sine_at(sample_rate, num_channels=num_channels)
+
+    compressed = MP3Compressor(vbr_quality)(sine_wave, sample_rate)
+    np.testing.assert_allclose(sine_wave, compressed, atol=MP3_ABSOLUTE_TOLERANCE)
+
+
+@pytest.mark.parametrize("sample_rate", [96000, 6000, 44101])
+@pytest.mark.parametrize("num_channels", [1, 2])
+def test_mp3_compressor_fails_on_invalid_sample_rate(sample_rate: int, num_channels: int):
+    sine_wave = generate_sine_at(sample_rate, num_channels=num_channels)
+
+    with pytest.raises(ValueError):
+        MP3Compressor(1)(sine_wave, sample_rate)

--- a/vendors/lame_config.h
+++ b/vendors/lame_config.h
@@ -1,0 +1,122 @@
+#include <stdlib.h>
+
+#ifndef CONFIGMS_H_INCLUDED
+#define CONFIGMS_H_INCLUDED
+
+/* The number of bytes in a double.  */
+#define SIZEOF_DOUBLE 8
+
+/* The number of bytes in a float.  */
+#define SIZEOF_FLOAT 4
+
+/* The number of bytes in a int.  */
+#define SIZEOF_INT 4
+
+/* The number of bytes in a long.  */
+#define SIZEOF_LONG 4
+
+/* The number of bytes in a long double.  */
+#define SIZEOF_LONG_DOUBLE 12
+
+/* The number of bytes in a short.  */
+#define SIZEOF_SHORT 2
+
+/* The number of bytes in a unsigned int.  */
+#define SIZEOF_UNSIGNED_INT 4
+
+/* The number of bytes in a unsigned long.  */
+#define SIZEOF_UNSIGNED_LONG 4
+
+/* The number of bytes in a unsigned short.  */
+#define SIZEOF_UNSIGNED_SHORT 2
+
+/* Define if you have the ANSI C header files.  */
+#define STDC_HEADERS
+
+/* Define if you have the <errno.h> header file.  */
+#define HAVE_ERRNO_H
+
+/* Define if you have the <fcntl.h> header file.  */
+#define HAVE_FCNTL_H
+
+/* Define if you have the <limits.h> header file.  */
+#define HAVE_LIMITS_H
+
+/* Name of package */
+#define PACKAGE "lame"
+
+/* Define if compiler has function prototypes */
+#define PROTOTYPES 1
+
+/* faster log implementation with less but enough precission */
+#define USE_FAST_LOG 1
+
+#define HAVE_STRCHR
+#define HAVE_MEMCPY
+
+#if defined(_MSC_VER) || defined(__BORLANDC__)
+#pragma warning( disable : 4305 )
+	typedef __int8  int8_t;
+	typedef __int16 int16_t;
+	typedef __int32 int32_t;
+	typedef __int64 int64_t;
+
+	typedef unsigned __int8  uint8_t;
+	typedef unsigned __int16 uint16_t;
+	typedef unsigned __int32 uint32_t;
+	typedef unsigned __int64 uint64_t;
+
+	typedef float  float32_t;
+	typedef double float64_t;
+#elif defined (__GNUC__)
+#define __int8_t_defined
+
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+
+typedef signed char int8_t;
+typedef signed short int16_t;
+typedef signed int int32_t;
+#endif
+
+typedef long double ieee854_float80_t;
+typedef double      ieee754_float64_t;
+typedef float       ieee754_float32_t;
+
+#ifdef HAVE_MPGLIB
+# define DECODE_ON_THE_FLY 1
+#endif
+
+#ifdef LAME_ACM
+/* memory hacking for driver purposes */
+#define calloc(x,y) acm_Calloc(x,y)
+#define free(x)     acm_Free(x)
+#define malloc(x)   acm_Malloc(x)
+
+#include <stddef.h>
+void *acm_Calloc( size_t num, size_t size );
+void *acm_Malloc( size_t size );
+void acm_Free( void * mem);
+#endif /* LAME_ACM */
+
+#define LAME_LIBRARY_BUILD
+
+
+#ifdef HAVE_NASM
+    #if (defined(__ICL) && (__ICL >= 450))
+        #define HAVE_XMMINTRIN_H
+    #elif defined(_MSC_VER)
+        #include <malloc.h>
+        #ifdef _mm_malloc
+            #define HAVE_XMMINTRIN_H
+        #endif
+    #endif
+#endif
+
+#if defined(_M_X64) && !defined(HAVE_XMMINTRIN_H)
+        #define HAVE_XMMINTRIN_H
+#endif
+
+#endif

--- a/vendors/lame_config.h
+++ b/vendors/lame_config.h
@@ -1,3 +1,4 @@
+#ifndef __cplusplus
 #include <stdlib.h>
 
 #ifndef CONFIGMS_H_INCLUDED
@@ -55,20 +56,20 @@
 #define HAVE_MEMCPY
 
 #if defined(_MSC_VER) || defined(__BORLANDC__)
-#pragma warning( disable : 4305 )
-	typedef __int8  int8_t;
-	typedef __int16 int16_t;
-	typedef __int32 int32_t;
-	typedef __int64 int64_t;
+#pragma warning(disable : 4305)
+typedef __int8 int8_t;
+typedef __int16 int16_t;
+typedef __int32 int32_t;
+typedef __int64 int64_t;
 
-	typedef unsigned __int8  uint8_t;
-	typedef unsigned __int16 uint16_t;
-	typedef unsigned __int32 uint32_t;
-	typedef unsigned __int64 uint64_t;
+typedef unsigned __int8 uint8_t;
+typedef unsigned __int16 uint16_t;
+typedef unsigned __int32 uint32_t;
+typedef unsigned __int64 uint64_t;
 
-	typedef float  float32_t;
-	typedef double float64_t;
-#elif defined (__GNUC__)
+typedef float float32_t;
+typedef double float64_t;
+#elif defined(__GNUC__)
 #define __int8_t_defined
 
 typedef unsigned char uint8_t;
@@ -82,41 +83,29 @@ typedef signed int int32_t;
 #endif
 
 typedef long double ieee854_float80_t;
-typedef double      ieee754_float64_t;
-typedef float       ieee754_float32_t;
+typedef double ieee754_float64_t;
+typedef float ieee754_float32_t;
 
 #ifdef HAVE_MPGLIB
-# define DECODE_ON_THE_FLY 1
+#define DECODE_ON_THE_FLY 1
 #endif
-
-#ifdef LAME_ACM
-/* memory hacking for driver purposes */
-#define calloc(x,y) acm_Calloc(x,y)
-#define free(x)     acm_Free(x)
-#define malloc(x)   acm_Malloc(x)
-
-#include <stddef.h>
-void *acm_Calloc( size_t num, size_t size );
-void *acm_Malloc( size_t size );
-void acm_Free( void * mem);
-#endif /* LAME_ACM */
 
 #define LAME_LIBRARY_BUILD
 
-
 #ifdef HAVE_NASM
-    #if (defined(__ICL) && (__ICL >= 450))
-        #define HAVE_XMMINTRIN_H
-    #elif defined(_MSC_VER)
-        #include <malloc.h>
-        #ifdef _mm_malloc
-            #define HAVE_XMMINTRIN_H
-        #endif
-    #endif
+#if (defined(__ICL) && (__ICL >= 450))
+#define HAVE_XMMINTRIN_H
+#elif defined(_MSC_VER)
+#include <malloc.h>
+#ifdef _mm_malloc
+#define HAVE_XMMINTRIN_H
+#endif
+#endif
 #endif
 
 #if defined(_M_X64) && !defined(HAVE_XMMINTRIN_H)
-        #define HAVE_XMMINTRIN_H
+#define HAVE_XMMINTRIN_H
 #endif
 
+#endif
 #endif


### PR DESCRIPTION
This PR adds `MP3Compressor`, a basic wrapper around [LAME](https://lame.sourceforge.io/), the "canonical" open-source, GPL-compatible MP3 compressor that's been around for ~24 years. This plugin compresses and then decompresses the audio stream with LAME.

(Note that the resulting output from Pedalboard is still in the same uncompressed format; this plugin is intended to apply the _sound_ of compression, rather than returning an output that is itself in a compressed format.)

This is still a draft PR as there are a couple things remaining to clean up:
 - `setup.py` has been refactored, and the changes added (to support building the LAME C code) have not yet been tested on Windows
 -  Mono audio is not yet supported (or rather, not tested)
 - Tests are failing for `-V0` and `-V0.5` compression levels (the highest possible)
 - Arbitrary sample rates have not been tested, and will likely throw exceptions (but these should be listed in the tests)