### PR TITLE
Improve MP3 compatibility by using an adaptive parser.

### DIFF
--- a/pedalboard/juce_overrides/juce_PatchedMP3AudioFormat.cpp
+++ b/pedalboard/juce_overrides/juce_PatchedMP3AudioFormat.cpp
@@ -2125,6 +2125,7 @@ private:
     auto oldPos = stream.getPosition();
     int offset = -3;
     uint32 header = 0;
+    bool isFirstScanAtThisPosition = true;
 
     for (;;) {
       auto streamPos = stream.getPosition();
@@ -2155,7 +2156,7 @@ private:
           break;
       }
 
-      if (offset == -3 && isParsingFirstFrame) {
+      if (isFirstScanAtThisPosition && isParsingFirstFrame) {
         // If we're parsing the first frame of a file/stream, that frame must be
         // at the start of the stream. This prevents accidentally parsing .mp4
         // files (among others) as MP3 files that start with junk.
@@ -2163,6 +2164,7 @@ private:
       }
 
       ++offset;
+      isFirstScanAtThisPosition = false;
     }
 
     if (offset >= 0) {

--- a/pedalboard/juce_overrides/juce_PatchedMP3AudioFormat.cpp
+++ b/pedalboard/juce_overrides/juce_PatchedMP3AudioFormat.cpp
@@ -1925,6 +1925,12 @@ struct PatchedMP3Stream {
           bufferSpace[bufferSpaceIndex] + 512 + sideInfoSize + dataSize;
       dataParsed = true;
       result = 0;
+
+      // We decoded a frame correctly, so increase the amount of patience
+      // we have when scanning for the next frame header:
+      if (maximumScanLength < 0xFFFFFFF) {
+        maximumScanLength *= 2;
+      }
     }
 
     if (isFreeFormat) {
@@ -2016,6 +2022,7 @@ private:
   float synthBuffers[2][2][0x110];
   float hybridIn[2][32][18];
   float hybridOut[2][18][32];
+  unsigned int maximumScanLength = 1024;
 
   void reset() noexcept {
     headerParsed = sideParsed = dataParsed = isFreeFormat = wasFreeFormat =
@@ -2026,6 +2033,7 @@ private:
     lastFrameSizeNoPadding = bufferSpaceIndex = 0;
     bufferPointer = bufferSpace[bufferSpaceIndex] + 512;
     synthBo = 1;
+    maximumScanLength = 1024;
 
     zerostruct(sideinfo);
     zeromem(bufferSpace, sizeof(bufferSpace));
@@ -2147,7 +2155,7 @@ private:
           break;
       }
 
-      if (isParsingFirstFrame) {
+      if (offset == -3 && isParsingFirstFrame) {
         // If we're parsing the first frame of a file/stream, that frame must be
         // at the start of the stream. This prevents accidentally parsing .mp4
         // files (among others) as MP3 files that start with junk.


### PR DESCRIPTION
Fixes #242.

Pedalboard uses a variant of [the JUCE MP3 parser](https://github.com/juce-framework/JUCE/blob/2a27ebcfae7ca7f6eb62b29d5f002ceefdaadbdb/modules/juce_audio_formats/codecs/juce_MP3AudioFormat.cpp#L2957), which has a couple of minor issues when used to read a variety of files.

In particular, the JUCE MP3 parser scans each file (or stream) for up to 32kB, looking for the next valid MP3 frame. The only check that's performed when opening a file is that there is a valid MP3 frame _header_ within the first 32kB of a file. Unfortunately, this is not quite enough, as many other audio formats have a valid-looking MP3 header frame (_most_ 32-bit values that look like `0xFFFE????` will match) somewhere within their first 32kB.

To work around this, this pull request changes the MP3 parser to scan only the first 1kB of the file or stream for an MP3 header at first. Each time a successful MP3 frame is parsed after that, the size of the window in which to scan for the next frame is doubled, up until a maximum of 250MB. This allows for fragmented MP3 streams (with corruption, or some non-MP3 data) to be read correctly, but only if they have a valid MP3 header within their first 1kB.