### PR TITLE
Allow Pedalboard to compile against JUCE 6.15+ on Red Hat.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 ![Pedalboard Logo](https://user-images.githubusercontent.com/213293/131147303-4805181a-c7d5-4afe-afb2-f591a4b8e586.png)
 
 
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pedalboard)
-![Supported Platforms](https://img.shields.io/badge/platforms-macOS%20%7C%20Windows%20%7C%20Linux-green)
-![Apple Silicon support for macOS and Linux (Docker)](https://img.shields.io/badge/Apple%20Silicon-macOS%20and%20Linux-brightgreen)
-![PyPI - Wheel](https://img.shields.io/pypi/wheel/pedalboard)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://github.com/spotify/pedalboard/blob/master/LICENSE)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pedalboard)](https://pypi.org/project/pedalboard)
+[![Supported Platforms](https://img.shields.io/badge/platforms-macOS%20%7C%20Windows%20%7C%20Linux-green)](https://pypi.org/project/pedalboard)
+[![Apple Silicon support for macOS and Linux (Docker)](https://img.shields.io/badge/Apple%20Silicon-macOS%20and%20Linux-brightgreen)](https://pypi.org/project/pedalboard)
+[![PyPI - Wheel](https://img.shields.io/pypi/wheel/pedalboard)](https://pypi.org/project/pedalboard)
 [![Test Badge](https://github.com/spotify/pedalboard/actions/workflows/all.yml/badge.svg)](https://github.com/spotify/pedalboard/actions/workflows/all.yml)
-![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/psobot/8736467e9952991ef44a67915ee7c762/raw/coverage.json)
-![PyPI - Downloads](https://img.shields.io/pypi/dm/pedalboard)
-![GitHub Repo stars](https://img.shields.io/github/stars/spotify/pedalboard?style=social)
+[![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/psobot/8736467e9952991ef44a67915ee7c762/raw/coverage.json)](https://gist.githubusercontent.com/psobot/8736467e9952991ef44a67915ee7c762/raw/coverage.json)
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/pedalboard)](https://pypistats.org/packages/pedalboard)
+[![GitHub Repo stars](https://img.shields.io/github/stars/spotify/pedalboard?style=social)](https://github.com/spotify/pedalboard/stargazers)
 
 `pedalboard` is a Python library for manipulating audio: adding effects, reading, writing, and more. It supports a number of common audio effects out of the box, and also allows the use of [VST3®](https://www.steinberg.net/en/company/technologies/vst3.html) and [Audio Unit](https://en.wikipedia.org/wiki/Audio_Units) plugin formats for third-party effects. It was built by [Spotify's Audio Intelligence Lab](https://research.atspotify.com/audio-intelligence/) to enable using studio-quality audio effects from within Python and TensorFlow.
 

--- a/pedalboard/io/ReadableAudioFile.h
+++ b/pedalboard/io/ReadableAudioFile.h
@@ -281,7 +281,12 @@ public:
         for (int c = 0; c < numChannels; c++) {
           juce::FloatVectorOperations::convertFixedToFloat(
               channelPointers[c], (const int *)channelPointers[c], scaleFactor,
+#ifdef LINUXX
+              static_cast<size_t>(numSamples));
+#else
               numSamples);
+#endif
+	  //https://github.com/Tencent/rapidjson/issues/873
         }
       }
     }

--- a/pedalboard/io/ReadableAudioFile.h
+++ b/pedalboard/io/ReadableAudioFile.h
@@ -281,12 +281,7 @@ public:
         for (int c = 0; c < numChannels; c++) {
           juce::FloatVectorOperations::convertFixedToFloat(
               channelPointers[c], (const int *)channelPointers[c], scaleFactor,
-#ifdef LINUXX
-              static_cast<size_t>(numSamples));
-#else
-              numSamples);
-#endif
-	  //https://github.com/Tencent/rapidjson/issues/873
+              static_cast<int>(numSamples));
         }
       }
     }


### PR DESCRIPTION
Problem

This is a solution for https://github.com/spotify/pedalboard/issues/120
When building on RedHat, and possibly other linux platforms, the
following error is seen during the C++ compilation

error: call of overloaded ‘convertFixedToFloat
    (float*&, const int*, float&, long long int&)’ is ambiguous

Solution

Conditionally, based on the preprocessor flag LINUX, cast the argument
numSamples to size_t

Result

Compilation of the C++ code will succeed on RedHat