### PR TITLE
Explicitly ignore "dB" when used as a value suffix.

### DIFF
--- a/pedalboard/pedalboard.py
+++ b/pedalboard/pedalboard.py
@@ -42,7 +42,9 @@ class Pedalboard(Chain):
         )
 
 
-FLOAT_SUFFIXES_TO_IGNORE = set(["x", "%", "*", ",", ".", "hz", "ms", "sec", "seconds", "dB"])
+FLOAT_SUFFIXES_TO_IGNORE = set([
+    "x", "%", "*", ",", ".", "hz", "ms", "sec", "seconds", "dB", "dBTP"
+])
 
 
 def strip_common_float_suffixes(s: Union[float, str]) -> Union[float, str]:

--- a/pedalboard/pedalboard.py
+++ b/pedalboard/pedalboard.py
@@ -42,9 +42,9 @@ class Pedalboard(Chain):
         )
 
 
-FLOAT_SUFFIXES_TO_IGNORE = set([
-    "x", "%", "*", ",", ".", "hz", "ms", "sec", "seconds", "dB", "dBTP"
-])
+FLOAT_SUFFIXES_TO_IGNORE = set(
+    ["x", "%", "*", ",", ".", "hz", "ms", "sec", "seconds", "dB", "dBTP"]
+)
 
 
 def strip_common_float_suffixes(s: Union[float, str]) -> Union[float, str]:

--- a/pedalboard/pedalboard.py
+++ b/pedalboard/pedalboard.py
@@ -42,7 +42,7 @@ class Pedalboard(Chain):
         )
 
 
-FLOAT_SUFFIXES_TO_IGNORE = set(["x", "%", "*", ",", ".", "hz", "ms", "sec", "seconds"])
+FLOAT_SUFFIXES_TO_IGNORE = set(["x", "%", "*", ",", ".", "hz", "ms", "sec", "seconds", "dB"])
 
 
 def strip_common_float_suffixes(s: Union[float, str]) -> Union[float, str]:

--- a/pedalboard/version.py
+++ b/pedalboard/version.py
@@ -17,6 +17,6 @@
 
 MAJOR = 0
 MINOR = 6
-PATCH = 4
+PATCH = 5
 
 __version__ = "%d.%d.%d" % (MAJOR, MINOR, PATCH)


### PR DESCRIPTION
Should fix value rounding issues with plugins like FabFilter.