### PR TITLE
Ensure that IIR filters are applied to all channels.

### DIFF
--- a/pedalboard/plugins/HighpassFilter.h
+++ b/pedalboard/plugins/HighpassFilter.h
@@ -36,8 +36,8 @@ public:
         *juce::dsp::IIR::Coefficients<SampleType>::makeFirstOrderHighPass(
             spec.sampleRate, cutoffFrequencyHz);
     JucePlugin<juce::dsp::ProcessorDuplicator<
-                           juce::dsp::IIR::Filter<SampleType>,
-                           juce::dsp::IIR::Coefficients<SampleType>>>::prepare(spec);
+        juce::dsp::IIR::Filter<SampleType>,
+        juce::dsp::IIR::Coefficients<SampleType>>>::prepare(spec);
   }
 
 private:

--- a/pedalboard/plugins/HighpassFilter.h
+++ b/pedalboard/plugins/HighpassFilter.h
@@ -24,16 +24,20 @@ namespace py = pybind11;
 
 namespace Pedalboard {
 template <typename SampleType>
-class HighpassFilter : public JucePlugin<juce::dsp::IIR::Filter<SampleType>> {
+class HighpassFilter : public JucePlugin<juce::dsp::ProcessorDuplicator<
+                           juce::dsp::IIR::Filter<SampleType>,
+                           juce::dsp::IIR::Coefficients<SampleType>>> {
 public:
   void setCutoffFrequencyHz(float f) noexcept { cutoffFrequencyHz = f; }
   float getCutoffFrequencyHz() const noexcept { return cutoffFrequencyHz; }
 
   virtual void prepare(const juce::dsp::ProcessSpec &spec) override {
-    JucePlugin<juce::dsp::IIR::Filter<SampleType>>::prepare(spec);
-    this->getDSP().coefficients =
-        juce::dsp::IIR::Coefficients<SampleType>::makeFirstOrderHighPass(
+    *this->getDSP().state =
+        *juce::dsp::IIR::Coefficients<SampleType>::makeFirstOrderHighPass(
             spec.sampleRate, cutoffFrequencyHz);
+    JucePlugin<juce::dsp::ProcessorDuplicator<
+                           juce::dsp::IIR::Filter<SampleType>,
+                           juce::dsp::IIR::Coefficients<SampleType>>>::prepare(spec);
   }
 
 private:

--- a/pedalboard/plugins/IIRFilters.h
+++ b/pedalboard/plugins/IIRFilters.h
@@ -88,7 +88,7 @@ public:
             spec.sampleRate,
             clampCutoffFrequency(this->cutoffFrequencyHz, spec.sampleRate),
             this->Q, this->gainFactor);
-            
+
     IIRFilter<SampleType>::prepare(spec);
   }
 };

--- a/pedalboard/plugins/LowpassFilter.h
+++ b/pedalboard/plugins/LowpassFilter.h
@@ -36,8 +36,8 @@ public:
         *juce::dsp::IIR::Coefficients<SampleType>::makeFirstOrderLowPass(
             spec.sampleRate, cutoffFrequencyHz);
     JucePlugin<juce::dsp::ProcessorDuplicator<
-                          juce::dsp::IIR::Filter<SampleType>,
-                          juce::dsp::IIR::Coefficients<SampleType>>>::prepare(spec);
+        juce::dsp::IIR::Filter<SampleType>,
+        juce::dsp::IIR::Coefficients<SampleType>>>::prepare(spec);
   }
 
 private:

--- a/pedalboard/plugins/LowpassFilter.h
+++ b/pedalboard/plugins/LowpassFilter.h
@@ -24,16 +24,20 @@ namespace py = pybind11;
 
 namespace Pedalboard {
 template <typename SampleType>
-class LowpassFilter : public JucePlugin<juce::dsp::IIR::Filter<SampleType>> {
+class LowpassFilter : public JucePlugin<juce::dsp::ProcessorDuplicator<
+                          juce::dsp::IIR::Filter<SampleType>,
+                          juce::dsp::IIR::Coefficients<SampleType>>> {
 public:
   void setCutoffFrequencyHz(float f) noexcept { cutoffFrequencyHz = f; }
   float getCutoffFrequencyHz() const noexcept { return cutoffFrequencyHz; }
 
   virtual void prepare(const juce::dsp::ProcessSpec &spec) override {
-    JucePlugin<juce::dsp::IIR::Filter<SampleType>>::prepare(spec);
-    this->getDSP().coefficients =
-        juce::dsp::IIR::Coefficients<SampleType>::makeFirstOrderLowPass(
+    *this->getDSP().state =
+        *juce::dsp::IIR::Coefficients<SampleType>::makeFirstOrderLowPass(
             spec.sampleRate, cutoffFrequencyHz);
+    JucePlugin<juce::dsp::ProcessorDuplicator<
+                          juce::dsp::IIR::Filter<SampleType>,
+                          juce::dsp::IIR::Coefficients<SampleType>>>::prepare(spec);
   }
 
 private:


### PR DESCRIPTION
IIR filters (`HighShelfFilter`, `LowShelfFilter`, `PeakFilter`) were previously being applied to only the first channel of input. This PR fixes that.