### PR TITLE
Fix exceptions and crashes when including None in a PluginContainer.

### DIFF
--- a/docs/_static/documentation_options.js
+++ b/docs/_static/documentation_options.js
@@ -1,6 +1,6 @@
 var DOCUMENTATION_OPTIONS = {
     URL_ROOT: document.getElementById("documentation_options").getAttribute('data-url_root'),
-    VERSION: 'v0.5.8',
+    VERSION: 'v0.5.9',
     LANGUAGE: 'None',
     COLLAPSE_INDEX: false,
     BUILDER: 'html',

--- a/docs/compatibility.html
+++ b/docs/compatibility.html
@@ -10,7 +10,7 @@
   
 <meta property="og:url" content="https://spotify.github.io/pedalboard/compatibility.html" />
   
-<meta property="og:site_name" content="Pedalboard v0.5.8 Documentation" />
+<meta property="og:site_name" content="Pedalboard v0.5.9 Documentation" />
   
 <meta property="og:description" content="pedalboard allows loading VST3® and Audio Unit plugins, which could contain any code. Most plugins that have been tested work just fine with pedalboard, but some plugins may not work with pedalboar..." />
   
@@ -20,7 +20,7 @@
   <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="next" title="Pedalboard Internals" href="internals.html" /><link rel="prev" title="Frequently Asked Questions" href="faq.html" />
 
     <link rel="shortcut icon" href="_static/favicon.ico"/><meta name="generator" content="sphinx-4.4.0, furo 2022.06.21"/>
-        <title>Plugin Compatibility - Pedalboard v0.5.8 Documentation</title>
+        <title>Plugin Compatibility - Pedalboard v0.5.9 Documentation</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?digest=40978830699223671f4072448e654b5958f38b89" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css" />
@@ -138,7 +138,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">Pedalboard v0.5.8 Documentation</div></a>
+      <a href="index.html"><div class="brand">Pedalboard v0.5.9 Documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -164,7 +164,7 @@
     <img class="sidebar-logo" src="_static/pedalboard_logo_small.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">Pedalboard v0.5.8 Documentation</span>
+  <span class="sidebar-brand-text">Pedalboard v0.5.9 Documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder=Search name="q" aria-label="Search">

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -10,7 +10,7 @@
   
 <meta property="og:url" content="https://spotify.github.io/pedalboard/examples.html" />
   
-<meta property="og:site_name" content="Pedalboard v0.5.8 Documentation" />
+<meta property="og:site_name" content="Pedalboard v0.5.9 Documentation" />
   
 <meta property="og:description" content="Quick start: Making a guitar-style pedalboard: Using VST3® or Audio Unit plugins: Creating parallel effects chains: This example creates a delayed pitch-shift effect by running multiple Pedalboards..." />
   
@@ -20,7 +20,7 @@
   <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="next" title="Frequently Asked Questions" href="faq.html" /><link rel="prev" title="The pedalboard.io API" href="reference/pedalboard.io.html" />
 
     <link rel="shortcut icon" href="_static/favicon.ico"/><meta name="generator" content="sphinx-4.4.0, furo 2022.06.21"/>
-        <title>Examples - Pedalboard v0.5.8 Documentation</title>
+        <title>Examples - Pedalboard v0.5.9 Documentation</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?digest=40978830699223671f4072448e654b5958f38b89" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css" />
@@ -138,7 +138,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">Pedalboard v0.5.8 Documentation</div></a>
+      <a href="index.html"><div class="brand">Pedalboard v0.5.9 Documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -164,7 +164,7 @@
     <img class="sidebar-logo" src="_static/pedalboard_logo_small.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">Pedalboard v0.5.8 Documentation</span>
+  <span class="sidebar-brand-text">Pedalboard v0.5.9 Documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder=Search name="q" aria-label="Search">

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -10,7 +10,7 @@
   
 <meta property="og:url" content="https://spotify.github.io/pedalboard/faq.html" />
   
-<meta property="og:site_name" content="Pedalboard v0.5.8 Documentation" />
+<meta property="og:site_name" content="Pedalboard v0.5.9 Documentation" />
   
 <meta property="og:description" content="Can Pedalboard be used with live (real-time) audio?: Technically, yes, Pedalboard could be used with live audio input/output. See: Pull request #98, which contains an experimental live audio interf..." />
   
@@ -20,7 +20,7 @@
   <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="next" title="Plugin Compatibility" href="compatibility.html" /><link rel="prev" title="Examples" href="examples.html" />
 
     <link rel="shortcut icon" href="_static/favicon.ico"/><meta name="generator" content="sphinx-4.4.0, furo 2022.06.21"/>
-        <title>Frequently Asked Questions - Pedalboard v0.5.8 Documentation</title>
+        <title>Frequently Asked Questions - Pedalboard v0.5.9 Documentation</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?digest=40978830699223671f4072448e654b5958f38b89" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css" />
@@ -138,7 +138,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">Pedalboard v0.5.8 Documentation</div></a>
+      <a href="index.html"><div class="brand">Pedalboard v0.5.9 Documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -164,7 +164,7 @@
     <img class="sidebar-logo" src="_static/pedalboard_logo_small.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">Pedalboard v0.5.8 Documentation</span>
+  <span class="sidebar-brand-text">Pedalboard v0.5.9 Documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder=Search name="q" aria-label="Search">

--- a/docs/genindex.html
+++ b/docs/genindex.html
@@ -4,7 +4,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <meta name="color-scheme" content="light dark"><link rel="index" title="Index" href="#" /><link rel="search" title="Search" href="search.html" />
 
-    <link rel="shortcut icon" href="_static/favicon.ico"/><meta name="generator" content="sphinx-4.4.0, furo 2022.06.21"/><title>Index - Pedalboard v0.5.8 Documentation</title>
+    <link rel="shortcut icon" href="_static/favicon.ico"/><meta name="generator" content="sphinx-4.4.0, furo 2022.06.21"/><title>Index - Pedalboard v0.5.9 Documentation</title>
 <link rel="stylesheet" type="text/css" href="_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?digest=40978830699223671f4072448e654b5958f38b89" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css" />
@@ -122,7 +122,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">Pedalboard v0.5.8 Documentation</div></a>
+      <a href="index.html"><div class="brand">Pedalboard v0.5.9 Documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -148,7 +148,7 @@
     <img class="sidebar-logo" src="_static/pedalboard_logo_small.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">Pedalboard v0.5.8 Documentation</span>
+  <span class="sidebar-brand-text">Pedalboard v0.5.9 Documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder=Search name="q" aria-label="Search">

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,7 @@
   
 <meta property="og:url" content="https://spotify.github.io/pedalboard/index.html" />
   
-<meta property="og:site_name" content="Pedalboard v0.5.8 Documentation" />
+<meta property="og:site_name" content="Pedalboard v0.5.9 Documentation" />
   
 <meta property="og:description" content="🎛 🔊 Documentation for Pedalboard: A Python library for working with audio." />
   
@@ -20,7 +20,7 @@
   <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="next" title="The pedalboard API" href="reference/pedalboard.html" />
 
     <link rel="shortcut icon" href="_static/favicon.ico"/><meta name="generator" content="sphinx-4.4.0, furo 2022.06.21"/>
-        <title>Pedalboard v0.5.8 Documentation</title>
+        <title>Pedalboard v0.5.9 Documentation</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?digest=40978830699223671f4072448e654b5958f38b89" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css" />
@@ -138,7 +138,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="#"><div class="brand">Pedalboard v0.5.8 Documentation</div></a>
+      <a href="#"><div class="brand">Pedalboard v0.5.9 Documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -164,7 +164,7 @@
     <img class="sidebar-logo" src="_static/pedalboard_logo_small.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">Pedalboard v0.5.8 Documentation</span>
+  <span class="sidebar-brand-text">Pedalboard v0.5.9 Documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder=Search name="q" aria-label="Search">

--- a/docs/internals.html
+++ b/docs/internals.html
@@ -10,7 +10,7 @@
   
 <meta property="og:url" content="https://spotify.github.io/pedalboard/internals.html" />
   
-<meta property="og:site_name" content="Pedalboard v0.5.8 Documentation" />
+<meta property="og:site_name" content="Pedalboard v0.5.9 Documentation" />
   
 <meta property="og:description" content="Pedalboard is a Python wrapper around JUCE, an open-source cross-platform C++ library for developing audio applications. Most of Pedalboard is written in C++ using pybind11, a library for binding C..." />
   
@@ -20,7 +20,7 @@
   <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="next" title="License" href="license.html" /><link rel="prev" title="Plugin Compatibility" href="compatibility.html" />
 
     <link rel="shortcut icon" href="_static/favicon.ico"/><meta name="generator" content="sphinx-4.4.0, furo 2022.06.21"/>
-        <title>Pedalboard Internals - Pedalboard v0.5.8 Documentation</title>
+        <title>Pedalboard Internals - Pedalboard v0.5.9 Documentation</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?digest=40978830699223671f4072448e654b5958f38b89" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css" />
@@ -138,7 +138,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">Pedalboard v0.5.8 Documentation</div></a>
+      <a href="index.html"><div class="brand">Pedalboard v0.5.9 Documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -164,7 +164,7 @@
     <img class="sidebar-logo" src="_static/pedalboard_logo_small.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">Pedalboard v0.5.8 Documentation</span>
+  <span class="sidebar-brand-text">Pedalboard v0.5.9 Documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder=Search name="q" aria-label="Search">

--- a/docs/license.html
+++ b/docs/license.html
@@ -10,7 +10,7 @@
   
 <meta property="og:url" content="https://spotify.github.io/pedalboard/license.html" />
   
-<meta property="og:site_name" content="Pedalboard v0.5.8 Documentation" />
+<meta property="og:site_name" content="Pedalboard v0.5.9 Documentation" />
   
 <meta property="og:description" content="pedalboard is Copyright 2021-2022 Spotify AB. pedalboard is licensed under the GNU General Public License v3. pedalboard includes a number of libraries that are statically compiled, and which carry..." />
   
@@ -20,7 +20,7 @@
   <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="prev" title="Pedalboard Internals" href="internals.html" />
 
     <link rel="shortcut icon" href="_static/favicon.ico"/><meta name="generator" content="sphinx-4.4.0, furo 2022.06.21"/>
-        <title>License - Pedalboard v0.5.8 Documentation</title>
+        <title>License - Pedalboard v0.5.9 Documentation</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?digest=40978830699223671f4072448e654b5958f38b89" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css" />
@@ -138,7 +138,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">Pedalboard v0.5.8 Documentation</div></a>
+      <a href="index.html"><div class="brand">Pedalboard v0.5.9 Documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -164,7 +164,7 @@
     <img class="sidebar-logo" src="_static/pedalboard_logo_small.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">Pedalboard v0.5.8 Documentation</span>
+  <span class="sidebar-brand-text">Pedalboard v0.5.9 Documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder=Search name="q" aria-label="Search">

--- a/docs/py-modindex.html
+++ b/docs/py-modindex.html
@@ -4,7 +4,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <meta name="color-scheme" content="light dark"><link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" />
 
-    <link rel="shortcut icon" href="_static/favicon.ico"/><meta name="generator" content="sphinx-4.4.0, furo 2022.06.21"/><title>Python Module Index - Pedalboard v0.5.8 Documentation</title>
+    <link rel="shortcut icon" href="_static/favicon.ico"/><meta name="generator" content="sphinx-4.4.0, furo 2022.06.21"/><title>Python Module Index - Pedalboard v0.5.9 Documentation</title>
 <link rel="stylesheet" type="text/css" href="_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?digest=40978830699223671f4072448e654b5958f38b89" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css" />
@@ -122,7 +122,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">Pedalboard v0.5.8 Documentation</div></a>
+      <a href="index.html"><div class="brand">Pedalboard v0.5.9 Documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -148,7 +148,7 @@
     <img class="sidebar-logo" src="_static/pedalboard_logo_small.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">Pedalboard v0.5.8 Documentation</span>
+  <span class="sidebar-brand-text">Pedalboard v0.5.9 Documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder=Search name="q" aria-label="Search">

--- a/docs/reference/pedalboard.html
+++ b/docs/reference/pedalboard.html
@@ -10,7 +10,7 @@
   
 <meta property="og:url" content="https://spotify.github.io/pedalboard/reference/pedalboard.html" />
   
-<meta property="og:site_name" content="Pedalboard v0.5.8 Documentation" />
+<meta property="og:site_name" content="Pedalboard v0.5.9 Documentation" />
   
 <meta property="og:description" content="This module provides classes and functions for adding effects to audio. Most classes in this module are subclasses of Plugin, each of which allows applying effects to an audio buffer or stream. For..." />
   
@@ -20,7 +20,7 @@
   <link rel="index" title="Index" href="../genindex.html" /><link rel="search" title="Search" href="../search.html" /><link rel="next" title="The pedalboard.io API" href="pedalboard.io.html" /><link rel="prev" title="Features" href="../index.html" />
 
     <link rel="shortcut icon" href="../_static/favicon.ico"/><meta name="generator" content="sphinx-4.4.0, furo 2022.06.21"/>
-        <title>The pedalboard API - Pedalboard v0.5.8 Documentation</title>
+        <title>The pedalboard API - Pedalboard v0.5.9 Documentation</title>
       <link rel="stylesheet" type="text/css" href="../_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="../_static/styles/furo.css?digest=40978830699223671f4072448e654b5958f38b89" />
     <link rel="stylesheet" type="text/css" href="../_static/copybutton.css" />
@@ -138,7 +138,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="../index.html"><div class="brand">Pedalboard v0.5.8 Documentation</div></a>
+      <a href="../index.html"><div class="brand">Pedalboard v0.5.9 Documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -164,7 +164,7 @@
     <img class="sidebar-logo" src="../_static/pedalboard_logo_small.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">Pedalboard v0.5.8 Documentation</span>
+  <span class="sidebar-brand-text">Pedalboard v0.5.9 Documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="../search.html" role="search">
   <input class="sidebar-search" placeholder=Search name="q" aria-label="Search">

--- a/docs/reference/pedalboard.io.html
+++ b/docs/reference/pedalboard.io.html
@@ -10,7 +10,7 @@
   
 <meta property="og:url" content="https://spotify.github.io/pedalboard/reference/pedalboard.io.html" />
   
-<meta property="og:site_name" content="Pedalboard v0.5.8 Documentation" />
+<meta property="og:site_name" content="Pedalboard v0.5.9 Documentation" />
   
 <meta property="og:description" content="This module provides classes and functions for reading and writing audio files. Introduced in v0.5.1." />
   
@@ -20,7 +20,7 @@
   <link rel="index" title="Index" href="../genindex.html" /><link rel="search" title="Search" href="../search.html" /><link rel="next" title="Examples" href="../examples.html" /><link rel="prev" title="The pedalboard API" href="pedalboard.html" />
 
     <link rel="shortcut icon" href="../_static/favicon.ico"/><meta name="generator" content="sphinx-4.4.0, furo 2022.06.21"/>
-        <title>The pedalboard.io API - Pedalboard v0.5.8 Documentation</title>
+        <title>The pedalboard.io API - Pedalboard v0.5.9 Documentation</title>
       <link rel="stylesheet" type="text/css" href="../_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="../_static/styles/furo.css?digest=40978830699223671f4072448e654b5958f38b89" />
     <link rel="stylesheet" type="text/css" href="../_static/copybutton.css" />
@@ -138,7 +138,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="../index.html"><div class="brand">Pedalboard v0.5.8 Documentation</div></a>
+      <a href="../index.html"><div class="brand">Pedalboard v0.5.9 Documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -164,7 +164,7 @@
     <img class="sidebar-logo" src="../_static/pedalboard_logo_small.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">Pedalboard v0.5.8 Documentation</span>
+  <span class="sidebar-brand-text">Pedalboard v0.5.9 Documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="../search.html" role="search">
   <input class="sidebar-search" placeholder=Search name="q" aria-label="Search">

--- a/docs/search.html
+++ b/docs/search.html
@@ -4,7 +4,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <meta name="color-scheme" content="light dark"><link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="#" />
 
-    <link rel="shortcut icon" href="_static/favicon.ico"/><meta name="generator" content="sphinx-4.4.0, furo 2022.06.21"/><title>Search - Pedalboard v0.5.8 Documentation</title><link rel="stylesheet" type="text/css" href="_static/pygments.css" />
+    <link rel="shortcut icon" href="_static/favicon.ico"/><meta name="generator" content="sphinx-4.4.0, furo 2022.06.21"/><title>Search - Pedalboard v0.5.9 Documentation</title><link rel="stylesheet" type="text/css" href="_static/pygments.css" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?digest=40978830699223671f4072448e654b5958f38b89" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo-extensions.css?digest=30d1aed668e5c3a91c3e3bf6a60b675221979f0e" />
@@ -121,7 +121,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">Pedalboard v0.5.8 Documentation</div></a>
+      <a href="index.html"><div class="brand">Pedalboard v0.5.9 Documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -147,7 +147,7 @@
     <img class="sidebar-logo" src="_static/pedalboard_logo_small.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">Pedalboard v0.5.8 Documentation</span>
+  <span class="sidebar-brand-text">Pedalboard v0.5.9 Documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="#" role="search">
   <input class="sidebar-search" placeholder=Search name="q" aria-label="Search">

--- a/pedalboard/PluginContainer.h
+++ b/pedalboard/PluginContainer.h
@@ -42,6 +42,10 @@ public:
   std::vector<std::shared_ptr<Plugin>> getAllPlugins() {
     std::vector<std::shared_ptr<Plugin>> flatList;
     for (auto plugin : plugins) {
+      if (!plugin) {
+        continue;
+      }
+
       flatList.push_back(plugin);
       if (auto *pluginContainer =
               dynamic_cast<PluginContainer *>(plugin.get())) {

--- a/pedalboard/plugins/Chain.h
+++ b/pedalboard/plugins/Chain.h
@@ -34,8 +34,11 @@ public:
   virtual ~Chain(){};
 
   virtual void prepare(const juce::dsp::ProcessSpec &spec) {
-    for (auto plugin : plugins)
-      plugin->prepare(spec);
+    for (auto plugin : plugins) {
+      if (plugin) {
+        plugin->prepare(spec);
+      }
+    }
     lastSpec = spec;
   }
 
@@ -56,14 +59,20 @@ public:
   }
 
   virtual void reset() {
-    for (auto plugin : plugins)
-      plugin->reset();
+    for (auto plugin : plugins) {
+      if (plugin) {
+        plugin->reset();
+      }
+    }
   }
 
   virtual int getLatencyHint() {
     int hint = 0;
-    for (auto plugin : plugins)
-      hint += plugin->getLatencyHint();
+    for (auto plugin : plugins) {
+      if (plugin) {
+        hint += plugin->getLatencyHint();
+      }
+    }
     return hint;
   }
 };

--- a/pedalboard/plugins/Mix.h
+++ b/pedalboard/plugins/Mix.h
@@ -35,8 +35,11 @@ public:
   virtual ~Mix(){};
 
   virtual void prepare(const juce::dsp::ProcessSpec &spec) {
-    for (auto plugin : plugins)
-      plugin->prepare(spec);
+    for (auto plugin : plugins) {
+      if (plugin) {
+        plugin->prepare(spec);
+      }
+    }
 
     int maximumBufferSize = getLatencyHint() + spec.maximumBlockSize;
     for (auto &buffer : pluginBuffers)
@@ -75,7 +78,12 @@ public:
           channelPointers, buffer.getNumChannels(), ioBlock.getNumSamples());
 
       juce::dsp::ProcessContextReplacing<float> subContext(subBlock);
-      int samplesRendered = plugin->process(subContext);
+
+      int samplesRendered = subBlock.getNumSamples();
+
+      if (plugin) {
+        samplesRendered = plugin->process(subContext);
+      }
       samplesAvailablePerPlugin[i] += samplesRendered;
 
       if (samplesRendered < subBlock.getNumSamples()) {
@@ -135,16 +143,23 @@ public:
   }
 
   virtual void reset() {
-    for (auto plugin : plugins)
-      plugin->reset();
+    for (auto plugin : plugins) {
+      if (plugin) {
+        plugin->reset();
+      }
+    }
+
     for (auto buffer : pluginBuffers)
       buffer.clear();
   }
 
   virtual int getLatencyHint() {
     int maxHint = 0;
-    for (auto plugin : plugins)
-      maxHint = std::max(maxHint, plugin->getLatencyHint());
+    for (auto plugin : plugins) {
+      if (plugin) {
+        maxHint = std::max(maxHint, plugin->getLatencyHint());
+      }
+    }
     return maxHint;
   }
 

--- a/pedalboard/version.py
+++ b/pedalboard/version.py
@@ -17,6 +17,6 @@
 
 MAJOR = 0
 MINOR = 5
-PATCH = 8
+PATCH = 9
 
 __version__ = "%d.%d.%d" % (MAJOR, MINOR, PATCH)

--- a/tests/test_mix_and_chain.py
+++ b/tests/test_mix_and_chain.py
@@ -298,3 +298,14 @@ def test_empty_list_is_valid_constructor_arg(cls):
 @pytest.mark.parametrize("cls", [Mix, Chain, Pedalboard])
 def test_no_arg_constructor(cls):
     assert len(cls()) == 0
+
+
+@pytest.mark.parametrize("cls", [Mix, Chain, Pedalboard])
+def test_none_as_argument(cls):
+    container = cls([None])
+    assert len(container) == 1
+    assert container[0] is None
+    sample_rate = 44100
+    noise = np.random.rand(int(NUM_SECONDS * sample_rate))
+    output = container(noise, sample_rate)
+    np.testing.assert_allclose(noise, output)


### PR DESCRIPTION
This PR makes it possible to pass `None` as a plugin to a `Chain([...])`, `Mix([...])`, or `Pedalboard([...])` without crashing or throwing exceptions at processing time. `None` acts as a dummy pass-through plugin, imparting no latency and passing input directly to output.