### PR TITLE
Add support for loading plugin containers (i.e.: Waves, Native Instruments, etc)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "JUCE"]
 	path = JUCE
-	url = https://github.com/juce-framework/JUCE.git
+	url = https://github.com/psobot/JUCE.git
 [submodule "vendors/rubberband"]
 	path = vendors/rubberband
 	url = https://github.com/BreakfastQuay/Rubberband.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "JUCE"]
 	path = JUCE
-	url = https://github.com/psobot/JUCE.git
+	url = https://github.com/juce-framework/JUCE.git
 [submodule "vendors/rubberband"]
 	path = vendors/rubberband
 	url = https://github.com/BreakfastQuay/Rubberband.git

--- a/pedalboard/AudioUnitParser.h
+++ b/pedalboard/AudioUnitParser.h
@@ -1,0 +1,33 @@
+/*
+ * pedalboard
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the GNU Public License, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <mutex>
+#include <optional>
+
+#include "JuceHeader.h"
+
+#if JUCE_MAC
+
+namespace Pedalboard {
+// This uses Objective-C++ code, so its implementation can't be defined inline:
+std::vector<std::string>
+getAudioUnitIdentifiersFromFile(const juce::String &filename);
+} // namespace Pedalboard
+
+#endif

--- a/pedalboard/AudioUnitParser.mm
+++ b/pedalboard/AudioUnitParser.mm
@@ -1,0 +1,108 @@
+/*
+ * pedalboard
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the GNU Public License, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "AudioUnitParser.h"
+
+#if JUCE_MAC
+#include <AudioToolbox/AudioUnitUtilities.h>
+
+namespace Pedalboard {
+
+static OSType stringToOSType(juce::String s) {
+  if (s.trim().length() >= 4) // (to avoid trimming leading spaces)
+    s = s.trim();
+
+  s += "    ";
+
+  return (((OSType)(unsigned char)s[0]) << 24) |
+         (((OSType)(unsigned char)s[1]) << 16) |
+         (((OSType)(unsigned char)s[2]) << 8) | ((OSType)(unsigned char)s[3]);
+}
+
+static juce::String osTypeToString(OSType type) noexcept {
+  const juce::juce_wchar s[4] = {(juce::juce_wchar)((type >> 24) & 0xff),
+                                 (juce::juce_wchar)((type >> 16) & 0xff),
+                                 (juce::juce_wchar)((type >> 8) & 0xff),
+                                 (juce::juce_wchar)(type & 0xff)};
+  return juce::String(s, 4);
+}
+
+const char *AU_IDENTIFIER_PREFIX = "AudioUnit:";
+
+static juce::String
+createPluginIdentifier(const AudioComponentDescription &desc) {
+  juce::String s(AU_IDENTIFIER_PREFIX);
+
+  if (desc.componentType == kAudioUnitType_MusicDevice)
+    s << "Synths/";
+  else if (desc.componentType == kAudioUnitType_MusicEffect ||
+           desc.componentType == kAudioUnitType_Effect)
+    s << "Effects/";
+  else if (desc.componentType == kAudioUnitType_Generator)
+    s << "Generators/";
+  else if (desc.componentType == kAudioUnitType_Panner)
+    s << "Panners/";
+  else if (desc.componentType == kAudioUnitType_Mixer)
+    s << "Mixers/";
+  else if (desc.componentType == kAudioUnitType_MIDIProcessor)
+    s << "MidiEffects/";
+
+  s << osTypeToString(desc.componentType) << ","
+    << osTypeToString(desc.componentSubType) << ","
+    << osTypeToString(desc.componentManufacturer);
+
+  return s;
+}
+
+inline juce::String nsStringToJuce(NSString *s) {
+  return juce::CharPointer_UTF8([s UTF8String]);
+}
+
+std::vector<std::string>
+getAudioUnitIdentifiersFromFile(const juce::String &filename) {
+  std::vector<std::string> identifiers;
+
+  const juce::File file(filename);
+  if (!file.hasFileExtension(".component") &&
+      !file.hasFileExtension(".appex")) {
+    return identifiers;
+  }
+
+  // Use NSBundle to open and extract identifiers:
+  NSBundle *bundle =
+      [[NSBundle alloc] initWithPath:(NSString *)filename.toCFString()];
+
+  NSArray *audioComponents =
+      [bundle objectForInfoDictionaryKey:@"AudioComponents"];
+  for (NSDictionary *component in audioComponents) {
+    AudioComponentDescription desc;
+    desc.componentManufacturer = stringToOSType(
+        nsStringToJuce((NSString *)[component valueForKey:@"manufacturer"]));
+    desc.componentType = stringToOSType(
+        nsStringToJuce((NSString *)[component valueForKey:@"type"]));
+    desc.componentSubType = stringToOSType(
+        nsStringToJuce((NSString *)[component valueForKey:@"subtype"]));
+    identifiers.push_back(createPluginIdentifier(desc).toStdString());
+  }
+
+  [bundle release];
+
+  return identifiers;
+}
+
+}
+#endif

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -134,6 +134,7 @@ static std::vector<std::string> getPluginNamesForFile(std::string filename) {
   std::string errorMessage = "Unable to scan plugin " + filename +
                              ": unsupported plugin format or scan failure.";
 
+#if JUCE_PLUGINHOST_AU && JUCE_MAC
   if constexpr (std::is_same<ExternalPluginType,
                              juce::AudioUnitPluginFormat>::value) {
     auto identifiers = getAudioUnitIdentifiersFromFile(filename);
@@ -148,6 +149,9 @@ static std::vector<std::string> getPluginNamesForFile(std::string filename) {
   } else {
     format.findAllTypesForFile(typesFound, filename);
   }
+#else
+  format.findAllTypesForFile(typesFound, filename);
+#endif
 
   if (typesFound.isEmpty()) {
     throw pybind11::import_error(errorMessage);
@@ -289,6 +293,7 @@ public:
                                    ": plugin file not found.");
     }
 
+#if JUCE_PLUGINHOST_AU && JUCE_MAC
     if constexpr (std::is_same<ExternalPluginType,
                                juce::AudioUnitPluginFormat>::value) {
       auto identifiers = getAudioUnitIdentifiersFromFile(pluginFileStripped);
@@ -299,6 +304,9 @@ public:
     } else {
       format.findAllTypesForFile(typesFound, pluginFileStripped);
     }
+#else
+    format.findAllTypesForFile(typesFound, pluginFileStripped);
+#endif
 
     if (!typesFound.isEmpty()) {
       if (typesFound.size() == 1) {

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -375,7 +375,7 @@ public:
                       "missing. (Try running `ldd \"" +
                       pathToSharedObjectFile.getFullPathName().toStdString() +
                       "\"` to see which dependencies might be missing.).";
-#else
+#elif JUCE_PLUGINHOST_AU && JUCE_MAC
       if constexpr (std::is_same<ExternalPluginType,
                                  juce::AudioUnitPluginFormat>::value) {
         if (!audioUnitIsInstalled(pathToPluginFile)) {

--- a/pedalboard/pedalboard.py
+++ b/pedalboard/pedalboard.py
@@ -525,8 +525,15 @@ try:
             self,
             path_to_plugin_file: str,
             parameter_values: Dict[str, Union[str, int, float, bool]] = {},
+            plugin_name: Optional[str] = None,
         ):
-            super().__init__(path_to_plugin_file)
+            if not isinstance(parameter_values, dict):
+                raise TypeError(
+                    "Expected a dictionary to be passed to parameter_values, but received a"
+                    f" {type(parameter_values).__name__}. (If passing a plugin name, pass"
+                    " \"plugin_name=...\" as a keyword argument instead.)"
+                )
+            super().__init__(path_to_plugin_file, plugin_name)
             self.__set_initial_parameter_values__(parameter_values)
 
 
@@ -542,8 +549,15 @@ try:
             self,
             path_to_plugin_file: str,
             parameter_values: Dict[str, Union[str, int, float, bool]] = {},
+            plugin_name: Optional[str] = None,
         ):
-            super().__init__(path_to_plugin_file)
+            if not isinstance(parameter_values, dict):
+                raise TypeError(
+                    "Expected a dictionary to be passed to parameter_values, but received a"
+                    f" {type(parameter_values).__name__}. (If passing a plugin name, pass"
+                    " \"plugin_name=...\" as a keyword argument instead.)"
+                )
+            super().__init__(path_to_plugin_file, plugin_name)
             self.__set_initial_parameter_values__(parameter_values)
 
 

--- a/setup.py
+++ b/setup.py
@@ -188,6 +188,8 @@ if platform.system() == "Darwin":
         )
         if matching_cpp_source:
             ALL_SOURCE_PATHS[ALL_SOURCE_PATHS.index(matching_cpp_source)] = objc_source
+        else:
+            ALL_SOURCE_PATHS.append(objc_source)
     ALL_RESOLVED_SOURCE_PATHS = [str(p.resolve()) for p in ALL_SOURCE_PATHS]
 elif platform.system() == "Linux":
     for package in ['freetype2']:

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -674,7 +674,7 @@ def test_show_editor(plugin_filename: str):
                 psutil.Process(os.getpid()).exe(),
                 "-c",
                 "import pedalboard;"
-                f"pedalboard.load_plugin(r\"{full_plugin_filename}\").show_editor();",
+                f'pedalboard.load_plugin(r"{full_plugin_filename}").show_editor();',
             ],
             timeout=5,
             stderr=subprocess.STDOUT,


### PR DESCRIPTION
Fixes #16 and #86, adding support for [Waves](https://www.waves.com/) plugins to Pedalboard.

This PR adds a new keyword argument to `pedalboard.load_plugin`, `pedalboard.VST3Plugin`, and `pedalboard.AudioUnitPlugin`: `plugin_name`, which can be used to choose which plugin to load from a plugin _container_ (i.e.: a VST or AU that contains multiple plugins).