### PR TITLE
Support reading more than 2^31 frames of audio at a time.

### DIFF
--- a/pedalboard/io/ReadableAudioFile.h
+++ b/pedalboard/io/ReadableAudioFile.h
@@ -216,11 +216,11 @@ public:
       throw std::runtime_error("I/O operation on a closed file.");
 
     // Allocate a buffer to return of up to numSamples:
-    int numChannels = reader->numChannels;
+    long long numChannels = reader->numChannels;
     numSamples =
         std::min(numSamples, reader->lengthInSamples - currentPosition);
     py::array_t<float> buffer =
-        py::array_t<float>({(int)numChannels, (int)numSamples});
+        py::array_t<float>({(long long)numChannels, (long long)numSamples});
 
     py::buffer_info outputInfo = buffer.request();
 
@@ -234,7 +234,7 @@ public:
                   numChannels * numSamples * sizeof(float));
 
       float **channelPointers = (float **)alloca(numChannels * sizeof(float *));
-      for (int c = 0; c < numChannels; c++) {
+      for (long long c = 0; c < numChannels; c++) {
         channelPointers[c] = ((float *)outputInfo.ptr) + (numSamples * c);
       }
 
@@ -283,7 +283,7 @@ public:
         }
         float scaleFactor = 1.0f / static_cast<float>(maxValueAsInt);
 
-        for (int c = 0; c < numChannels; c++) {
+        for (long long c = 0; c < numChannels; c++) {
           juce::FloatVectorOperations::convertFixedToFloat(
               channelPointers[c], (const int *)channelPointers[c], scaleFactor,
               static_cast<int>(numSamples));
@@ -333,11 +333,11 @@ public:
     }
 
     // Allocate a buffer to return of up to numSamples:
-    int numChannels = reader->numChannels;
+    long long numChannels = reader->numChannels;
     numSamples =
         std::min(numSamples, reader->lengthInSamples - currentPosition);
-    py::array_t<SampleType> buffer =
-        py::array_t<SampleType>({(int)numChannels, (int)numSamples});
+    py::array_t<SampleType> buffer = py::array_t<SampleType>(
+        {(long long)numChannels, (long long)numSamples});
 
     py::buffer_info outputInfo = buffer.request();
 
@@ -354,7 +354,7 @@ public:
                     numChannels * numSamples * sizeof(SampleType));
 
         int **channelPointers = (int **)alloca(numChannels * sizeof(int *));
-        for (int c = 0; c < numChannels; c++) {
+        for (long long c = 0; c < numChannels; c++) {
           channelPointers[c] = ((int *)outputInfo.ptr) + (numSamples * c);
         }
 
@@ -373,11 +373,11 @@ public:
         int **channelPointers = (int **)alloca(numChannels * sizeof(int *));
         for (long long startSample = 0; startSample < numSamples;
              startSample += DEFAULT_AUDIO_BUFFER_SIZE_FRAMES) {
-          int samplesToRead =
+          long long samplesToRead =
               std::min(numSamples - startSample,
                        (long long)DEFAULT_AUDIO_BUFFER_SIZE_FRAMES);
 
-          for (int c = 0; c < numChannels; c++) {
+          for (long long c = 0; c < numChannels; c++) {
             intBuffers[c].resize(samplesToRead);
             channelPointers[c] = intBuffers[c].data();
           }
@@ -394,10 +394,10 @@ public:
 
           // Convert the data in intBuffers to the output format:
           char shift = 32 - reader->bitsPerSample;
-          for (int c = 0; c < numChannels; c++) {
+          for (long long c = 0; c < numChannels; c++) {
             SampleType *outputChannelPointer =
                 (((SampleType *)outputInfo.ptr) + (c * numSamples));
-            for (int i = 0; i < samplesToRead; i++) {
+            for (long long i = 0; i < samplesToRead; i++) {
               outputChannelPointer[startSample + i] = intBuffers[c][i] >> shift;
             }
           }


### PR DESCRIPTION
When reading audio via `pedalboard.io.AudioFile`, reads of over 2<sup>31</sup> frames (2,147,483,648, or about 13 hours at 44.1kHz) cause cryptic errors due to integer overflow.

This PR fixes the issue by using `long long`, allowing for up to 2<sup>63</sup> frames to be read at once; enough to read 6.6 million years' worth of audio in a single `read` call. _That ought to be [enough for everyone](https://skeptics.stackexchange.com/questions/2863/did-bill-gates-say-640k-ought-to-be-enough-for-everyone)._