### PR TITLE
Use the same MP3 parser on macOS, Linux, and Windows.

### DIFF
--- a/pedalboard/io/AudioFile.h
+++ b/pedalboard/io/AudioFile.h
@@ -50,7 +50,7 @@ void registerPedalboardAudioFormats(juce::AudioFormatManager &manager,
     manager.registerFormat(new juce::CoreAudioFormat(), false);
 #endif
   }
-  
+
 #if JUCE_USE_WINDOWS_MEDIA_FORMAT
   manager.registerFormat(new juce::WindowsMediaAudioFormat(), false);
 #endif

--- a/pedalboard/io/AudioFile.h
+++ b/pedalboard/io/AudioFile.h
@@ -40,10 +40,6 @@ void registerPedalboardAudioFormats(juce::AudioFormatManager &manager,
   manager.registerFormat(new juce::OggVorbisAudioFormat(), false);
 #endif
 
-#if JUCE_USE_WINDOWS_MEDIA_FORMAT
-  manager.registerFormat(new juce::WindowsMediaAudioFormat(), false);
-#endif
-
   if (forWriting) {
     // Prefer our own custom MP3 format (which only writes, doesn't read) over
     // PatchedMP3AudioFormat (which only reads, doesn't write)
@@ -54,6 +50,10 @@ void registerPedalboardAudioFormats(juce::AudioFormatManager &manager,
     manager.registerFormat(new juce::CoreAudioFormat(), false);
 #endif
   }
+  
+#if JUCE_USE_WINDOWS_MEDIA_FORMAT
+  manager.registerFormat(new juce::WindowsMediaAudioFormat(), false);
+#endif
 }
 
 class AudioFile {};

--- a/pedalboard/io/AudioFile.h
+++ b/pedalboard/io/AudioFile.h
@@ -28,12 +28,10 @@ static constexpr const unsigned int DEFAULT_AUDIO_BUFFER_SIZE_FRAMES = 8192;
 
 /**
  * Registers audio formats for reading and writing in a deterministic (but
- * configurable) order. On different platforms, different formats are handled by
- * different backends (i.e.: CoreAudioFormat handles MP3 on macOS, but only for
- * reading) so this method allows us to ensure reproducibility in tests.
+ * configurable) order.
  */
 void registerPedalboardAudioFormats(juce::AudioFormatManager &manager,
-                                    bool forWriting, bool crossPlatformOnly) {
+                                    bool forWriting) {
   manager.registerFormat(new juce::WavAudioFormat(), true);
   manager.registerFormat(new juce::AiffAudioFormat(), false);
   manager.registerFormat(new juce::PatchedFlacAudioFormat(), false);
@@ -42,30 +40,20 @@ void registerPedalboardAudioFormats(juce::AudioFormatManager &manager,
   manager.registerFormat(new juce::OggVorbisAudioFormat(), false);
 #endif
 
-  if (forWriting) {
-    // Prefer our own custom MP3 format (which only writes, doesn't read) over
-    // MP3AudioFormat (which only reads, doesn't write)
-    manager.registerFormat(new LameMP3AudioFormat(), false);
-  } else {
-    // On macOS, CoreAudio can read MP3s better (more fault-tolerantly) than
-    // MP3AudioFormat can. But sometimes, we still want to use the built-in MP3
-    // reader so that we can get identical parsing behaviour on both macOS and
-    // Linux. To do so, we use this flag:
-
-    if (crossPlatformOnly) {
-      manager.registerFormat(new juce::PatchedMP3AudioFormat(), false);
-    } else {
-#if JUCE_MAC || JUCE_IOS
-      manager.registerFormat(new juce::CoreAudioFormat(), false);
-#else
-      manager.registerFormat(new juce::PatchedMP3AudioFormat(), false);
-#endif
-    }
-  }
-
 #if JUCE_USE_WINDOWS_MEDIA_FORMAT
   manager.registerFormat(new juce::WindowsMediaAudioFormat(), false);
 #endif
+
+  if (forWriting) {
+    // Prefer our own custom MP3 format (which only writes, doesn't read) over
+    // PatchedMP3AudioFormat (which only reads, doesn't write)
+    manager.registerFormat(new LameMP3AudioFormat(), false);
+  } else {
+    manager.registerFormat(new juce::PatchedMP3AudioFormat(), false);
+#if JUCE_MAC || JUCE_IOS
+    manager.registerFormat(new juce::CoreAudioFormat(), false);
+#endif
+  }
 }
 
 class AudioFile {};

--- a/pedalboard/io/WriteableAudioFile.h
+++ b/pedalboard/io/WriteableAudioFile.h
@@ -248,7 +248,7 @@ public:
                            "non-zero num_channels.");
     }
 
-    registerPedalboardAudioFormats(formatManager, true, false);
+    registerPedalboardAudioFormats(formatManager, true);
 
     std::unique_ptr<juce::OutputStream> outputStream;
     juce::AudioFormat *format = nullptr;
@@ -966,17 +966,14 @@ inline void init_writeable_audio_file(
           "The strings ``\"best\"``, ``\"worst\"``, ``\"fastest\"``, and "
           "``\"slowest\"`` will also work for any codec.");
 
-  m.def(
-      "get_supported_write_formats",
-      [](bool crossPlatformFormatsOnly = false) {
-        // JUCE doesn't support writing other formats out-of-the-box on all
-        // platforms, and there's no easy way to tell which formats are
-        // supported without attempting to create an AudioFileWriter object - so
-        // this list is hardcoded for now.
-        const std::vector<std::string> formats = {".aiff", ".flac", ".ogg",
-                                                  ".wav", ".mp3"};
-        return formats;
-      },
-      py::arg("cross_platform_formats_only") = false);
+  m.def("get_supported_write_formats", []() {
+    // JUCE doesn't support writing other formats out-of-the-box on all
+    // platforms, and there's no easy way to tell which formats are
+    // supported without attempting to create an AudioFileWriter object -
+    // so this list is hardcoded for now.
+    const std::vector<std::string> formats = {".aiff", ".flac", ".ogg", ".wav",
+                                              ".mp3"};
+    return formats;
+  });
 }
 } // namespace Pedalboard


### PR DESCRIPTION
Should make it less likely that we run into another issue like #192, as Linux and macOS MP3 parsing will be identical.