### PR TITLE
Fix bug in the vst example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ effect.ratio = 15
 samplerate = 44100
 audio = instrument(
   [Message("note_on", note=60), Message("note_off", note=60, time=5)],
-  samplerate,
+  sample_rate=samplerate,
   duration=5, # seconds
 )
 

--- a/README.md
+++ b/README.md
@@ -169,20 +169,20 @@ print(effect.parameters.keys())
 effect.ratio = 15
 
 # Render some audio by passing MIDI to an instrument:
-samplerate = 44100
+sample_rate = 44100
 audio = instrument(
   [Message("note_on", note=60), Message("note_off", note=60, time=5)],
-  sample_rate=samplerate,
   duration=5, # seconds
+  sample_rate=sample_rate,
 )
 
 # Apply effects to this audio:
-effected = effect(audio, samplerate)
+effected = effect(audio, sample_rate)
 
 # ...or put the effect into a chain with other plugins:
 board = Pedalboard([effect, Reverb()])
 # ...and run that pedalboard with the same VST instance!
-effected = board(audio, samplerate)
+effected = board(audio, sample_rate)
 ```
 
 ### Creating parallel effects chains


### PR DESCRIPTION
Hello, this is just a fix for a small bug in the vst example of the readme. The code crashes if you don't include the name of the `sample_rate` argument.