### PR TITLE
Add explicit Numpy import to workaround GIL deadlock with asyncio.

### DIFF
--- a/pedalboard/__init__.py
+++ b/pedalboard/__init__.py
@@ -14,6 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# In certain situations (including when using asyncio), Pedalboard's C++ code will
+# implicitly and lazily import NumPy via its Pybind11 bindings. This lazy import
+# can sometimes (!) cause a deadlock on the GIL if multiple threads are attempting
+# it simultaneously. To work around this, we preload Numpy into the current Python
+# process so that Pybind11's lazy import is effectively a no-op.
+import numpy  # noqa
+
 try:
     from pedalboard_native import *  # noqa: F403, F401
 except ImportError as _e:

--- a/pedalboard/io/__init__.py
+++ b/pedalboard/io/__init__.py
@@ -1,1 +1,7 @@
+# In certain situations (including when using asyncio), Pedalboard's C++ code will
+# implicitly and lazily import NumPy via its Pybind11 bindings. This lazy import
+# can sometimes (!) cause a deadlock on the GIL if multiple threads are attempting
+# it simultaneously. To work around this, we preload Numpy into the current Python
+# process so that Pybind11's lazy import is effectively a no-op.
+import numpy  # noqa
 from pedalboard_native.io import *  # noqa: F403, F401


### PR DESCRIPTION
See #154.

In certain situations (including when using asyncio), Pedalboard's C++ code will implicitly and lazily import NumPy via its Pybind11 bindings. This lazy import can sometimes (!) cause a deadlock on the GIL if multiple threads are attempting it simultaneously. To work around this, we preload Numpy into the current Python process so that Pybind11's lazy import is effectively a no-op.

No tests included here: the buggy behaviour occurs when `numpy` isn't loaded into the running Python process, which is very hard to simulate in test without running a subprocess and writing a very elaborate (and likely brittle) test.