### PR TITLE
Fix parameter inference for Valhalla Supermassive.

### DIFF
--- a/pedalboard/pedalboard.py
+++ b/pedalboard/pedalboard.py
@@ -220,10 +220,10 @@ class AudioProcessorParameter(object):
         self.ranges: Dict[Tuple[float, float], Union[str, float, bool]] = {}
 
         with self.__get_cpp_parameter() as cpp_parameter:
-            start_of_range: float = 0
-            text_value: Optional[str] = None
-
             for fetch_slow in (False, True):
+                start_of_range: float = 0
+                text_value: Optional[str] = None
+
                 self.ranges = {}
                 for x in range(0, search_steps + 1):
                     raw_value = x / search_steps

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -420,6 +420,9 @@ def test_float_parameters(plugin_filename: str, parameter_name: str):
         _min, _max, _ = parameter_value.range
         step_size = parameter_value.step_size
         new_values = np.arange(_min, _max, step_size)
+        # Because sometimes np.arange(_min, _max) gives values _slightly outside_
+        # of [_min, _max] thanks to floating point:
+        new_values = [max(_min, min(_max, new_value)) for new_value in new_values]
 
     epsilon = parameter_value.step_size or parameter_value.approximate_step_size or 0.001
 


### PR DESCRIPTION
Tests were also inadvertently broken by #148 when including Supermassive in the CI test suite.