### PR TITLE
use pb setter instead of juce setter in noisegate

### DIFF
--- a/pedalboard/plugins/NoiseGate.h
+++ b/pedalboard/plugins/NoiseGate.h
@@ -40,10 +40,10 @@ inline void init_noisegate(py::module &m) {
       .def(py::init([](float thresholddB, float ratio, float attackMs,
                        float releaseMs) {
              auto plugin = std::make_unique<NoiseGate<float>>();
-             plugin->getDSP().setThreshold(thresholddB);
-             plugin->getDSP().setRatio(ratio);
-             plugin->getDSP().setAttack(attackMs);
-             plugin->getDSP().setRelease(releaseMs);
+             plugin->setThreshold(thresholddB);
+             plugin->setRatio(ratio);
+             plugin->setAttack(attackMs);
+             plugin->setRelease(releaseMs);
              return plugin;
            }),
            py::arg("threshold_db") = -100.0, py::arg("ratio") = 10,


### PR DESCRIPTION
NoiseGate: The `init`-function wrongly uses JUCEs setter

Problem

After calling `NoiseGate()`, the parameters passed to `init` only get set in JUCEs `NoiseGate`-class and not in the pedalboard `NoiseGate`-class. This can be easily tested with:

```python
noise_gate = pb.NoiseGate(threshold_db=-40, ratio=10, attack_ms=100, release_ms=100)
noise_gate.__repr__
```
Output:
`>>> <bound method PyCapsule.__repr__ of <pedalboard.NoiseGate threshold_db=0 ratio=0 attack_ms=0 release_ms=0 at 0x4905f00>>`

Solution

Use pedalboards `NoiseGate` setter-function, which in turn also sets the parameter in the downstream JUCE class.