### PR TITLE
Avoid exposing internal symbols to decrease binary size.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,8 +122,9 @@ if platform.system() == "Darwin":
     ALL_LINK_ARGS.append("-fvisibility=hidden")
 elif platform.system() == "Linux":
     ALL_CPPFLAGS.append("-DLINUX=1")
-    ALL_CPPFLAGS.append("-flto=thin")
-    ALL_LINK_ARGS.append("-flto=thin")
+    # We use GCC on Linux, which doesn't take a value for the -flto flag:
+    ALL_CPPFLAGS.append("-flto")
+    ALL_LINK_ARGS.append("-flto")
     ALL_LINK_ARGS.append("-fvisibility=hidden")
 elif platform.system() == "Windows":
     ALL_CPPFLAGS.append("-DWINDOWS=1")

--- a/setup.py
+++ b/setup.py
@@ -117,8 +117,14 @@ ALL_INCLUDES += ['vendors/libgsm/inc']
 if platform.system() == "Darwin":
     ALL_CPPFLAGS.append("-DMACOS=1")
     ALL_CPPFLAGS.append("-DHAVE_VDSP=1")
+    ALL_CPPFLAGS.append("-flto=thin")
+    ALL_LINK_ARGS.append("-flto=thin")
+    ALL_LINK_ARGS.append("-fvisibility=hidden")
 elif platform.system() == "Linux":
     ALL_CPPFLAGS.append("-DLINUX=1")
+    ALL_CPPFLAGS.append("-flto=thin")
+    ALL_LINK_ARGS.append("-flto=thin")
+    ALL_LINK_ARGS.append("-fvisibility=hidden")
 elif platform.system() == "Windows":
     ALL_CPPFLAGS.append("-DWINDOWS=1")
 else:


### PR DESCRIPTION
This PR turns on [Clang's ThinLTO](https://clang.llvm.org/docs/ThinLTO.html), which should reduce binary size by at least 33% on macOS alone.