### PR TITLE
Allow parsing MP3 file-like objects without a .name parameter.

### DIFF
--- a/pedalboard/io/ReadableAudioFile.h
+++ b/pedalboard/io/ReadableAudioFile.h
@@ -53,17 +53,6 @@ public:
     if (!reader) {
       // This is slower but more thorough:
       reader.reset(formatManager.createReaderFor(file.createInputStream()));
-
-      // Known bug: the juce::MP3Reader class will parse formats that are not
-      // MP3 and pretend like they are, producing garbage output. For now, if we
-      // parse MP3 from an input stream that's not explicitly got ".mp3" on the
-      // end, ignore it.
-      if (reader && reader->getFormatName() == "MP3 file") {
-        throw std::domain_error(
-            "Failed to open audio file: file \"" + filename +
-            "\" does not seem to be of a known or supported format. (If trying "
-            "to open an MP3 file, ensure the filename ends with '.mp3'.)");
-      }
     }
 
     if (!reader)
@@ -105,26 +94,6 @@ public:
               "Input file-like object did not seek to the expected position. "
               "The provided file-like object must be fully seekable to allow "
               "reading audio files.");
-        }
-      }
-
-      // Known bug: the juce::MP3Reader class will parse formats that are not
-      // MP3 and pretend like they are, producing garbage output. For now, if we
-      // parse MP3 from an input stream that's not explicitly got ".mp3" on the
-      // end, ignore it.
-      if (reader && reader->getFormatName() == "MP3 file") {
-        bool fileLooksLikeAnMP3 = false;
-        if (auto filename = getPythonInputStream()->getFilename()) {
-          fileLooksLikeAnMP3 = juce::File(*filename).hasFileExtension("mp3");
-        }
-
-        if (!fileLooksLikeAnMP3) {
-          PythonException::raise();
-          throw std::domain_error(
-              "Failed to open audio file-like object: stream does not seem to "
-              "contain a known or supported format. (If trying to open an MP3 "
-              "file, pass a file-like with a \"name\" attribute ending with "
-              "\".mp3\".)");
         }
       }
     }

--- a/pedalboard/juce_overrides/juce_PatchedMP3AudioFormat.cpp
+++ b/pedalboard/juce_overrides/juce_PatchedMP3AudioFormat.cpp
@@ -2107,7 +2107,10 @@ private:
     uint32 header = 0;
 
     for (;;) {
-      if (stream.isExhausted() || stream.getPosition() > oldPos + 32768) {
+      auto streamPos = stream.getPosition();
+      bool isParsingFirstFrame = streamPos == 0;
+
+      if (stream.isExhausted() || streamPos > oldPos + 32768) {
         offset = -1;
         break;
       }
@@ -2132,7 +2135,6 @@ private:
           break;
       }
 
-      bool isParsingFirstFrame = stream.getPosition() == 0;
       if (isParsingFirstFrame) {
         // If we're parsing the first frame of a file/stream, that frame must be
         // at the start of the stream. This prevents accidentally parsing .mp4

--- a/pedalboard/juce_overrides/juce_PatchedMP3AudioFormat.cpp
+++ b/pedalboard/juce_overrides/juce_PatchedMP3AudioFormat.cpp
@@ -2132,6 +2132,14 @@ private:
           break;
       }
 
+      bool isParsingFirstFrame = stream.getPosition() == 0;
+      if (isParsingFirstFrame) {
+        // If we're parsing the first frame of a file/stream, that frame must be
+        // at the start of the stream. This prevents accidentally parsing .mp4
+        // files (among others) as MP3 files that start with junk.
+        break;
+      }
+
       ++offset;
     }
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -344,8 +344,10 @@ def test_read_from_seekable_stream(
     "mp3_filename",
     [f for f in sum(TEST_AUDIO_FILES.values(), []) if f.endswith("mp3")],
 )
-def test_read_mp3_from_named_stream(mp3_filename: str):
-    with pedalboard.io.AudioFile(open(mp3_filename, "rb")) as af:
+def test_read_mp3_from_unnamed_stream(mp3_filename: str):
+    with open(mp3_filename, "rb") as f:
+        file_like = io.BytesIO(f.read())
+    with pedalboard.io.AudioFile(file_like) as af:
         assert af is not None
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -66,6 +66,15 @@ UNSUPPORTED_FILENAMES = [
     )
 ]
 
+UNSUPPORTED_CROSS_PLATFORM_FILENAMES = [
+    filename
+    for filename in sum(TEST_AUDIO_FILES.values(), [])
+    if not any(
+        filename.endswith(extension)
+        for extension in pedalboard.io.get_supported_read_formats(cross_platform_formats_only=True)
+    )
+]
+
 
 def get_tolerance_for_format_and_bit_depth(extension: str, input_format, file_dtype: str) -> float:
     if not extension.startswith("."):
@@ -485,10 +494,16 @@ def test_fails_gracefully():
             pass
 
 
-@pytest.mark.parametrize("audio_filename", UNSUPPORTED_FILENAMES)
-def test_fails_on_unsupported_format(audio_filename: str):
+@pytest.mark.parametrize(
+    "cross_platform_formats_only,audio_filename",
+    [(False, f) for f in UNSUPPORTED_FILENAMES]
+    + [(True, f) for f in UNSUPPORTED_CROSS_PLATFORM_FILENAMES],
+)
+def test_fails_on_unsupported_format(cross_platform_formats_only: bool, audio_filename: str):
     with pytest.raises(ValueError):
-        af = pedalboard.io.AudioFile(audio_filename)
+        af = pedalboard.io.ReadableAudioFile(
+            audio_filename, cross_platform_formats_only=cross_platform_formats_only
+        )
         assert not af
 
 


### PR DESCRIPTION
Due to an underlying bug in JUCE's MP3 parser, Pedalboard was previously mis-identifying MP4 streams (and perhaps other formats too) as MP3 files, as long as a valid-looking MP3 header appeared in the first 32kB of the file. Pedalboard would detect this condition and throw an error like:
```
Failed to open audio file: file does not seem to be of a known or supported format. (If trying to open an MP3 file, ensure the filename ends with '.mp3'.)
```
...forcing the user to specify a format hint on the file-like object by setting its `.name` parameter to something that ends with `.mp3`.

This PR fixes the issue by patching the MP3 parser, which we can now do as we've vendored our own copy as part of #183. After merging and deploying, Pedalboard will no longer require file-like objects containing MP3 data to have `.name` parameters to parse correctly on Linux or Windows.