### PR TITLE
Better handle misbehaving file-like objects when writing audio files.

### DIFF
--- a/pedalboard/io/AudioStream.h
+++ b/pedalboard/io/AudioStream.h
@@ -159,7 +159,11 @@ public:
 
   void exit(const py::object &type, const py::object &value,
             const py::object &traceback) {
+    bool shouldThrow = PythonException::isPending();
     stop();
+
+    if (shouldThrow || PythonException::isPending())
+      throw py::error_already_set();
   }
 
   static std::vector<std::string> getDeviceNames(bool isInput) {

--- a/pedalboard/io/PythonOutputStream.h
+++ b/pedalboard/io/PythonOutputStream.h
@@ -84,7 +84,7 @@ public:
 
       int bytesWritten;
       if (writeResponse.is_none()) {
-        // Assume bytesWritten is numBytes if `write` returned 0.
+        // Assume bytesWritten is numBytes if `write` returned None.
         // This shouldn't happen, but sometimes does if the file-like
         // object is not fully compliant with io.RawIOBase.
         bytesWritten = numBytes;
@@ -131,7 +131,7 @@ public:
 
         int bytesWritten;
         if (writeResponse.is_none()) {
-          // Assume bytesWritten is numBytes if `write` returned 0.
+          // Assume bytesWritten is numBytes if `write` returned None.
           // This shouldn't happen, but sometimes does if the file-like
           // object is not fully compliant with io.RawIOBase.
           bytesWritten = chunkSize;

--- a/pedalboard/io/PythonOutputStream.h
+++ b/pedalboard/io/PythonOutputStream.h
@@ -48,6 +48,9 @@ public:
   virtual void flush() noexcept override {
     py::gil_scoped_acquire acquire;
 
+    if (PythonException::isPending())
+      return;
+
     try {
       if (py::hasattr(fileLike, "flush")) {
         fileLike.attr("flush")();
@@ -72,6 +75,9 @@ public:
   virtual bool write(const void *ptr, size_t numBytes) noexcept override {
     py::gil_scoped_acquire acquire;
 
+    if (PythonException::isPending())
+      return false;
+
     try {
       int bytesWritten =
           fileLike.attr("write")(py::bytes((const char *)ptr, numBytes))
@@ -93,6 +99,9 @@ public:
   virtual bool writeRepeatedByte(juce::uint8 byte,
                                  size_t numTimesToRepeat) noexcept override {
     py::gil_scoped_acquire acquire;
+
+    if (PythonException::isPending())
+      return false;
 
     try {
       const size_t maxEffectiveSize = std::min(numTimesToRepeat, (size_t)8192);

--- a/pedalboard/io/ReadableAudioFile.h
+++ b/pedalboard/io/ReadableAudioFile.h
@@ -431,7 +431,11 @@ public:
 
   void exit(const py::object &type, const py::object &value,
             const py::object &traceback) {
+    bool shouldThrow = PythonException::isPending();
     close();
+
+    if (shouldThrow || PythonException::isPending())
+      throw py::error_already_set();
   }
 
 private:

--- a/pedalboard/io/ResampledReadableAudioFile.h
+++ b/pedalboard/io/ResampledReadableAudioFile.h
@@ -224,7 +224,11 @@ public:
 
   void exit(const py::object &type, const py::object &value,
             const py::object &traceback) {
+    bool shouldThrow = PythonException::isPending();
     close();
+
+    if (shouldThrow || PythonException::isPending())
+      throw py::error_already_set();
   }
 
 private:

--- a/pedalboard/io/WriteableAudioFile.h
+++ b/pedalboard/io/WriteableAudioFile.h
@@ -724,7 +724,11 @@ public:
 
   void exit(const py::object &type, const py::object &value,
             const py::object &traceback) {
+    bool shouldThrow = PythonException::isPending();
     close();
+
+    if (shouldThrow || PythonException::isPending())
+      throw py::error_already_set();
   }
 
   PythonOutputStream *getPythonOutputStream() const {


### PR DESCRIPTION
Improvements to error messages discovered when trying to use Pedalboard to write audio files to a TensorFlow `GFile` file handle, which does not properly support seeking when writing (despite being `seekable()`; see https://github.com/tensorflow/tensorflow/issues/32122).

Also includes a small test speed-up around FLAC seeking.