### PR TITLE
INSTALLATION: Tox whitelist should match the virt env in the docs

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -18,7 +18,7 @@ You can set up a virtual environment by navigating to your project directory in 
 ```
 # Create a virtual environment
 python3 -m pip install --user virtualenv 
-python3 -m venv env
+python3 -m venv .venv
 
 # Activate the virtual environment
 source env/bin/activate

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -21,7 +21,7 @@ python3 -m pip install --user virtualenv
 python3 -m venv .venv
 
 # Activate the virtual environment
-source env/bin/activate
+source .venv/bin/activate
 ```
 
 Note: Windows commands are available [here](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/).
@@ -70,7 +70,7 @@ You'll want an IDE to build, run, and debug your code. [Thonny](https://thonny.o
 
 Open a new Python file in your IDE and save it to your project directory. 
 
-Note: creating a virtual environment will create a new directory (env) within your project directory. Save your .py file in the project directory. 
+Note: creating a virtual environment will create a new directory (.venv) within your project directory. Save your .py file in the project directory. 
 
 You can now refer to the [interactive demo](https://colab.research.google.com/drive/1bHjhJj1aCoOlXKl_lOfG99Xs3qWVrhch#scrollTo=J3MBH6-5yz97) to understand how audio and effects are called.
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py,docs,check-formatting,lint
 skipsdist = True
 usedevelop = True
+ignore_basepython_conflict=true
 
 [testenv]
 basepython = python3
@@ -51,7 +52,7 @@ commands = flake8
 show-source = true
 max-line-length = 120
 ignore = W503,E203
-exclude = .venv,.tox,.git,dist,doc,*.egg,build
+exclude = .venv,.tox,.git,dist,doc,*.egg,build,vendors
 
 [pytest]
 addopts = -v --cov=pedalboard --cov-report=xml:cobertura/coverage.xml --cov-report=term-missing --junitxml=junit.xml

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist = py,docs,check-formatting,lint
 skipsdist = True
 usedevelop = True
-ignore_basepython_conflict=true
 
 [testenv]
 basepython = python3


### PR DESCRIPTION
Problem
    
The tox linter has a whilelist of directories which will not get
scanned. The virtual environment that is whitelisted does not match the
virtual env created in the INSTALLATION doc
    
Solution
    
Change the virtual environement creation instructions to match the
directory in the tox configuration.

I chose to use .venv as the directory, assuming that as that was the one
used in the tox.ini config then that is likely to be the one that developers
are already using. vendors was also added as linting issues were found 
under lame, which pedalboard has no control over