### PR TITLE
Updated Quick Start section from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ audio, sample_rate = sf.read('some-file.wav')
 board = Pedalboard([Chorus(), Reverb(room_size=0.25)])
 
 # Run the audio through this pedalboard!
-effected = board(audio, s)
+effected = board(audio, sample_rate)
 
 # Write the audio back as a wav file:
 sf.write('./processed-output.wav', effected, sample_rate)


### PR DESCRIPTION
In the first example of Quick Start in README.md, "s" was replaced with "sample_rate".