### PR TITLE
Change channel limit from 2 to 32.

### DIFF
--- a/pedalboard/BufferUtils.h
+++ b/pedalboard/BufferUtils.h
@@ -91,8 +91,8 @@ juce::AudioBuffer<T> copyPyArrayIntoJuceBuffer(
 
   if (numChannels == 0) {
     throw std::runtime_error("No channels passed!");
-  } else if (numChannels > 2) {
-    throw std::runtime_error("More than two channels received!");
+  } else if (numChannels > 32) {
+    throw std::runtime_error("More than 32 channels received!");
   }
 
   juce::AudioBuffer<T> ioBuffer(numChannels, numSamples);
@@ -173,8 +173,8 @@ const juce::AudioBuffer<T> convertPyArrayIntoJuceBuffer(
 
     if (numChannels == 0) {
       throw std::runtime_error("No channels passed!");
-    } else if (numChannels > 2) {
-      throw std::runtime_error("More than two channels received!");
+    } else if (numChannels > 32) {
+      throw std::runtime_error("More than 32 channels received!");
     }
 
     T **channelPointers = (T **)alloca(numChannels * sizeof(T *));

--- a/tests/plugins/effect/.gitignore
+++ b/tests/plugins/effect/.gitignore
@@ -1,0 +1,2 @@
+*/Builds*
+*/JuceLibraryCode*

--- a/tests/plugins/effect/UnityGainNChannel/Source/PluginEditor.cpp
+++ b/tests/plugins/effect/UnityGainNChannel/Source/PluginEditor.cpp
@@ -1,0 +1,40 @@
+/*
+  ==============================================================================
+
+    This file contains the basic framework code for a JUCE plugin editor.
+
+  ==============================================================================
+*/
+
+#include "PluginProcessor.h"
+#include "PluginEditor.h"
+
+//==============================================================================
+UnityGainNChannelAudioProcessorEditor::UnityGainNChannelAudioProcessorEditor (UnityGainNChannelAudioProcessor& p)
+    : AudioProcessorEditor (&p), audioProcessor (p)
+{
+    // Make sure that before the constructor has finished, you've set the
+    // editor's size to whatever you need it to be.
+    setSize (400, 300);
+}
+
+UnityGainNChannelAudioProcessorEditor::~UnityGainNChannelAudioProcessorEditor()
+{
+}
+
+//==============================================================================
+void UnityGainNChannelAudioProcessorEditor::paint (juce::Graphics& g)
+{
+    // (Our component is opaque, so we must completely fill the background with a solid colour)
+    g.fillAll (getLookAndFeel().findColour (juce::ResizableWindow::backgroundColourId));
+
+    g.setColour (juce::Colours::white);
+    g.setFont (15.0f);
+    g.drawFittedText ("Hello World!", getLocalBounds(), juce::Justification::centred, 1);
+}
+
+void UnityGainNChannelAudioProcessorEditor::resized()
+{
+    // This is generally where you'll want to lay out the positions of any
+    // subcomponents in your editor..
+}

--- a/tests/plugins/effect/UnityGainNChannel/Source/PluginEditor.h
+++ b/tests/plugins/effect/UnityGainNChannel/Source/PluginEditor.h
@@ -1,0 +1,33 @@
+/*
+  ==============================================================================
+
+    This file contains the basic framework code for a JUCE plugin editor.
+
+  ==============================================================================
+*/
+
+#pragma once
+
+#include <JuceHeader.h>
+#include "PluginProcessor.h"
+
+//==============================================================================
+/**
+*/
+class UnityGainNChannelAudioProcessorEditor  : public juce::AudioProcessorEditor
+{
+public:
+    UnityGainNChannelAudioProcessorEditor (UnityGainNChannelAudioProcessor&);
+    ~UnityGainNChannelAudioProcessorEditor() override;
+
+    //==============================================================================
+    void paint (juce::Graphics&) override;
+    void resized() override;
+
+private:
+    // This reference is provided as a quick way for your editor to
+    // access the processor object that created it.
+    UnityGainNChannelAudioProcessor& audioProcessor;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (UnityGainNChannelAudioProcessorEditor)
+};

--- a/tests/plugins/effect/UnityGainNChannel/Source/PluginProcessor.cpp
+++ b/tests/plugins/effect/UnityGainNChannel/Source/PluginProcessor.cpp
@@ -1,0 +1,168 @@
+/*
+  ==============================================================================
+
+    This file contains the basic framework code for a JUCE plugin processor.
+
+  ==============================================================================
+*/
+
+#include "PluginProcessor.h"
+#include "PluginEditor.h"
+
+//==============================================================================
+UnityGainNChannelAudioProcessor::UnityGainNChannelAudioProcessor()
+#ifndef JucePlugin_PreferredChannelConfigurations
+     : AudioProcessor (BusesProperties()
+                     #if ! JucePlugin_IsMidiEffect
+                      #if ! JucePlugin_IsSynth
+                       .withInput  ("Input",  juce::AudioChannelSet::discreteChannels(32), true)
+                      #endif
+                       .withOutput ("Output", juce::AudioChannelSet::discreteChannels(32), true)
+                     #endif
+                       )
+#endif
+{
+}
+
+UnityGainNChannelAudioProcessor::~UnityGainNChannelAudioProcessor()
+{
+}
+
+//==============================================================================
+const juce::String UnityGainNChannelAudioProcessor::getName() const
+{
+    return JucePlugin_Name;
+}
+
+bool UnityGainNChannelAudioProcessor::acceptsMidi() const
+{
+   #if JucePlugin_WantsMidiInput
+    return true;
+   #else
+    return false;
+   #endif
+}
+
+bool UnityGainNChannelAudioProcessor::producesMidi() const
+{
+   #if JucePlugin_ProducesMidiOutput
+    return true;
+   #else
+    return false;
+   #endif
+}
+
+bool UnityGainNChannelAudioProcessor::isMidiEffect() const
+{
+   #if JucePlugin_IsMidiEffect
+    return true;
+   #else
+    return false;
+   #endif
+}
+
+double UnityGainNChannelAudioProcessor::getTailLengthSeconds() const
+{
+    return 0.0;
+}
+
+int UnityGainNChannelAudioProcessor::getNumPrograms()
+{
+    return 1;   // NB: some hosts don't cope very well if you tell them there are 0 programs,
+                // so this should be at least 1, even if you're not really implementing programs.
+}
+
+int UnityGainNChannelAudioProcessor::getCurrentProgram()
+{
+    return 0;
+}
+
+void UnityGainNChannelAudioProcessor::setCurrentProgram (int index)
+{
+}
+
+const juce::String UnityGainNChannelAudioProcessor::getProgramName (int index)
+{
+    return {};
+}
+
+void UnityGainNChannelAudioProcessor::changeProgramName (int index, const juce::String& newName)
+{
+}
+
+//==============================================================================
+void UnityGainNChannelAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBlock)
+{
+    // Use this method as the place to do any pre-playback
+    // initialisation that you need..
+}
+
+void UnityGainNChannelAudioProcessor::releaseResources()
+{
+    // When playback stops, you can use this as an opportunity to free up any
+    // spare memory, etc.
+}
+
+#ifndef JucePlugin_PreferredChannelConfigurations
+bool UnityGainNChannelAudioProcessor::isBusesLayoutSupported (const BusesLayout& layouts) const
+{
+  #if JucePlugin_IsMidiEffect
+    juce::ignoreUnused (layouts);
+    return true;
+  #else
+
+    // This checks if the input layout matches the output layout
+   #if ! JucePlugin_IsSynth
+    if (layouts.getMainOutputChannelSet() != layouts.getMainInputChannelSet())
+        return false;
+   #endif
+
+    return true;
+  #endif
+}
+#endif
+
+void UnityGainNChannelAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages)
+{
+	juce::ScopedNoDenormals noDenormals;
+
+	for (auto i = 0; i < buffer.getNumSamples(); ++i)
+	{
+		for (auto j = 0; j < buffer.getNumChannels(); ++j)
+		{
+			*buffer.getWritePointer(j, i) = *buffer.getReadPointer(j, i);
+		}
+	}
+}
+
+//==============================================================================
+bool UnityGainNChannelAudioProcessor::hasEditor() const
+{
+    return true; // (change this to false if you choose to not supply an editor)
+}
+
+juce::AudioProcessorEditor* UnityGainNChannelAudioProcessor::createEditor()
+{
+    return new UnityGainNChannelAudioProcessorEditor (*this);
+}
+
+//==============================================================================
+void UnityGainNChannelAudioProcessor::getStateInformation (juce::MemoryBlock& destData)
+{
+    // You should use this method to store your parameters in the memory block.
+    // You could do that either as raw data, or use the XML or ValueTree classes
+    // as intermediaries to make it easy to save and load complex data.
+}
+
+void UnityGainNChannelAudioProcessor::setStateInformation (const void* data, int sizeInBytes)
+{
+    // You should use this method to restore your parameters from this memory block,
+    // whose contents will have been created by the getStateInformation() call.
+}
+
+//==============================================================================
+// This creates new instances of the plugin..
+juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
+{
+    return new UnityGainNChannelAudioProcessor();
+}

--- a/tests/plugins/effect/UnityGainNChannel/Source/PluginProcessor.h
+++ b/tests/plugins/effect/UnityGainNChannel/Source/PluginProcessor.h
@@ -1,0 +1,62 @@
+/*
+  ==============================================================================
+
+    This file contains the basic framework code for a JUCE plugin processor.
+
+  ==============================================================================
+*/
+
+#pragma once
+
+#include <JuceHeader.h>
+
+//==============================================================================
+/**
+*/
+class UnityGainNChannelAudioProcessor  : public juce::AudioProcessor
+                            #if JucePlugin_Enable_ARA
+                             , public juce::AudioProcessorARAExtension
+                            #endif
+{
+public:
+    //==============================================================================
+    UnityGainNChannelAudioProcessor();
+    ~UnityGainNChannelAudioProcessor() override;
+
+    //==============================================================================
+    void prepareToPlay (double sampleRate, int samplesPerBlock) override;
+    void releaseResources() override;
+
+   #ifndef JucePlugin_PreferredChannelConfigurations
+    bool isBusesLayoutSupported (const BusesLayout& layouts) const override;
+   #endif
+
+    void processBlock (juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
+
+    //==============================================================================
+    juce::AudioProcessorEditor* createEditor() override;
+    bool hasEditor() const override;
+
+    //==============================================================================
+    const juce::String getName() const override;
+
+    bool acceptsMidi() const override;
+    bool producesMidi() const override;
+    bool isMidiEffect() const override;
+    double getTailLengthSeconds() const override;
+
+    //==============================================================================
+    int getNumPrograms() override;
+    int getCurrentProgram() override;
+    void setCurrentProgram (int index) override;
+    const juce::String getProgramName (int index) override;
+    void changeProgramName (int index, const juce::String& newName) override;
+
+    //==============================================================================
+    void getStateInformation (juce::MemoryBlock& destData) override;
+    void setStateInformation (const void* data, int sizeInBytes) override;
+
+private:
+    //==============================================================================
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (UnityGainNChannelAudioProcessor)
+};

--- a/tests/plugins/effect/UnityGainNChannel/UnityGainNChannel.jucer
+++ b/tests/plugins/effect/UnityGainNChannel/UnityGainNChannel.jucer
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<JUCERPROJECT id="BK6haA" name="UnityGainNChannel" projectType="audioplug"
+              useAppConfig="0" addUsingNamespaceToJuceHeader="0" displaySplashScreen="1"
+              jucerFormatVersion="1">
+  <MAINGROUP id="l4smPP" name="UnityGainNChannel">
+    <GROUP id="{0210CB18-7889-3D0B-F8A5-F554843C1CEC}" name="Source">
+      <FILE id="xRP3IP" name="PluginProcessor.cpp" compile="1" resource="0"
+            file="Source/PluginProcessor.cpp"/>
+      <FILE id="bnCQ1V" name="PluginProcessor.h" compile="0" resource="0"
+            file="Source/PluginProcessor.h"/>
+      <FILE id="gLKfHv" name="PluginEditor.cpp" compile="1" resource="0"
+            file="Source/PluginEditor.cpp"/>
+      <FILE id="Fb7ULJ" name="PluginEditor.h" compile="0" resource="0" file="Source/PluginEditor.h"/>
+    </GROUP>
+  </MAINGROUP>
+  <JUCEOPTIONS JUCE_STRICT_REFCOUNTEDPOINTER="1" JUCE_VST3_CAN_REPLACE_VST2="0"/>
+  <EXPORTFORMATS>
+    <VS2017 targetFolder="Builds/VisualStudio2017">
+      <CONFIGURATIONS>
+        <CONFIGURATION isDebug="1" name="Debug" targetName="UnityGainNChannel"/>
+        <CONFIGURATION isDebug="0" name="Release" targetName="UnityGainNChannel"/>
+      </CONFIGURATIONS>
+      <MODULEPATHS>
+        <MODULEPATH id="juce_audio_basics" path="../../../../../../../../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_devices" path="../../../../../../../../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_formats" path="../../../../../../../../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_plugin_client" path="../../../../../../../../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_processors" path="../../../../../../../../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_utils" path="../../../../../../../../JUCE/modules"/>
+        <MODULEPATH id="juce_core" path="../../../../../../../../JUCE/modules"/>
+        <MODULEPATH id="juce_data_structures" path="../../../../../../../../JUCE/modules"/>
+        <MODULEPATH id="juce_events" path="../../../../../../../../JUCE/modules"/>
+        <MODULEPATH id="juce_graphics" path="../../../../../../../../JUCE/modules"/>
+        <MODULEPATH id="juce_gui_basics" path="../../../../../../../../JUCE/modules"/>
+        <MODULEPATH id="juce_gui_extra" path="../../../../../../../../JUCE/modules"/>
+      </MODULEPATHS>
+    </VS2017>
+  </EXPORTFORMATS>
+  <MODULES>
+    <MODULE id="juce_audio_basics" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_audio_devices" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_audio_formats" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_audio_plugin_client" showAllCode="1" useLocalCopy="0"
+            useGlobalPath="1"/>
+    <MODULE id="juce_audio_processors" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_audio_utils" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_core" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_data_structures" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_events" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_graphics" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_gui_basics" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_gui_extra" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+  </MODULES>
+</JUCERPROJECT>

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -922,3 +922,30 @@ def test_get_plugin_names_from_container(plugin_filename: str):
         raise ValueError("Plugin does not seem to be a .vst3 or .component.")
 
     assert len(names) > 1
+
+
+@pytest.mark.parametrize("plugin_filename", ["UnityGain32Channel"])
+def test_poly_channel_plugins(plugin_filename):
+
+    plugin_path = find_plugin_path(plugin_filename)
+    plugin = pedalboard.load_plugin(plugin_path)
+
+    fs = 48000
+    f0 = 1000
+    T = 4 / f0
+    N = int(T * fs)
+    time_vector = np.arange(0, N) / fs
+    stimulus = np.sin(2 * np.pi * f0 * time_vector)
+
+    inputs = []
+    for i in range(1, 33):
+        inputs.append(stimulus / i)
+    inputs = np.vstack(inputs)
+
+    outputs = plugin(
+        input_array=inputs,
+        sample_rate=fs)
+
+    assert outputs.shape == inputs.shape
+
+    assert np.all(np.isclose(inputs, outputs))

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -932,28 +932,19 @@ def test_get_plugin_names_from_container(plugin_filename: str):
     assert len(names) > 1
 
 
-@pytest.mark.parametrize("plugin_filename", ["UnityGain32Channel"])
+@pytest.mark.parametrize("plugin_filename", ["UnityGain32Channel.vst3"])
 def test_poly_channel_plugins(plugin_filename):
 
     plugin_path = find_plugin_path(plugin_filename)
     plugin = pedalboard.load_plugin(plugin_path)
 
-    fs = 48000
-    f0 = 1000
-    T = 4 / f0
-    N = int(T * fs)
-    time_vector = np.arange(0, N) / fs
-    stimulus = np.sin(2 * np.pi * f0 * time_vector)
-
-    inputs = []
-    for i in range(1, 33):
-        inputs.append(stimulus / i)
-    inputs = np.vstack(inputs)
+    sr = 44100
+    noise = np.random.rand(sr, 32)
 
     outputs = plugin(
-        input_array=inputs,
-        sample_rate=fs)
+        input_array=noise,
+        sample_rate=sr)
 
-    assert outputs.shape == inputs.shape
+    assert outputs.shape == noise.shape
 
-    assert np.all(np.isclose(inputs, outputs))
+    assert np.all(np.isclose(noise, outputs))

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -663,6 +663,10 @@ def test_string_parameter_valdation(plugin_filename: str, parameter_name: str):
 
 @pytest.mark.parametrize("plugin_filename", AVAILABLE_EFFECT_PLUGINS_IN_TEST_ENVIRONMENT)
 def test_plugin_parameters_persist_between_calls(plugin_filename: str):
+
+    if plugin_filename == "UnityGain32Channel.vst3":
+        pytest.skip("No parameters in this plugin.")
+
     plugin = load_test_plugin(plugin_filename)
     sr = 44100
     noise = np.random.rand(2, sr)
@@ -728,6 +732,10 @@ def test_plugin_state_cleared_between_invocations_by_default(plugin_filename: st
 
 @pytest.mark.parametrize("plugin_filename", AVAILABLE_EFFECT_PLUGINS_IN_TEST_ENVIRONMENT)
 def test_plugin_state_not_cleared_between_invocations_if_reset_is_false(plugin_filename: str):
+
+    if plugin_filename == "UnityGain32Channel.vst3":
+        pytest.skip("No internal state stored in this plugin.")
+
     plugin = load_test_plugin(plugin_filename, disable_caching=True)
 
     sr = 44100

--- a/tests/test_memory_leaks.py
+++ b/tests/test_memory_leaks.py
@@ -23,9 +23,12 @@ from .test_external_plugins import load_test_plugin, AVAILABLE_PLUGINS_IN_TEST_E
 
 
 def get_first_parameter_from(plugin):
-    param_name, param = next(
-        iter([(name, param) for name, param in plugin.parameters.items() if param.type is float])
-    )
+    try:
+        param_name, param = next(
+            iter([(name, param) for name, param in plugin.parameters.items() if param.type is float])
+        )
+    except StopIteration:
+        pytest.skip("No float parameter in plugin.")
     value = getattr(plugin, param_name)
     return param_name, param, value
 
@@ -33,6 +36,7 @@ def get_first_parameter_from(plugin):
 @pytest.mark.parametrize("plugin_path", AVAILABLE_PLUGINS_IN_TEST_ENVIRONMENT)
 def test_plugin_can_be_garbage_collected(plugin_path: str):
     # Load a VST3 or Audio Unit plugin from disk:
+        
     plugin = load_test_plugin(plugin_path, disable_caching=True)
 
     _plugin_ref = weakref.ref(plugin)


### PR DESCRIPTION
Implementation of the changes recommended in #97 to enable the use of plug-ins with more than 2 channels. 

A limit of 32 channels is chosen as for plug-ins with more than 36 input/output channels, the bus sizes are recognised incorrectly. The JUCE projects used to create the effects plug-ins used to test these changes can be provided if needed.

A 32 channel unity gain effect plug-in was created and added to the test effect plug-ins folder.

A basic test for the unity gain plug-in is also implemented. 