### PR TITLE
Produce more helpful error messages when reading from file-like objects that have been seeked.

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -316,6 +316,29 @@ def test_read_mp3_from_unnamed_stream(mp3_filename: str):
         assert af is not None
 
 
+@pytest.mark.parametrize("extension", pedalboard.io.get_supported_write_formats())
+def test_read_from_end_of_stream_produces_helpful_error_message(extension: str):
+    buf = io.BytesIO()
+    buf.name = f"something.{extension}"
+    with pedalboard.io.AudioFile(buf, "w", 44100, 1) as af:
+        af.write(np.random.rand(44100))
+    buf.seek(len(buf.getvalue()))
+
+    try:
+        with pedalboard.io.AudioFile(buf) as af:
+            assert af.frames >= 44100
+    except Exception as e:
+        assert "end of the stream" in str(e)
+        assert "Try seeking" in str(e)
+
+
+def test_read_from_empty_stream_produces_helpful_error_message():
+    with pytest.raises(ValueError) as exc_info:
+        with pedalboard.io.AudioFile(io.BytesIO()):
+            pass
+    assert "is empty" in str(exc_info.value)
+
+
 def test_file_like_exceptions_propagate():
     audio_filename = FILENAMES_AND_SAMPLERATES[0][0]
     stream = open(audio_filename, "rb")


### PR DESCRIPTION
(cc @CWFred)

Pedalboard supports reading audio from file-like objects. If a file-like object is provided but its position is not at index `0` (i.e.: it has been `seek`-ed or written to without seeking back to the start), Pedalboard will throw an unhelpful `ValueError`:
```python
Failed to open audio file-like object: <_io.BytesIO object at 0x7fd1983f6a40> does not seem to contain a known or supported format. 
```

This PR changes the error message to indicate that the provided file-like object is at its end, or seeked to some other point along its length.