### PR TITLE
Fix pybind11 inheritance chain for IIRFilter subclasses.

### DIFF
--- a/pedalboard/plugins/IIRFilters.h
+++ b/pedalboard/plugins/IIRFilters.h
@@ -120,7 +120,14 @@ public:
 };
 
 inline void init_iir_filters(py::module &m) {
-  py::class_<HighShelfFilter<float>, Plugin,
+  py::class_<IIRFilter<float>, Plugin, std::shared_ptr<IIRFilter<float>>>(
+      m, "IIRFilter",
+      "An abstract class that implements various kinds of infinite impulse "
+      "response (IIR) filter designs. This should not be used directly; use "
+      ":class:`HighShelfFilter`, :class:`LowShelfFilter`, or "
+      ":class:`PeakFilter` directly instead.");
+
+  py::class_<HighShelfFilter<float>, IIRFilter<float>,
              std::shared_ptr<HighShelfFilter<float>>>(
       m, "HighShelfFilter",
       "A high shelf filter plugin with variable Q and gain, as would be used "
@@ -154,7 +161,7 @@ inline void init_iir_filters(py::module &m) {
       .def_property("q", &HighShelfFilter<float>::getQ,
                     &HighShelfFilter<float>::setQ);
 
-  py::class_<LowShelfFilter<float>, Plugin,
+  py::class_<LowShelfFilter<float>, IIRFilter<float>,
              std::shared_ptr<LowShelfFilter<float>>>(
       m, "LowShelfFilter",
       "A low shelf filter with variable Q and gain, as would be used in an "
@@ -188,7 +195,8 @@ inline void init_iir_filters(py::module &m) {
       .def_property("q", &LowShelfFilter<float>::getQ,
                     &LowShelfFilter<float>::setQ);
 
-  py::class_<PeakFilter<float>, Plugin, std::shared_ptr<PeakFilter<float>>>(
+  py::class_<PeakFilter<float>, IIRFilter<float>,
+             std::shared_ptr<PeakFilter<float>>>(
       m, "PeakFilter",
       "A peak (or notch) filter with variable Q and gain, as would be used in "
       "an equalizer. Frequencies around the cutoff frequency will be boosted "

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -125,3 +125,24 @@ def test_q_factor(filter_type, fundamental_hz, sample_rate, num_channels, gain_d
     np.testing.assert_allclose(
         rms(filtered) / rms(sine_wave), db_to_gain(gain_db), rtol=0.1, atol=0.1
     )
+
+
+@pytest.mark.parametrize(
+    "klass",
+    [
+        HighpassFilter,
+        LowpassFilter,
+        HighShelfFilter,
+        LowShelfFilter,
+        PeakFilter,
+    ],
+)
+def test_getters_and_setters(klass):
+    """
+    If any plugins don't inherit from `Plugin` directly on the C++ side,
+    property access will fail. This test makes sure all attributes are accessible.
+    """
+    plugin = klass()
+    for x in dir(plugin):
+        if not x.startswith("_"):
+            getattr(plugin, x)


### PR DESCRIPTION
Fixes #123.