### PR TITLE
Re-enable x86-only wheels on macOS.

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -177,6 +177,9 @@ jobs:
         include:
         - { os: macos-latest, build: cp36-macosx_x86_64 }
         - { os: macos-latest, build: cp37-macosx_x86_64 }
+        - { os: macos-latest, build: cp38-macosx_x86_64 }
+        - { os: macos-latest, build: cp39-macosx_x86_64 }
+        - { os: macos-latest, build: cp310-macosx_x86_64 }
         - { os: macos-latest, build: cp38-macosx_universal2 }
         - { os: macos-latest, build: cp39-macosx_universal2 }
         - { os: macos-latest, build: cp310-macosx_universal2 }


### PR DESCRIPTION
Fixes #94.

When running Python on Apple Silicon under [Rosetta 2](https://support.apple.com/en-us/HT211861), Pip looks for only `macosx_x86_64` wheels, not `universal2` wheels. This PR makes debugging easier by re-publishing x86_64 wheels on macOS, as we previously did until version 0.3.8.