### PR TITLE
Midi, instrument support for vst3 plugins, including in AudioStream.

### DIFF
--- a/pedalboard_native/__init__.pyi
+++ b/pedalboard_native/__init__.pyi
@@ -1007,6 +1007,23 @@ class _VST3Plugin(ExternalPlugin, Plugin):
 
 
         """
+    # def addMidiMessage(midiMessage, sampleNumber: int):
+    #     """Add a midi message to the internal buffer at the specified sample"""
+
+    # def midi_note_on(
+    #     self,
+    #     channel: int = 0, 
+    #     noteNumber: int = 69, 
+    #     velocity: int = 63,
+    #     sampleNumber: int = 0
+    # ) -> bool:
+    #     """add a 'note on' MIDI event to the internal buffer"""
+
+    # def get_midi_events(self) -> int:
+    #     """returns the number of MIDI events in the internal buffer"""
+
+    # def clearMidi(self):
+    #     """clears the internal midi buffer of any and all events"""
     pass
 
 def process(

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -768,3 +768,17 @@ def test_get_plugin_names_from_container(plugin_filename: str):
         raise ValueError("Plugin does not seem to be a .vst3 or .component.")
 
     assert len(names) > 1
+
+
+@pytest.mark.parametrize("plugin_filename", AVAILABLE_PLUGINS_IN_TEST_ENVIRONMENT)
+def test_midi(plugin_filename: str):
+    if not '.vst' in plugin_filename:
+        return #TODO make midi work with .component plugins
+    plugin = load_test_plugin(plugin_filename)
+    assert plugin.get_num_midi_events() == 0
+    assert plugin.midi_note_on()
+    assert plugin.get_num_midi_events() == 1
+    assert plugin.midi_note_off(sampleNumber=16000)
+    assert plugin.get_num_midi_events() == 2
+    plugin.clear_midi()
+    assert plugin.get_num_midi_events() == 0


### PR DESCRIPTION
I wanted to use Pedalboard for a school project involving VST3 instrument plugins, so I have added that functionality in as sensible a manner as I could think of. 

external plugins store an internal `juce::MidiMessageSequence` which can be manipulated via instance methods (e.g. `midi_note_on`). This message sequence then gets split into blocks according to how many samples are passed in, meaning that it is viable both in real-time and otherwise.

I also made adjustments to ExternalPlugin methods to allow VST instrument plugins which have no input bus. 

In working with this I discovered what may be a bug in `AudioStream`, in that certain plugin methods need to be called from the `MessageThread`, however the current Pedalboard implementation calls `plugin->prepare` from the `ChangeObserver` thread, while the main thread is the `MessageThread`. I have fixed this by setting the new thread to be the `MessageThread` and everything works perfectly.

I cannot figure out how to create the .pyi typing files as that functionality seems to be broken right now (running the mypy test command on a fresh clone yields an error relating to overload decorators). Additionally, the post processing file for the stubs does not properly write to the supplied output directory (in fact, much of this file seems suspect to me). I tried adding these manually but it did not work so I have commented those stubs out.

I have not thought of a good way to test VST3 instrument processing without including a VST3 instrument plugin in the repository, which seems like it could become a license issue if not resolved carefully.

I also would like to add more Midi helper methods to `ExternalPlugin` including a way to pass raw Midi data, but I would like these changes reviewed and ideally accepted before I put that time in, as what I have already more than fulfills my personal needs.

I've never used pybind before, nor do I have a ton of C++ experience, so I may have made mistakes along the way, but all tests (save those run by mypy) are passing right now on my local install of this branch. I'll include the file I've been using to test instrument support for clarity on the interface since the type hinting and function signatures are not working without the bindings.
[bbc.py.zip](https://github.com/spotify/pedalboard/files/11525712/bbc.py.zip)