### PR TITLE
Fix master build failures due to universal2 issues on macos-latest.

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -59,7 +59,7 @@ jobs:
       MINIMUM_COVERAGE_PERCENTAGE: 89
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11.0-beta.3']
         # TODO: Switch back to macos-latest once https://github.com/actions/python-versions/pull/114 is fixed
         os: [ubuntu-18.04, ubuntu-latest, windows-latest, macos-10.15]
     name: Test with Python ${{ matrix.python-version }} on ${{ matrix.os }}
@@ -194,6 +194,7 @@ jobs:
         - { os: windows-latest, build: cp38-win_amd64 }
         - { os: windows-latest, build: cp39-win_amd64 }
         - { os: windows-latest, build: cp310-win_amd64 }
+        - { os: windows-latest, build: cp311-win_amd64 }
         - { os: windows-latest, build: pp37-win_amd64 }
         - { os: windows-latest, build: pp38-win_amd64 }
         - { os: windows-latest, build: pp39-win_amd64 }
@@ -217,6 +218,10 @@ jobs:
         - { os: ubuntu-latest, build: cp310-musllinux_x86_64 }
         - { os: ubuntu-latest, build: cp310-manylinux_aarch64 }
         - { os: ubuntu-latest, build: cp310-musllinux_aarch64 }
+        - { os: ubuntu-latest, build: cp311-manylinux_x86_64 }
+        - { os: ubuntu-latest, build: cp311-musllinux_x86_64 }
+        - { os: ubuntu-latest, build: cp311-manylinux_aarch64 }
+        - { os: ubuntu-latest, build: cp311-musllinux_aarch64 }
         - { os: ubuntu-latest, build: pp37-manylinux_x86_64 }
         - { os: ubuntu-latest, build: pp37-manylinux_aarch64 }
         - { os: ubuntu-latest, build: pp38-manylinux_x86_64 }

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -59,7 +59,7 @@ jobs:
       MINIMUM_COVERAGE_PERCENTAGE: 89
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
         # TODO: Switch back to macos-latest once https://github.com/actions/python-versions/pull/114 is fixed
         os: [ubuntu-18.04, ubuntu-latest, windows-latest, macos-10.15]
     name: Test with Python ${{ matrix.python-version }} on ${{ matrix.os }}

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -60,7 +60,8 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        os: [ubuntu-18.04, ubuntu-latest, windows-latest, macos-10.15, macos-12]
+        # TODO: Switch back to macos-latest once https://github.com/actions/python-versions/pull/114 is fixed
+        os: [ubuntu-18.04, ubuntu-latest, windows-latest, macos-10.15]
     name: Test with Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
       - name: Set up Python ${{ matrix.python-version }}
@@ -175,16 +176,19 @@ jobs:
     strategy:
       matrix:
         include:
-        - { os: macos-12, build: cp36-macosx_x86_64 }
-        - { os: macos-12, build: cp37-macosx_x86_64 }
-        - { os: macos-12, build: cp38-macosx_x86_64 }
-        - { os: macos-12, build: cp39-macosx_x86_64 }
-        - { os: macos-12, build: cp310-macosx_x86_64 }
-        - { os: macos-12, build: cp38-macosx_universal2 }
-        - { os: macos-12, build: cp39-macosx_universal2 }
-        - { os: macos-12, build: cp310-macosx_universal2 }
-        - { os: macos-12, build: pp37-macosx_x86_64 }
-        - { os: macos-12, build: pp38-macosx_x86_64 }
+        - { os: macos-10.15, build: cp36-macosx_x86_64 }
+        - { os: macos-10.15, build: cp37-macosx_x86_64 }
+        - { os: macos-10.15, build: cp38-macosx_x86_64 }
+        - { os: macos-10.15, build: cp39-macosx_x86_64 }
+        - { os: macos-10.15, build: cp310-macosx_x86_64 }
+        - { os: macos-10.15, build: cp311-macosx_x86_64 }
+        - { os: macos-10.15, build: cp38-macosx_universal2 }
+        - { os: macos-10.15, build: cp39-macosx_universal2 }
+        - { os: macos-10.15, build: cp310-macosx_universal2 }
+        - { os: macos-10.15, build: cp311-macosx_universal2 }
+        - { os: macos-10.15, build: pp37-macosx_x86_64 }
+        - { os: macos-10.15, build: pp38-macosx_x86_64 }
+        - { os: macos-10.15, build: pp39-macosx_x86_64 }
         - { os: windows-latest, build: cp36-win_amd64 }
         - { os: windows-latest, build: cp37-win_amd64 }
         - { os: windows-latest, build: cp38-win_amd64 }
@@ -192,20 +196,33 @@ jobs:
         - { os: windows-latest, build: cp310-win_amd64 }
         - { os: windows-latest, build: pp37-win_amd64 }
         - { os: windows-latest, build: pp38-win_amd64 }
+        - { os: windows-latest, build: pp39-win_amd64 }
         - { os: ubuntu-latest, build: cp36-manylinux_x86_64 }
+        - { os: ubuntu-latest, build: cp36-musllinux_x86_64 }
         - { os: ubuntu-latest, build: cp36-manylinux_aarch64 }
+        - { os: ubuntu-latest, build: cp36-musllinux_aarch64 }
         - { os: ubuntu-latest, build: cp37-manylinux_x86_64 }
+        - { os: ubuntu-latest, build: cp37-musllinux_x86_64 }
         - { os: ubuntu-latest, build: cp37-manylinux_aarch64 }
+        - { os: ubuntu-latest, build: cp37-musllinux_aarch64 }
         - { os: ubuntu-latest, build: cp38-manylinux_x86_64 }
+        - { os: ubuntu-latest, build: cp38-musllinux_x86_64 }
         - { os: ubuntu-latest, build: cp38-manylinux_aarch64 }
+        - { os: ubuntu-latest, build: cp38-musllinux_aarch64 }
         - { os: ubuntu-latest, build: cp39-manylinux_x86_64 }
+        - { os: ubuntu-latest, build: cp39-musllinux_x86_64 }
         - { os: ubuntu-latest, build: cp39-manylinux_aarch64 }
+        - { os: ubuntu-latest, build: cp39-musllinux_aarch64 }
         - { os: ubuntu-latest, build: cp310-manylinux_x86_64 }
+        - { os: ubuntu-latest, build: cp310-musllinux_x86_64 }
         - { os: ubuntu-latest, build: cp310-manylinux_aarch64 }
+        - { os: ubuntu-latest, build: cp310-musllinux_aarch64 }
         - { os: ubuntu-latest, build: pp37-manylinux_x86_64 }
         - { os: ubuntu-latest, build: pp37-manylinux_aarch64 }
         - { os: ubuntu-latest, build: pp38-manylinux_x86_64 }
         - { os: ubuntu-latest, build: pp38-manylinux_aarch64 }
+        - { os: ubuntu-latest, build: pp39-manylinux_x86_64 }
+        - { os: ubuntu-latest, build: pp39-manylinux_aarch64 }
     name: Build wheel for ${{ matrix.build }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        os: [ubuntu-18.04, ubuntu-latest, windows-latest, macos-10.15, macos-latest]
+        os: [ubuntu-18.04, ubuntu-latest, windows-latest, macos-10.15, macos-12]
     name: Test with Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
       - name: Set up Python ${{ matrix.python-version }}
@@ -175,16 +175,16 @@ jobs:
     strategy:
       matrix:
         include:
-        - { os: macos-latest, build: cp36-macosx_x86_64 }
-        - { os: macos-latest, build: cp37-macosx_x86_64 }
-        - { os: macos-latest, build: cp38-macosx_x86_64 }
-        - { os: macos-latest, build: cp39-macosx_x86_64 }
-        - { os: macos-latest, build: cp310-macosx_x86_64 }
-        - { os: macos-latest, build: cp38-macosx_universal2 }
-        - { os: macos-latest, build: cp39-macosx_universal2 }
-        - { os: macos-latest, build: cp310-macosx_universal2 }
-        - { os: macos-latest, build: pp37-macosx_x86_64 }
-        - { os: macos-latest, build: pp38-macosx_x86_64 }
+        - { os: macos-12, build: cp36-macosx_x86_64 }
+        - { os: macos-12, build: cp37-macosx_x86_64 }
+        - { os: macos-12, build: cp38-macosx_x86_64 }
+        - { os: macos-12, build: cp39-macosx_x86_64 }
+        - { os: macos-12, build: cp310-macosx_x86_64 }
+        - { os: macos-12, build: cp38-macosx_universal2 }
+        - { os: macos-12, build: cp39-macosx_universal2 }
+        - { os: macos-12, build: cp310-macosx_universal2 }
+        - { os: macos-12, build: pp37-macosx_x86_64 }
+        - { os: macos-12, build: pp38-macosx_x86_64 }
         - { os: windows-latest, build: cp36-win_amd64 }
         - { os: windows-latest, build: cp37-win_amd64 }
         - { os: windows-latest, build: cp38-win_amd64 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
-    "setuptools>=42",
-    "wheel",
-    "pybind11>=2.6.0",
+    "setuptools>=63",
+    "wheel>=0.36.2",
+    "pybind11>=2.9.2",
 ]
 
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
[The `Test with Python 3.10 on macos-latest` (macos-11) build step is failing](https://github.com/spotify/pedalboard/runs/7271457313?check_suite_focus=true) for unknown reasons at the moment - I suspect the issue may be related to the deployment target used at build time on macOS 11, and/or https://github.com/pypa/wheel/pull/390, and/or https://github.com/actions/python-versions/pull/114. This PR bumps dependency versions of the dependencies we use at build time to attempt to fix the issue.