### PR TITLE
Added MP3 writing support to AudioFile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ Internally at Spotify, `pedalboard` is used for [data augmentation](https://en.w
  - Supports VST3® plugins on macOS, Windows, and Linux (`pedalboard.load_plugin`)
  - Supports Audio Units on macOS
  - Built-in audio I/O utilities (`pedalboard.io.AudioFile`)
-   - Support for reading AIFF, FLAC, MP3, OGG, and WAV files on all platforms with no dependencies
-   - Support for writing AIFF, FLAC, OGG, and WAV on all platforms with no dependencies
+   - Support for reading and writing AIFF, FLAC, MP3, OGG, and WAV files on all platforms with no dependencies
    - Additional support for reading AAC, AC3, WMA, and other formats depending on platform
  - Strong thread-safety, memory usage, and speed guarantees
    - Releases Python's Global Interpreter Lock (GIL) to allow use of multiple CPU cores

--- a/pedalboard/io/LameMP3AudioFormat.h
+++ b/pedalboard/io/LameMP3AudioFormat.h
@@ -1,0 +1,200 @@
+/*
+ * pedalboard
+ * Copyright 2022 Spotify AB
+ *
+ * Licensed under the GNU Public License, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "../JuceHeader.h"
+#include "../plugins/MP3Compressor.h"
+
+extern "C" {
+#include <lame.h>
+}
+
+namespace Pedalboard {
+class LameMP3AudioFormat : public juce::AudioFormat {
+public:
+  LameMP3AudioFormat() : juce::AudioFormat("MP3", ".mp3"){};
+  ~LameMP3AudioFormat(){};
+
+  juce::Array<int> getPossibleSampleRates() { return {32000, 44100, 48000}; }
+  juce::Array<int> getPossibleBitDepths() { return {16}; }
+  bool canDoStereo() { return true; }
+  bool canDoMono() { return true; }
+  bool isCompressed() { return true; }
+
+  juce::StringArray getQualityOptions() {
+    juce::StringArray opts(VBR_OPTIONS);
+
+    for (int i = 0; i < juce::numElementsInArray(CBR_OPTIONS); ++i)
+      opts.add(juce::String(CBR_OPTIONS[i]) + " kbps");
+
+    return opts;
+  }
+
+  juce::AudioFormatReader *createReaderFor(juce::InputStream *,
+                                           bool deleteStreamIfOpeningFails) {
+    return nullptr;
+  }
+
+  juce::AudioFormatWriter *
+  createWriterFor(juce::OutputStream *out, double sampleRateToUse,
+                  unsigned int numberOfChannels, int bitsPerSample,
+                  const juce::StringPairArray &metadataValues,
+                  int qualityOptionIndex) {
+
+    try {
+      if (out != nullptr)
+        return new Writer(out, sampleRateToUse, numberOfChannels,
+                          qualityOptionIndex);
+    } catch (...) {
+      // TODO: Make WriteableAudioFile exception-safe so we can bubble up more
+      // useful error messages.
+    }
+
+    return nullptr;
+  }
+  using juce::AudioFormat::createWriterFor;
+
+  class Writer : public juce::AudioFormatWriter {
+  public:
+    Writer(juce::OutputStream *destStream, double sampleRate,
+           unsigned int numberOfChannels, int qualityOptionIndex)
+        : juce::AudioFormatWriter(nullptr, "MP3", sampleRate, numberOfChannels,
+                                  16) {
+      usesFloatingPointData = false;
+
+      // Suppress all error logging from LAME
+      // TODO: find out how to catch and report these errors to Python!
+      lame_set_errorf(encoder.getContext(), nullptr);
+
+      if (lame_set_in_samplerate(encoder.getContext(), sampleRate) != 0 ||
+          lame_set_out_samplerate(encoder.getContext(), sampleRate) != 0) {
+        throw std::domain_error(
+            "MP3 only supports 32kHz, 44.1kHz, and 48kHz audio. (Was passed "
+            "a sample rate of " +
+            juce::String(sampleRate / 1000, 1).toStdString() + "kHz.)");
+      }
+
+      if (lame_set_num_channels(encoder.getContext(), numChannels) != 0) {
+        throw std::domain_error(
+            "MP3 only supports mono or stereo audio. (Was passed " +
+            std::to_string(numChannels) + "-channel audio.)");
+      }
+
+      if (lame_set_VBR(encoder.getContext(), vbr_default) != 0) {
+        throw std::domain_error(
+            "MP3 encoder failed to set variable bit rate flag.");
+      }
+
+      juce::StringArray opts(VBR_OPTIONS);
+
+      if (qualityOptionIndex < NUM_VBR_OPTIONS) {
+        // VBR options:
+        if (lame_set_VBR_quality(encoder.getContext(), qualityOptionIndex) !=
+            0) {
+          throw std::domain_error(
+              "MP3 encoder failed to set variable bit rate quality to " +
+              std::to_string(qualityOptionIndex) + "!");
+        }
+      } else if (qualityOptionIndex <
+                 (NUM_VBR_OPTIONS + juce::numElementsInArray(CBR_OPTIONS))) {
+        // CBR options:
+        if (lame_set_brate(encoder.getContext(),
+                           CBR_OPTIONS[qualityOptionIndex - NUM_VBR_OPTIONS]) !=
+            0) {
+          throw std::domain_error(
+              "MP3 encoder failed to set constant bit rate quality to " +
+              std::to_string(
+                  CBR_OPTIONS[qualityOptionIndex - NUM_VBR_OPTIONS]) +
+              "!");
+        }
+      } else {
+        throw std::domain_error("Unsupported quality index!");
+      }
+
+      int ret = lame_init_params(encoder.getContext());
+      if (ret != 0) {
+        throw std::runtime_error("Failed to initialize MP3 encoder! (error " +
+                                 std::to_string(ret) + ")");
+      }
+
+      // Assign this at the end, as the AudioFormatWriter destructor
+      // automatically deletes this pointer, and we don't want that
+      // to happen if our constructor fails.
+      output = destStream;
+
+      // Flush the initial header:
+      const int *emptyBuffers[2] = {0};
+      if (!write(emptyBuffers, 0)) {
+        output = nullptr;
+        throw std::runtime_error("Failed to write header!");
+      }
+    }
+
+    virtual ~Writer() override { flush(); };
+
+    virtual bool write(const int **samplesToWrite, int numSamples) {
+      // Constants from the LAME docs
+      std::vector<unsigned char> encodedMp3Buffer(1.25 * numSamples + 7200);
+
+      std::vector<std::vector<short>> shortSamples(numChannels);
+      for (int c = 0; c < numChannels; c++) {
+        shortSamples[c].resize(numSamples);
+        for (int i = 0; i < numSamples; i++) {
+          shortSamples[c][i] = samplesToWrite[c][i] >> 16;
+        }
+      }
+
+      int mp3BufferBytesFilled = lame_encode_buffer(
+          encoder.getContext(), shortSamples[0].data(),
+          numChannels == 1 ? nullptr : shortSamples[1].data(), numSamples,
+          (unsigned char *)encodedMp3Buffer.data(), encodedMp3Buffer.size());
+      return output->write((unsigned char *)encodedMp3Buffer.data(),
+                           mp3BufferBytesFilled);
+    }
+
+    virtual bool flush() {
+      if (!output)
+        return false;
+
+      std::vector<unsigned char> mp3buf(7200); // Constant from the LAME docs
+      int bytesWritten = lame_encode_flush_nogap(encoder.getContext(),
+                                                 mp3buf.data(), mp3buf.size());
+
+      if (bytesWritten < 0) {
+        return false;
+      }
+
+      output->write(mp3buf.data(), bytesWritten);
+      output->flush();
+      return true;
+    }
+
+  private:
+    EncoderWrapper encoder;
+  };
+
+private:
+  static inline const char *VBR_OPTIONS[] = {
+      "V0 (best)", "V1", "V2", "V3", "V4 (normal)",
+      "V5",        "V6", "V7", "V8", "V9 (smallest)",
+      nullptr};
+  static const int NUM_VBR_OPTIONS = 10;
+  static inline const int CBR_OPTIONS[] = {32,  40,  48,  56,  64,  80,  96,
+                                           112, 128, 160, 192, 224, 256, 320};
+};
+
+} // namespace Pedalboard

--- a/pedalboard/io/LameMP3AudioFormat.h
+++ b/pedalboard/io/LameMP3AudioFormat.h
@@ -227,6 +227,10 @@ public:
         return;
       }
 
+      if (!output->setPosition(0)) {
+        return;
+      }
+
       if (!output->write(buffer, frameTagSize)) {
         return;
       }

--- a/pedalboard/io/WriteableAudioFile.h
+++ b/pedalboard/io/WriteableAudioFile.h
@@ -894,33 +894,6 @@ inline void init_writeable_audio_file(py::module &m) {
           "The quality setting used to write this file. For many "
           "formats, this may be None.");
 
-  m.def("get_supported_read_formats", []() {
-    juce::AudioFormatManager manager;
-    manager.registerBasicFormats();
-
-    std::vector<std::string> formatNames(manager.getNumKnownFormats());
-    juce::StringArray extensions;
-    for (int i = 0; i < manager.getNumKnownFormats(); i++) {
-      auto *format = manager.getKnownFormat(i);
-      extensions.addArray(format->getFileExtensions());
-    }
-
-    extensions.trim();
-    extensions.removeEmptyStrings();
-    extensions.removeDuplicates(true);
-
-    std::vector<std::string> output;
-    for (juce::String s : extensions) {
-      output.push_back(s.toStdString());
-    }
-
-    std::sort(
-        output.begin(), output.end(),
-        [](const std::string lhs, const std::string rhs) { return lhs < rhs; });
-
-    return output;
-  });
-
   m.def("get_supported_write_formats", []() {
     // JUCE doesn't support writing other formats out-of-the-box on all
     // platforms, and there's no easy way to tell which formats are supported

--- a/pedalboard/io/WriteableAudioFile.h
+++ b/pedalboard/io/WriteableAudioFile.h
@@ -462,10 +462,12 @@ public:
           }
         }
 
-        if (!write(channelPointers, numChannels, samplesToWrite)) {
+        bool writeSuccessful =
+            write(channelPointers, numChannels, samplesToWrite);
+        PythonException::raise();
+        if (!writeSuccessful) {
           throw std::runtime_error("Unable to write data to audio file.");
         }
-        PythonException::raise();
       }
 
       break;
@@ -477,10 +479,12 @@ public:
       for (int c = 0; c < numChannels; c++) {
         channelPointers[c] = ((SampleType *)inputInfo.ptr) + (numSamples * c);
       }
-      if (!write(channelPointers, numChannels, numSamples)) {
+
+      bool writeSuccessful = write(channelPointers, numChannels, numSamples);
+      PythonException::raise();
+      if (!writeSuccessful) {
         throw std::runtime_error("Unable to write data to audio file.");
       }
-      PythonException::raise();
       break;
     }
     default:

--- a/pedalboard/io/WriteableAudioFile.h
+++ b/pedalboard/io/WriteableAudioFile.h
@@ -26,6 +26,7 @@
 #include "../BufferUtils.h"
 #include "../JuceHeader.h"
 #include "AudioFile.h"
+#include "LameMP3AudioFormat.h"
 #include "PythonOutputStream.h"
 
 namespace py = pybind11;
@@ -66,6 +67,8 @@ int determineQualityOptionIndex(juce::AudioFormat *format,
       for (int i = 0; i < qualityString.size(); i++) {
         if (juce::CharacterFunctions::isDigit(qualityString[i])) {
           numLeadingDigits++;
+        } else {
+          break;
         }
       }
 
@@ -211,7 +214,13 @@ public:
                            "non-zero num_channels.");
     }
 
-    formatManager.registerBasicFormats();
+    // Don't use registerBasicFormats(), as it'll register the wrong MP3 format:
+    formatManager.registerFormat(new juce::WavAudioFormat(), false);
+    formatManager.registerFormat(new juce::AiffAudioFormat(), false);
+    formatManager.registerFormat(new juce::FlacAudioFormat(), false);
+    formatManager.registerFormat(new juce::OggVorbisAudioFormat(), false);
+    formatManager.registerFormat(new LameMP3AudioFormat(), false);
+
     std::unique_ptr<juce::OutputStream> outputStream;
     juce::AudioFormat *format = nullptr;
     std::string extension;
@@ -318,7 +327,7 @@ public:
         throw std::domain_error(
             format->getFormatName().toStdString() +
             " audio files do not support the provided sample rate of " +
-            std::to_string(writeSampleRate) +
+            juce::String(writeSampleRate, 2).toStdString() +
             "Hz. Supported sample rates: " + sampleRateString.str());
       }
 
@@ -913,7 +922,8 @@ inline void init_writeable_audio_file(py::module &m) {
     // platforms, and there's no easy way to tell which formats are supported
     // without attempting to create an AudioFileWriter object - so this list is
     // hardcoded for now.
-    const std::vector<std::string> formats = {".aiff", ".flac", ".ogg", ".wav"};
+    const std::vector<std::string> formats = {".aiff", ".flac", ".ogg", ".wav",
+                                              ".mp3"};
     return formats;
   });
 }

--- a/pedalboard/plugins/MP3Compressor.h
+++ b/pedalboard/plugins/MP3Compressor.h
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
 
 #include "../Plugin.h"
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -729,6 +729,33 @@ def test_mp3_write(samplerate: float, num_channels: int, qualities):
     assert len(set(file_sizes)) <= len(file_sizes)
 
 
+@pytest.mark.parametrize("extension", pedalboard.io.get_supported_write_formats())
+@pytest.mark.parametrize("samplerate", [32000, 44100, 48000])
+@pytest.mark.parametrize("num_channels", [1, 2])
+def test_write_empty_file(extension: str, samplerate: float, num_channels: int):
+    stream = io.BytesIO()
+
+    with pedalboard.io.WriteableAudioFile(
+        stream,
+        samplerate=samplerate,
+        num_channels=num_channels,
+        format=extension,
+    ) as af:
+        pass
+
+    assert len(stream.getvalue()) > 0
+    stream.seek(0)
+
+    with pedalboard.io.AudioFile(stream) as af:
+        assert af.samplerate == samplerate
+        assert af.num_channels == num_channels
+        try:
+            assert af.frames == 0
+        finally:
+            with open("should_be_empty.mp3", "wb") as f:
+                f.write(stream.getvalue())
+
+
 @pytest.mark.parametrize(
     "extension,quality,expected",
     [

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -735,6 +735,9 @@ def test_mp3_write(samplerate: float, num_channels: int, qualities):
 def test_write_empty_file(extension: str, samplerate: float, num_channels: int):
     stream = io.BytesIO()
 
+    # Set the stream's name so that ReadableAudioFile knows that it's an MP3 on Linux/Windows
+    stream.name = f"test{extension}"
+
     with pedalboard.io.WriteableAudioFile(
         stream,
         samplerate=samplerate,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -754,7 +754,7 @@ def test_write_empty_file(extension: str, samplerate: float, num_channels: int):
         assert af.num_channels == num_channels
         # The built-in JUCE MP3 reader (only used on Linux and Windows)
         # reads zero-length MP3 files as having exactly one frame.
-        if 'mp3' in extension and platform.system() != "Darwin":
+        if "mp3" in extension and platform.system() != "Darwin":
             assert af.frames <= 1152
             contents = af.read(af.frames)
             np.testing.assert_allclose(np.zeros_like(contents), contents)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -752,11 +752,14 @@ def test_write_empty_file(extension: str, samplerate: float, num_channels: int):
     with pedalboard.io.AudioFile(stream) as af:
         assert af.samplerate == samplerate
         assert af.num_channels == num_channels
-        try:
+        # The built-in JUCE MP3 reader (only used on Linux and Windows)
+        # reads zero-length MP3 files as having exactly one frame.
+        if 'mp3' in extension and platform.system() != "Darwin":
+            assert af.frames <= 1152
+            contents = af.read(af.frames)
+            np.testing.assert_allclose(np.zeros_like(contents), contents)
+        else:
             assert af.frames == 0
-        finally:
-            with open("should_be_empty.mp3", "wb") as f:
-                f.write(stream.getvalue())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds support for writing MP3 files with `pedalboard.io.AudioFile`, which previously only supported reading MP3 files.

The built-in `juce::MP3AudioFormat` class (used to read MP3s) doesn't support writing MP3s, but we already embed `libmp3lame` within Pedalboard, which can be used to encode MP3 frames. This PR adds a new custom `juce::AudioFormat` subclass (called `LameMP3AudioFormat`) that wraps the existing `libmp3lame` symbols.