### PR TITLE
Add experimental support for showing plugin UIs.

### DIFF
--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -762,6 +762,11 @@ public:
           "Pedalboard error and should be reported.");
     }
 
+    if (!juce::Desktop::getInstance().getDisplays().getPrimaryDisplay()) {
+      throw std::runtime_error(
+          "Editor cannot be shown - no visual display devices available.");
+    }
+
     if (!juce::MessageManager::getInstance()->isThisTheMessageThread()) {
       throw std::runtime_error(
           "Plugin UI windows can only be shown from the main thread.");

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -110,10 +110,6 @@ private:
 };
 #endif
 
-//==============================================================================
-/**
-    A desktop window containing a plugin's GUI.
-*/
 class StandalonePluginWindow : public juce::DocumentWindow {
 public:
   StandalonePluginWindow(juce::AudioProcessor &processor)
@@ -121,7 +117,8 @@ public:
                        juce::LookAndFeel::getDefaultLookAndFeel().findColour(
                            juce::ResizableWindow::backgroundColourId),
                        juce::DocumentWindow::minimiseButton |
-                           juce::DocumentWindow::closeButton), processor(processor) {
+                           juce::DocumentWindow::closeButton),
+        processor(processor) {
     setUsingNativeTitleBar(true);
 
     if (processor.hasEditor()) {
@@ -177,13 +174,9 @@ public:
     }
   }
 
-  void closeButtonPressed() override {
-    setVisible(false);
-  }
+  void closeButtonPressed() override { setVisible(false); }
 
-  ~StandalonePluginWindow() override {
-    clearContentComponent();
-  }
+  ~StandalonePluginWindow() override { clearContentComponent(); }
 
   void show() {
     setVisible(true);
@@ -770,7 +763,8 @@ public:
     }
 
     if (!juce::MessageManager::getInstance()->isThisTheMessageThread()) {
-      throw std::runtime_error("Plugin UI windows can only be shown from the main thread.");
+      throw std::runtime_error(
+          "Plugin UI windows can only be shown from the main thread.");
     }
 
     StandalonePluginWindow::openWindowAndWait(*pluginInstance);
@@ -936,12 +930,10 @@ inline void init_external_plugins(py::module &m) {
       .def("_get_parameter",
            &ExternalPlugin<juce::VST3PluginFormat>::getParameter,
            py::return_value_policy::reference_internal)
-      .def(
-          "show_editor",
-          &ExternalPlugin<juce::VST3PluginFormat>::showEditor,
-          "Show the UI of this plugin as a native window. This method will "
-          "block until the window is closed or a KeyboardInterrupt is "
-          "received.");
+      .def("show_editor", &ExternalPlugin<juce::VST3PluginFormat>::showEditor,
+           "Show the UI of this plugin as a native window. This method will "
+           "block until the window is closed or a KeyboardInterrupt is "
+           "received.");
 #endif
 
 #if JUCE_PLUGINHOST_AU && JUCE_MAC
@@ -981,12 +973,11 @@ inline void init_external_plugins(py::module &m) {
       .def("_get_parameter",
            &ExternalPlugin<juce::AudioUnitPluginFormat>::getParameter,
            py::return_value_policy::reference_internal)
-      .def(
-          "show_editor",
-          &ExternalPlugin<juce::AudioUnitPluginFormat>::showEditor,
-          "Show the UI of this plugin as a native window. This method will "
-          "block until the window is closed or a KeyboardInterrupt is "
-          "received.");
+      .def("show_editor",
+           &ExternalPlugin<juce::AudioUnitPluginFormat>::showEditor,
+           "Show the UI of this plugin as a native window. This method will "
+           "block until the window is closed or a KeyboardInterrupt is "
+           "received.");
 #endif
 }
 

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ ALL_CPPFLAGS.extend(
         "-DJUCE_WEB_BROWSER=0",
         "-DJUCE_USE_CURL=0",
         # "-DJUCE_USE_FREETYPE=0",
+        "-DJUCE_MODAL_LOOPS_PERMITTED=1",
     ]
 )
 ALL_INCLUDES.extend(['JUCE/modules/', 'JUCE/modules/juce_audio_processors/format_types/VST3_SDK/'])

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,3 +14,4 @@ sox
 tensorflow~=2.6.2; python_version < '3.10' and platform.machine != 'arm64'
 google-cloud-storage
 tqdm
+psutil

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -657,15 +657,21 @@ def test_show_editor(plugin_filename: str):
     # Run this test in a subprocess, as otherwise we'd block this thread:
     full_plugin_filename = os.path.join(TEST_PLUGIN_BASE_PATH, platform.system(), plugin_filename)
     try:
-        subprocess.check_call(
+        subprocess.check_output(
             [
                 psutil.Process(os.getpid()).exe(),
                 "-c",
                 "import pedalboard;"
-                f" pedalboard.load_plugin(\"{full_plugin_filename}\").show_editor()",
+                f'pedalboard.load_plugin(r"{full_plugin_filename}").show_editor();',
             ],
             timeout=5,
+            stderr=subprocess.STDOUT,
         )
+    except subprocess.CalledProcessError as e:
+        if b"no visual display devices available" in e.output:
+            pass
+        else:
+            raise
     except subprocess.TimeoutExpired:
         # This is good: the UI was shown, no issues.
         pass


### PR DESCRIPTION
Closes #8.

This PR adds a `show_editor()` method on both `VST3Plugin` and `AudioUnitPlugin`, which launches the plugin's GUI (if it has one) in a native window. This has been tested on macOS so far, but not on Windows or Linux; it will likely not work, throw an exception, or crash in headless environments (i.e.: remote Jupyter notebooks, Docker containers without window managers, etc).