### PR TITLE
Add PythonPlugin wrapper experiment to allow implementing Pedalboard plugins in Python.

### DIFF
--- a/pedalboard/BufferUtils.h
+++ b/pedalboard/BufferUtils.h
@@ -64,8 +64,17 @@ copyPyArrayIntoJuceBuffer(const py::array_t<T, py::array::c_style> inputArray) {
     numSamples = inputInfo.shape[0];
     numChannels = 1;
   } else if (inputInfo.ndim == 2) {
-    // Try to auto-detect the channel layout from the shape
-    if (inputInfo.shape[1] < inputInfo.shape[0]) {
+    // Try to auto-detect the channel layout from the shape.
+    // Assume that if one dimension is 0 but the other is not, the 0 dimension
+    // must be the number of samples (as it's meaningless to provide <n> samples
+    // of 0-channel audio).
+    if (inputInfo.shape[0] == 0 && inputInfo.shape[1] != 0) {
+      numSamples = inputInfo.shape[0];
+      numChannels = inputInfo.shape[1];
+    } else if (inputInfo.shape[0] != 0 && inputInfo.shape[1] == 0) {
+      numSamples = inputInfo.shape[1];
+      numChannels = inputInfo.shape[0];
+    } else if (inputInfo.shape[1] < inputInfo.shape[0]) {
       numSamples = inputInfo.shape[0];
       numChannels = inputInfo.shape[1];
     } else if (inputInfo.shape[0] < inputInfo.shape[1]) {

--- a/pedalboard/PythonPlugin.h
+++ b/pedalboard/PythonPlugin.h
@@ -1,0 +1,218 @@
+/*
+ * pedalboard
+ * Copyright 2022 Spotify AB
+ *
+ * Licensed under the GNU Public License, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "BufferUtils.h"
+#include "JuceHeader.h"
+#include "Plugin.h"
+
+using namespace pybind11::literals;
+
+namespace Pedalboard {
+/**
+ * A C++ class that wraps a Python object with three methods:
+ *  - prepare(sample_rate: float, num_channels: int, maximum_block_size: int)
+ *  - process(np.ndarray[np.float32]) -> np.ndarray[np.float32]
+ *  - reset()
+ */
+class PythonPlugin : public Plugin {
+public:
+  PythonPlugin(py::object pythonPluginLike)
+      : pythonPluginLike(pythonPluginLike) {
+    if (!py::hasattr(pythonPluginLike, "process") &&
+        !py::hasattr(pythonPluginLike, "__call__")) {
+      throw py::type_error(
+          "Expected Python plugin-like object to be either a callable (i.e.: a "
+          "function or lambda) or to be an object with a process method (and "
+          "optional prepare and reset methods).");
+    }
+  }
+
+  virtual ~PythonPlugin(){};
+
+  void prepare(const juce::dsp::ProcessSpec &spec) override {
+    if (lastSpec.sampleRate != spec.sampleRate ||
+        lastSpec.maximumBlockSize < spec.maximumBlockSize ||
+        spec.numChannels != lastSpec.numChannels) {
+
+      py::gil_scoped_acquire gil;
+      try {
+        if (py::hasattr(pythonPluginLike, "prepare")) {
+          pythonPluginLike.attr("prepare")("sample_rate"_a = spec.sampleRate,
+                                           "num_channels"_a = spec.numChannels,
+                                           "maximum_block_size"_a =
+                                               spec.maximumBlockSize);
+        }
+      } catch (py::error_already_set &e) {
+        py::raise_from(e, PyExc_RuntimeError,
+                       ("PythonPlugin failed to call \"prepare\" method on " +
+                        py::repr(pythonPluginLike).cast<std::string>())
+                           .c_str());
+        throw py::error_already_set();
+      }
+
+      lastSpec = spec;
+    }
+  }
+
+  int process(
+      const juce::dsp::ProcessContextReplacing<float> &context) override {
+    auto outputBlock = context.getOutputBlock();
+    juce::AudioBuffer<float> bufferFromPython;
+
+    {
+      py::gil_scoped_acquire acquire;
+
+      py::object callable = pythonPluginLike;
+      if (py::hasattr(pythonPluginLike, "process")) {
+        callable = pythonPluginLike.attr("process");
+      }
+
+      const float **channels = (const float **)alloca(
+          outputBlock.getNumChannels() * sizeof(float *));
+
+      for (int c = 0; c < outputBlock.getNumChannels(); c++) {
+        channels[c] = outputBlock.getChannelPointer(c);
+      }
+
+      juce::AudioBuffer<float> bufferForPython((float *const *)channels,
+                                               outputBlock.getNumChannels(),
+                                               outputBlock.getNumSamples());
+      py::array_t<float> arrayForPython = copyJuceBufferIntoPyArray<float>(
+          bufferForPython, ChannelLayout::NotInterleaved, 0);
+
+      py::array_t<float> response;
+      try {
+        response = callable(arrayForPython).cast<py::array_t<float>>();
+      } catch (py::error_already_set &e) {
+        if (py::hasattr(pythonPluginLike, "process")) {
+          py::raise_from(
+              e, PyExc_RuntimeError,
+              ("PythonPlugin failed to call the \"process\" method of " +
+               py::repr(pythonPluginLike).cast<std::string>())
+                  .c_str());
+        } else {
+          py::raise_from(e, PyExc_RuntimeError,
+                         ("PythonPlugin failed to call " +
+                          py::repr(pythonPluginLike).cast<std::string>())
+                             .c_str());
+        }
+
+        throw py::error_already_set();
+      }
+
+      // TODO: We could avoid a copy here by changing BufferUtils to support an
+      // existing AudioBlock to copy into, but that's an overhaul for another
+      // day.
+      try {
+        bufferFromPython = copyPyArrayIntoJuceBuffer<float>(response);
+      } catch (std::runtime_error &e) {
+        std::throw_with_nested(std::runtime_error(
+            "PythonPlugin expected a buffer with zero or more samples of " +
+            std::to_string(outputBlock.getNumChannels()) +
+            "-channel audio, but was unable to interpret the audio data "
+            "returned by " +
+            py::repr(pythonPluginLike).cast<std::string>()));
+      }
+
+      if (bufferFromPython.getNumSamples() > outputBlock.getNumSamples()) {
+        throw std::domain_error(
+            "PythonPlugin wrapping " +
+            py::repr(pythonPluginLike).cast<std::string>() +
+            " returned more samples than provided, which is not supported by "
+            "Pedalboard. (Provided " +
+            std::to_string(outputBlock.getNumSamples()) + " samples of " +
+            std::to_string(outputBlock.getNumChannels()) +
+            "-channel audio, but got back " +
+            std::to_string(bufferFromPython.getNumSamples()) + " samples of " +
+            std::to_string(bufferFromPython.getNumChannels()) +
+            "-channel audio.)");
+      }
+
+      if (bufferFromPython.getNumChannels() != outputBlock.getNumChannels()) {
+        throw std::domain_error(
+            "PythonPlugin wrapping " +
+            py::repr(pythonPluginLike).cast<std::string>() +
+            " returned a different number of channels than provided, which is "
+            "not supported by "
+            "Pedalboard. (Provided " +
+            std::to_string(outputBlock.getNumSamples()) + " samples of " +
+            std::to_string(outputBlock.getNumChannels()) +
+            "-channel audio, but got back " +
+            std::to_string(bufferFromPython.getNumSamples()) + " samples of " +
+            std::to_string(bufferFromPython.getNumChannels()) +
+            "-channel audio.)");
+      }
+    }
+
+    outputBlock.copyFrom(bufferFromPython, 0,
+                         outputBlock.getNumSamples() -
+                             bufferFromPython.getNumSamples(),
+                         bufferFromPython.getNumSamples());
+    return bufferFromPython.getNumSamples();
+  }
+
+  void reset() override {
+    py::gil_scoped_acquire gil;
+    if (py::hasattr(pythonPluginLike, "reset")) {
+      try {
+        pythonPluginLike.attr("reset")();
+      } catch (py::error_already_set &e) {
+        py::raise_from(e, PyExc_RuntimeError,
+                       ("PythonPlugin failed to call \"reset\" method on " +
+                        py::repr(pythonPluginLike).cast<std::string>())
+                           .c_str());
+        throw py::error_already_set();
+      }
+    }
+  }
+
+  py::object getPythonObject() { return pythonPluginLike; }
+
+private:
+  py::object pythonPluginLike;
+};
+
+inline void init_python_plugin(py::module &m) {
+  py::class_<PythonPlugin, Plugin, std::shared_ptr<PythonPlugin>>(
+      m, "PythonPlugin",
+      "A wrapper around a Python object to be called as an audio plugin. "
+      "The provided object must either be a callable (i.e.: a function or "
+      "lambda) or an object with a process(numpy.ndarray[np.float32]) "
+      "method. If the provided object has prepare(sample_rate: float, "
+      "num_channels: int, maximum_block_size: int) and reset() methods, "
+      "these will be called during processing.")
+      .def(py::init([](py::object wrapped) {
+             return std::make_unique<PythonPlugin>(wrapped);
+           }),
+           py::arg("wrapped"))
+      .def("__repr__",
+           [](PythonPlugin &plugin) {
+             std::ostringstream ss;
+             ss << "<pedalboard.PythonPlugin";
+             ss << " wrapped="
+                << py::repr(plugin.getPythonObject()).cast<std::string>();
+             ss << " at " << &plugin;
+             ss << ">";
+             return ss.str();
+           })
+      .def_property_readonly("wrapped", &PythonPlugin::getPythonObject,
+                             "The Python object wrapped by this plugin.");
+}
+
+} // namespace Pedalboard

--- a/pedalboard/python_bindings.cpp
+++ b/pedalboard/python_bindings.cpp
@@ -31,6 +31,7 @@ namespace py = pybind11;
 #include "JucePlugin.h"
 #include "Plugin.h"
 #include "PluginContainer.h"
+#include "PythonPlugin.h"
 #include "process.h"
 
 #include "plugin_templates/FixedBlockSize.h"
@@ -177,6 +178,7 @@ PYBIND11_MODULE(pedalboard_native, m) {
   init_reverb(m);
 
   init_external_plugins(m);
+  init_python_plugin(m);
 
   // Plugins that don't perform any audio effects, but that add other utilities:
   py::module utils = m.def_submodule("utils");

--- a/tests/test_python_plugin.py
+++ b/tests/test_python_plugin.py
@@ -1,0 +1,147 @@
+#! /usr/bin/env python
+#
+# Copyright 2021 Spotify AB
+#
+# Licensed under the GNU Public License, Version 3.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.gnu.org/licenses/gpl-3.0.html
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+import numpy as np
+from pedalboard import PythonPlugin
+from .utils import generate_sine_at
+
+
+@pytest.mark.parametrize("sample_rate", [22050, 44100, 48000])
+def test_python_plugin(sample_rate: float):
+    sine = generate_sine_at(sample_rate).astype(np.float32)
+    plugin = PythonPlugin(np.sqrt)
+    np.testing.assert_allclose(np.sqrt(sine), plugin(sine, sample_rate))
+
+
+@pytest.mark.parametrize("power", [1, 2, 3])
+@pytest.mark.parametrize("sample_rate", [22050, 44100, 48000])
+@pytest.mark.parametrize("num_channels", [1, 2])
+def test_python_plugin_with_lambda(sample_rate: float, power: float, num_channels: int):
+    sine = generate_sine_at(sample_rate, num_channels=num_channels).astype(np.float32)
+    plugin = PythonPlugin(lambda signal: np.power(signal, power))
+    np.testing.assert_allclose(np.power(sine, power), plugin(sine, sample_rate))
+
+
+class PowPlugin(object):
+    def __init__(self, power: float):
+        self.power = power
+        self.was_prepared = False
+        self.was_reset = False
+
+    def prepare(self, sample_rate: float, num_channels: int, maximum_block_size: int):
+        self.sample_rate = sample_rate
+        self.num_channels = num_channels
+        self.maximum_block_size = maximum_block_size
+        self.was_prepared = True
+
+    def reset(self):
+        self.was_reset = True
+
+    def process(self, signal: np.ndarray) -> np.ndarray:
+        return np.power(signal, self.power)
+
+
+@pytest.mark.parametrize("power", [1, 2, 3])
+@pytest.mark.parametrize("sample_rate", [22050, 44100, 48000])
+@pytest.mark.parametrize("num_channels", [1, 2])
+def test_python_plugin_with_object(sample_rate: float, power: float, num_channels: int):
+    sine = generate_sine_at(sample_rate, num_channels=num_channels).astype(np.float32)
+
+    python_object = PowPlugin(power=power)
+    plugin = PythonPlugin(python_object)
+    np.testing.assert_allclose(np.power(sine, power), plugin(sine, sample_rate))
+    assert plugin.wrapped is python_object
+    assert python_object.was_prepared
+    assert python_object.was_reset
+    assert python_object.sample_rate == sample_rate
+    assert python_object.num_channels == num_channels
+
+
+class UnpreparedPlugin(object):
+    def prepare(self, wrong_signature: float):
+        pass
+
+    def reset(self):
+        self.was_reset = True
+
+    def process(self, signal: np.ndarray) -> np.ndarray:
+        return np.power(signal, self.power)
+
+
+def test_python_plugin_with_wrong_prepare_signature():
+    with pytest.raises(RuntimeError):
+        plugin = PythonPlugin(UnpreparedPlugin())
+        plugin(np.random.rand(1, 10), 44100)
+
+
+class BadResetPlugin(object):
+    def reset(self):
+        raise ValueError("Oh no!")
+
+    def process(self, signal: np.ndarray) -> np.ndarray:
+        return np.power(signal, self.power)
+
+
+def test_python_plugin_with_exception_in_reset():
+    plugin = PythonPlugin(BadResetPlugin())
+    with pytest.raises(RuntimeError):
+        plugin(np.random.rand(1, 10), 44100)
+
+
+class BadProcessPlugin(object):
+    def process(self, signal: np.ndarray) -> np.ndarray:
+        raise ValueError("Too much data")
+
+
+def test_python_plugin_with_exception_in_process():
+    plugin = PythonPlugin(BadProcessPlugin())
+    with pytest.raises(RuntimeError):
+        plugin(np.random.rand(1, 10), 44100)
+
+
+def test_python_plugin_returns_more_channels_than_provided():
+    plugin = PythonPlugin(lambda x: np.concatenate([x, x]))
+    with pytest.raises(ValueError) as e:
+        plugin(np.random.rand(1, 10), 44100)
+    assert "a different number of channels" in e.value.args[0]
+
+
+def test_python_plugin_returns_more_samples_than_provided():
+    plugin = PythonPlugin(lambda x: np.concatenate([x[0], x[0]]))
+    with pytest.raises(ValueError) as e:
+        plugin(np.random.rand(1, 10), 44100)
+    assert "more samples" in e.value.args[0]
+
+
+@pytest.mark.parametrize("sample_rate", [22050, 44100, 48000])
+@pytest.mark.parametrize("num_channels", [1, 2])
+def test_python_plugin_returns_fewer_samples_than_provided(sample_rate: float, num_channels: int):
+    sine = generate_sine_at(sample_rate, num_channels=num_channels).astype(np.float32)
+
+    last_buffer = [np.array([], dtype=np.float32).reshape(num_channels, 0)]
+
+    def add_latency(signal: np.ndarray) -> np.ndarray:
+        """
+        Totally dumb plugin that introduces one buffer's worth of latency.
+        """
+        to_return = last_buffer[0]
+        last_buffer[0] = signal
+        return to_return[:, : signal.shape[1]]
+
+    plugin = PythonPlugin(add_latency)
+    np.testing.assert_allclose(sine, plugin(sine, 44100))


### PR DESCRIPTION
This PR closes #12, but I'm still not 100% convinced that this is a good idea - the point of Pedalboard is to use audio effects as efficiently as possible from within Python code. Adding a Python interface to _define_ an effect introduces a number of foot-guns:
 - Concurrency goes out the window: running multiple Pedalboards simultaneously is no longer as efficient, as the Python GIL would have to be locked every time a `PythonPlugin` processes audio. (Even if that `PythonPlugin` just calls into efficient code like NumPy!)
 - It would now be possible to pass arbitrary Python functions to the `Pedalboard` constructor and to use `lambda` expressions in `Pedalboard` objects - both useful, but both would come with the above concurrency issues.
 - Many use cases would now be possible (i.e.: `PythonPlugin(lambda signal: VST3Plugin(...).process(signal, sr))`) that would dramatically decrease performance and introduce issues that might frustrate users, and it wouldn't be easy to automatically detect and discourage these use cases.