### PR TITLE
Enable musllinux builds for Python 3.10 and 3.11.

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -248,8 +248,12 @@ jobs:
         - { os: 'ubuntu-20.04', build: cp39-manylinux_aarch64 }
         - { os: 'ubuntu-20.04', build: cp310-manylinux_x86_64 }
         - { os: 'ubuntu-20.04', build: cp310-manylinux_aarch64 }
+        - { os: 'ubuntu-20.04', build: cp310-musllinux_x86_64 }
+        - { os: 'ubuntu-20.04', build: cp310-musllinux_aarch64 }
         - { os: 'ubuntu-20.04', build: cp311-manylinux_x86_64 }
         - { os: 'ubuntu-20.04', build: cp311-manylinux_aarch64 }
+        - { os: 'ubuntu-20.04', build: cp311-musllinux_x86_64 }
+        - { os: 'ubuntu-20.04', build: cp311-musllinux_aarch64 }
         - { os: 'ubuntu-20.04', build: pp37-manylinux_x86_64 }
         - { os: 'ubuntu-20.04', build: pp37-manylinux_aarch64 }
         - { os: 'ubuntu-20.04', build: pp38-manylinux_x86_64 }

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -286,7 +286,7 @@ jobs:
           CIBW_ARCHS_LINUX: auto64 aarch64 # Useful for building linux images with Apple Silicon
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64 # Support Apple Silicon
           # on macOS and with Python 3.10: building NumPy from source fails without these options:
-          CIBW_ENVIRONMENT: NPY_BLAS_ORDER="" NPY_LAPACK_ORDER=""
+          CIBW_ENVIRONMENT: NPY_BLAS_ORDER="" NPY_LAPACK_ORDER="" CIBW_BUILD="${{ matrix.build }}"
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: pip install auditwheel-symbols && (auditwheel repair -w {dest_dir} {wheel} || auditwheel-symbols --manylinux 2010 {wheel})
           # The manylinux container doesn't have a new enough glibc version,
           # so we can't run post-wheel-build tests there.

--- a/pedalboard/io/ReadableAudioFile.h
+++ b/pedalboard/io/ReadableAudioFile.h
@@ -102,7 +102,13 @@ public:
 
     if (!reader) {
       std::ostringstream ss;
-      ss.imbue(std::locale(""));
+      try {
+        ss.imbue(std::locale(""));
+      } catch (const std::runtime_error &e) {
+        // On some systems (like Alpine Linux) we only have "C" and "POSIX"
+        // locales:
+        ss.imbue(std::locale("C"));
+      }
 
       ss << "Failed to open audio file-like object: ";
       ss << inputStream->getRepresentation();
@@ -521,7 +527,13 @@ private:
   void throwReadError(long long currentPosition, long long numSamples,
                       long long samplesRead = -1) {
     std::ostringstream ss;
-    ss.imbue(std::locale(""));
+    try {
+      ss.imbue(std::locale(""));
+    } catch (const std::runtime_error &e) {
+      // On some systems (like Alpine Linux) we only have "C" and "POSIX"
+      // locales:
+      ss.imbue(std::locale("C"));
+    }
 
     ss << "Failed to read audio data";
 

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ ALL_CPPFLAGS.extend(
 )
 ALL_INCLUDES.extend(["JUCE/modules/", "JUCE/modules/juce_audio_processors/format_types/VST3_SDK/"])
 
-if os.getenv("CIBW_BUILD").contains("musllinux"):
+if "musllinux" in os.getenv("CIBW_BUILD", ""):
     # For Alpine/musllinux compatibility:
     ALL_CPPFLAGS.extend(
         [

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,9 @@ ALL_CPPFLAGS.extend(
         "-DJUCE_USE_FLAC=0",  # We've patched this out
         # "-DJUCE_USE_FREETYPE=0",
         "-DJUCE_MODAL_LOOPS_PERMITTED=1",
+        # For Alpine/musllinux compatibility:
+        "-D_NL_IDENTIFICATION_LANGUAGE=0x42",
+        "-D_NL_IDENTIFICATION_TERRITORY=0x43",
     ]
 )
 ALL_INCLUDES.extend(["JUCE/modules/", "JUCE/modules/juce_audio_processors/format_types/VST3_SDK/"])

--- a/setup.py
+++ b/setup.py
@@ -76,12 +76,18 @@ ALL_CPPFLAGS.extend(
         "-DJUCE_USE_FLAC=0",  # We've patched this out
         # "-DJUCE_USE_FREETYPE=0",
         "-DJUCE_MODAL_LOOPS_PERMITTED=1",
-        # For Alpine/musllinux compatibility:
-        "-D_NL_IDENTIFICATION_LANGUAGE=0x42",
-        "-D_NL_IDENTIFICATION_TERRITORY=0x43",
     ]
 )
 ALL_INCLUDES.extend(["JUCE/modules/", "JUCE/modules/juce_audio_processors/format_types/VST3_SDK/"])
+
+if os.getenv("CIBW_BUILD").contains("musllinux"):
+    # For Alpine/musllinux compatibility:
+    ALL_CPPFLAGS.extend(
+        [
+            "-D_NL_IDENTIFICATION_LANGUAGE=0x42",
+            "-D_NL_IDENTIFICATION_TERRITORY=0x43",
+        ]
+    )
 
 # Rubber Band library:
 ALL_CPPFLAGS.extend(

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -69,6 +69,13 @@ if os.getenv("CIBW_TEST_REQUIRES") or os.getenv("CI"):
         f for f in AVAILABLE_INSTRUMENT_PLUGINS_IN_TEST_ENVIRONMENT if "component" not in f
     ]
 
+IS_TESTING_MUSL_LIBC_ON_CI = "musl" in os.getenv("CIBW_BUILD", "")
+if IS_TESTING_MUSL_LIBC_ON_CI:
+    # We can't load any external plugins at all on musl libc (unless they don't require glibc,
+    # but I don't know of any that fit that description)
+    AVAILABLE_EFFECT_PLUGINS_IN_TEST_ENVIRONMENT = []
+    AVAILABLE_INSTRUMENT_PLUGINS_IN_TEST_ENVIRONMENT = []
+
 AVAILABLE_PLUGINS_IN_TEST_ENVIRONMENT = (
     AVAILABLE_EFFECT_PLUGINS_IN_TEST_ENVIRONMENT + AVAILABLE_INSTRUMENT_PLUGINS_IN_TEST_ENVIRONMENT
 )
@@ -207,6 +214,10 @@ def max_volume_of(x: np.ndarray) -> float:
     return np.amax(np.abs(x))
 
 
+@pytest.mark.skipif(
+    IS_TESTING_MUSL_LIBC_ON_CI,
+    reason="External plugins are not officially supported without glibc.",
+)
 def test_at_least_one_plugin_is_available_for_testing():
     assert AVAILABLE_EFFECT_PLUGINS_IN_TEST_ENVIRONMENT
 


### PR DESCRIPTION
Resolves #231.