### PR TITLE
Fix AudioFile behaviour when overwriting existing audio files.

### DIFF
--- a/pedalboard/io/WriteableAudioFile.h
+++ b/pedalboard/io/WriteableAudioFile.h
@@ -158,6 +158,12 @@ public:
     return juce::FileOutputStream::write(bytes, len);
   }
 
+  virtual juce::int64 getPosition() override {
+    if (!hasWrittenToFile)
+      return 0;
+    return juce::FileOutputStream::getPosition();
+  }
+
   virtual bool writeRepeatedByte(juce::uint8 byte,
                                  size_t numTimesToRepeat) override {
     if (!hasWrittenToFile) {
@@ -261,7 +267,7 @@ public:
       extension = file.getFileExtension().toStdString();
 
       outputStream = AutoDeleteFileOutputStream::createOutputStream(file);
-      if (!static_cast<juce::FileOutputStream *>(outputStream.get())
+      if (!static_cast<AutoDeleteFileOutputStream *>(outputStream.get())
                ->openedOk()) {
         throw std::domain_error("Unable to open audio file for writing: " +
                                 filename);

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,6 +7,7 @@ setuptools>=42
 wheel
 flake8
 black==21.7b0
+click==8.0.4
 interrogate
 
 numpy


### PR DESCRIPTION
When writing to the same file path twice, `pedalboard.io.AudioFile` could write incorrect output files, due to an inaccurate file position (end-of-old-file, rather than start-of-new-file) being returned to the format-specific file writing code. This PR fixes the issue and adds tests for it.