### PR TITLE
Prevent memory leaks if invalid parameters are passed to plugin constructors.

### DIFF
--- a/pedalboard/plugins/AddLatency.h
+++ b/pedalboard/plugins/AddLatency.h
@@ -57,7 +57,7 @@ inline void init_add_latency(py::module &m) {
       "Pedalboard's automatic latency compensation. Probably not useful as a "
       "real effect.")
       .def(py::init([](int samples) {
-             auto al = new AddLatency();
+             auto al = std::make_unique<AddLatency>();
              al->getDSP().setMaximumDelayInSamples(samples);
              al->getDSP().setDelay(samples);
              return al;

--- a/pedalboard/plugins/Chorus.h
+++ b/pedalboard/plugins/Chorus.h
@@ -49,7 +49,7 @@ inline void init_chorus(py::module &m) {
       "lot of feedback, and as a vibrato effect if the mix value is 1.")
       .def(py::init([](float rateHz, float depth, float centreDelayMs,
                        float feedback, float mix) {
-             auto plugin = new Chorus<float>();
+             auto plugin = std::make_unique<Chorus<float>>();
              plugin->setRate(rateHz);
              plugin->setDepth(depth);
              plugin->setCentreDelay(centreDelayMs);

--- a/pedalboard/plugins/Compressor.h
+++ b/pedalboard/plugins/Compressor.h
@@ -42,7 +42,7 @@ inline void init_compressor(py::module &m) {
       "volume of loud sounds.")
       .def(py::init([](float thresholddB, float ratio, float attackMs,
                        float releaseMs) {
-             auto plugin = new Compressor<float>();
+             auto plugin = std::make_unique<Compressor<float>>();
              plugin->setThreshold(thresholddB);
              plugin->setRatio(ratio);
              plugin->setAttack(attackMs);

--- a/pedalboard/plugins/Delay.h
+++ b/pedalboard/plugins/Delay.h
@@ -105,7 +105,7 @@ inline void init_delay(py::module &m) {
       "A digital delay plugin with controllable delay time, feedback "
       "percentage, and dry/wet mix.")
       .def(py::init([](float delaySeconds, float feedback, float mix) {
-             auto delay = new Delay<float>();
+             auto delay = std::make_unique<Delay<float>>();
              delay->setDelaySeconds(delaySeconds);
              delay->setFeedback(feedback);
              delay->setMix(mix);

--- a/pedalboard/plugins/Distortion.h
+++ b/pedalboard/plugins/Distortion.h
@@ -51,7 +51,7 @@ inline void init_distortion(py::module &m) {
   py::class_<Distortion<float>, Plugin>(
       m, "Distortion", "Apply soft distortion with a tanh waveshaper.")
       .def(py::init([](float drive_db) {
-             auto plugin = new Distortion<float>();
+             auto plugin = std::make_unique<Distortion<float>>();
              plugin->setDriveDecibels(drive_db);
              return plugin;
            }),

--- a/pedalboard/plugins/Gain.h
+++ b/pedalboard/plugins/Gain.h
@@ -34,7 +34,7 @@ inline void init_gain(py::module &m) {
       "Increase or decrease the volume of a signal by applying a gain value "
       "(in decibels). No distortion or other effects are applied.")
       .def(py::init([](float gaindB) {
-             auto plugin = new Gain<float>();
+             auto plugin = std::make_unique<Gain<float>>();
              plugin->setGainDecibels(gaindB);
              return plugin;
            }),

--- a/pedalboard/plugins/HighpassFilter.h
+++ b/pedalboard/plugins/HighpassFilter.h
@@ -47,7 +47,7 @@ inline void init_highpass(py::module &m) {
       "The cutoff frequency will be attenuated by -3dB (i.e.: 0.707x as "
       "loud).")
       .def(py::init([](float cutoff_frequency_hz) {
-             auto plugin = new HighpassFilter<float>();
+             auto plugin = std::make_unique<HighpassFilter<float>>();
              plugin->setCutoffFrequencyHz(cutoff_frequency_hz);
              return plugin;
            }),

--- a/pedalboard/plugins/Invert.h
+++ b/pedalboard/plugins/Invert.h
@@ -37,7 +37,7 @@ inline void init_invert(py::module &m) {
   py::class_<Invert<float>, Plugin>(
       m, "Invert",
       "Flip the polarity of the signal. This effect is not audible on its own.")
-      .def(py::init([]() { return new Invert<float>(); }))
+      .def(py::init([]() { return std::make_unique<Invert<float>>(); }))
       .def("__repr__", [](const Invert<float> &plugin) {
         std::ostringstream ss;
         ss << "<pedalboard.Invert";

--- a/pedalboard/plugins/LadderFilter.h
+++ b/pedalboard/plugins/LadderFilter.h
@@ -81,7 +81,7 @@ inline void init_ladderfilter(py::module &m) {
   ladderFilter
       .def(py::init([](juce::dsp::LadderFilterMode mode, float cutoffHz,
                        float resonance, float drive) {
-             auto plugin = new LadderFilter<float>();
+             auto plugin = std::make_unique<LadderFilter<float>>();
              plugin->setMode(mode);
              plugin->setCutoffFrequencyHz(cutoffHz);
              plugin->setResonance(resonance);

--- a/pedalboard/plugins/Limiter.h
+++ b/pedalboard/plugins/Limiter.h
@@ -35,7 +35,7 @@ inline void init_limiter(py::module &m) {
       "A simple limiter with standard threshold and release time controls, "
       "featuring two compressors and a hard clipper at 0 dB.")
       .def(py::init([](float thresholdDb, float releaseMs) {
-             auto plugin = new Limiter<float>();
+             auto plugin = std::make_unique<Limiter<float>>();
              plugin->setThreshold(thresholdDb);
              plugin->setRelease(releaseMs);
              return plugin;

--- a/pedalboard/plugins/LowpassFilter.h
+++ b/pedalboard/plugins/LowpassFilter.h
@@ -47,7 +47,7 @@ inline void init_lowpass(py::module &m) {
       "The cutoff frequency will be attenuated by -3dB (i.e.: 0.707x as "
       "loud).")
       .def(py::init([](float cutoff_frequency_hz) {
-             auto plugin = new LowpassFilter<float>();
+             auto plugin = std::make_unique<LowpassFilter<float>>();
              plugin->setCutoffFrequencyHz(cutoff_frequency_hz);
              return plugin;
            }),

--- a/pedalboard/plugins/MP3Compressor.h
+++ b/pedalboard/plugins/MP3Compressor.h
@@ -364,7 +364,7 @@ inline void init_mp3_compressor(py::module &m) {
       m, "MP3Compressor",
       "Apply an MP3 compressor to the audio to reduce its quality.")
       .def(py::init([](float vbr_quality) {
-             auto plugin = new MP3Compressor();
+             auto plugin = std::make_unique<MP3Compressor>();
              plugin->setVBRQuality(vbr_quality);
              return plugin;
            }),

--- a/pedalboard/plugins/NoiseGate.h
+++ b/pedalboard/plugins/NoiseGate.h
@@ -39,7 +39,7 @@ inline void init_noisegate(py::module &m) {
       "release time controls. Can be used as an expander if the ratio is low.")
       .def(py::init([](float thresholddB, float ratio, float attackMs,
                        float releaseMs) {
-             auto plugin = new NoiseGate<float>();
+             auto plugin = std::make_unique<NoiseGate<float>>();
              plugin->getDSP().setThreshold(thresholddB);
              plugin->getDSP().setRatio(ratio);
              plugin->getDSP().setAttack(attackMs);

--- a/pedalboard/plugins/Phaser.h
+++ b/pedalboard/plugins/Phaser.h
@@ -43,7 +43,7 @@ inline void init_phaser(py::module &m) {
       "feedback control, and the centre frequency of the modulation.")
       .def(py::init([](float rateHz, float depth, float centreFrequency,
                        float feedback, float mix) {
-             auto plugin = new Phaser<float>();
+             auto plugin = std::make_unique<Phaser<float>>();
              plugin->setRate(rateHz);
              plugin->setDepth(depth);
              plugin->setCentreFrequency(centreFrequency);

--- a/pedalboard/plugins/PitchShift.h
+++ b/pedalboard/plugins/PitchShift.h
@@ -64,7 +64,7 @@ inline void init_pitch_shift(py::module &m) {
   py::class_<PitchShift, Plugin>(
       m, "PitchShift", "Shift pitch without affecting audio duration.")
       .def(py::init([](double scale) {
-             auto plugin = new PitchShift();
+             auto plugin = std::make_unique<PitchShift>();
              plugin->setSemitones(scale);
              return plugin;
            }),

--- a/pedalboard/plugins/Reverb.h
+++ b/pedalboard/plugins/Reverb.h
@@ -84,7 +84,7 @@ inline void init_reverb(py::module &m) {
       "FreeVerb.")
       .def(py::init([](float roomSize, float damping, float wetLevel,
                        float dryLevel, float width, float freezeMode) {
-             auto plugin = new Reverb();
+             auto plugin = std::make_unique<Reverb>();
              plugin->setRoomSize(roomSize);
              plugin->setDamping(damping);
              plugin->setWetLevel(wetLevel);


### PR DESCRIPTION
Using `new` in the Python bindings for `Plugin` instances causes each plugin instance to be leaked if an exception is thrown by any of the `set` methods in the `py::init`. This PR replaces all of those `new` calls with `std::make_unique`.