### PR TITLE
Allow negative indices when accessing Pedalboard objects like lists.

### DIFF
--- a/pedalboard/PluginContainer.h
+++ b/pedalboard/PluginContainer.h
@@ -73,18 +73,30 @@ inline void init_plugin_container(py::module &m) {
       // Implement the Sequence protocol:
       .def("__getitem__",
            [](PluginContainer &s, size_t i) {
+             if (i < 0)
+               i = s.getPlugins().size() + i;
+             if (i < 0)
+               throw py::index_error("index out of range");
              if (i >= s.getPlugins().size())
                throw py::index_error("index out of range");
              return s.getPlugins()[i];
            })
       .def("__setitem__",
            [](PluginContainer &s, size_t i, std::shared_ptr<Plugin> plugin) {
+             if (i < 0)
+               i = s.getPlugins().size() + i;
+             if (i < 0)
+               throw py::index_error("index out of range");
              if (i >= s.getPlugins().size())
                throw py::index_error("index out of range");
              s.getPlugins()[i] = plugin;
            })
       .def("__delitem__",
            [](PluginContainer &s, size_t i) {
+             if (i < 0)
+               i = s.getPlugins().size() + i;
+             if (i < 0)
+               throw py::index_error("index out of range");
              if (i >= s.getPlugins().size())
                throw py::index_error("index out of range");
              auto &plugins = s.getPlugins();
@@ -93,6 +105,10 @@ inline void init_plugin_container(py::module &m) {
       .def("__len__", [](PluginContainer &s) { return s.getPlugins().size(); })
       .def("insert",
            [](PluginContainer &s, int i, std::shared_ptr<Plugin> plugin) {
+             if (i < 0)
+               i = s.getPlugins().size() + i;
+             if (i < 0)
+               throw py::index_error("index out of range");
              if (i > s.getPlugins().size())
                throw py::index_error("index out of range");
              auto &plugins = s.getPlugins();

--- a/pedalboard/PluginContainer.h
+++ b/pedalboard/PluginContainer.h
@@ -72,7 +72,7 @@ inline void init_plugin_container(py::module &m) {
       }))
       // Implement the Sequence protocol:
       .def("__getitem__",
-           [](PluginContainer &s, size_t i) {
+           [](PluginContainer &s, int i) {
              if (i < 0)
                i = s.getPlugins().size() + i;
              if (i < 0)
@@ -82,7 +82,7 @@ inline void init_plugin_container(py::module &m) {
              return s.getPlugins()[i];
            })
       .def("__setitem__",
-           [](PluginContainer &s, size_t i, std::shared_ptr<Plugin> plugin) {
+           [](PluginContainer &s, int i, std::shared_ptr<Plugin> plugin) {
              if (i < 0)
                i = s.getPlugins().size() + i;
              if (i < 0)
@@ -92,7 +92,7 @@ inline void init_plugin_container(py::module &m) {
              s.getPlugins()[i] = plugin;
            })
       .def("__delitem__",
-           [](PluginContainer &s, size_t i) {
+           [](PluginContainer &s, int i) {
              if (i < 0)
                i = s.getPlugins().size() + i;
              if (i < 0)

--- a/tests/test_mix_and_chain.py
+++ b/tests/test_mix_and_chain.py
@@ -34,6 +34,33 @@ from pedalboard_native._internal import AddLatency
 NUM_SECONDS = 4
 
 
+def test_chain_access_like_list():
+    a = Gain(6)
+
+    b = Gain(-6)
+    c = Gain(1)
+
+    d = Chain([b, c])
+    e = Gain(-1)
+
+    pb = Pedalboard([a, d, e])
+
+    assert pb[0] is a
+    assert pb[-3] is a
+
+    assert pb[1] is d
+    assert pb[-2] is d
+
+    assert pb[1][0] is b
+    assert pb[1][-2] is b
+
+    assert pb[1][1] is c
+    assert pb[1][-1] is c
+
+    assert pb[2] is e
+    assert pb[-1] is e
+
+
 def test_nested_chain():
     sr = 44100
     _input = np.random.rand(int(NUM_SECONDS * sr), 2).astype(np.float32)


### PR DESCRIPTION
Fixes #112.