### PR TITLE
Fix typos

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -56,7 +56,7 @@ If you experience or witness unacceptable behaviorâ€”or have any other concernsâ
 include them as well. Your account of what occurred, and if you believe the incident is ongoing. If there is a publicly available record (e.g. a mailing list archive or a public IRC logger), please include a link.
 - Any additional information that may be helpful.
 
-After filing a report, a representative will contact you personally, review the incident, follow up with any additional questions, and make a decision as to how to respond. If the person who is harassing you is part of the response team, they will recuse themselves from handling your incident. If the complaint originates from a member of the response team, it will be handled by a different member of the response team. We will respect confidentiality requests for the purpose of protecting victims of abuse.
+After filing a report, a representative will contact you personally, review the incident, follow up with any additional questions, and make a decision as to how to respond. If the person who is harassing you is part of the response team, they will recurse themselves from handling your incident. If the complaint originates from a member of the response team, it will be handled by a different member of the response team. We will respect confidentiality requests for the purpose of protecting victims of abuse.
 
 ### Attribution & Acknowledgements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ Use [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) for C++ code,
 
 ## Issues
 
-When creating an issue please try to ahere to the following format:
+When creating an issue please try to adhere to the following format:
 
     module-name: One line summary of the issue (less than 72 characters)
 

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -774,7 +774,7 @@ public:
    * loading assets from disk, etc). These background tasks may depend on the
    * event loop, which Pedalboard does not pump by default.
    *
-   * Returns true if the plugin rendered audio within the alloted timeout; false
+   * Returns true if the plugin rendered audio within the allotted timeout; false
    * if no audio was received before the timeout expired.
    */
   bool attemptToWarmUp() {
@@ -793,7 +793,7 @@ public:
       return false;
     }
 
-    // Set input and output busses/channels appropriately:
+    // Set input and output buses/channels appropriately:
     int numOutputChannels =
         std::max(pluginInstance->getMainBusNumInputChannels(),
                  pluginInstance->getMainBusNumOutputChannels());
@@ -893,7 +893,7 @@ public:
       return ExternalPluginReloadType::Unknown;
     }
 
-    // Set input and output busses/channels appropriately:
+    // Set input and output buses/channels appropriately:
     setNumChannels(numInputChannels);
     pluginInstance->setNonRealtime(true);
     pluginInstance->prepareToPlay(sampleRate, bufferSize);

--- a/pedalboard/io/AudioFileInit.h
+++ b/pedalboard/io/AudioFileInit.h
@@ -34,7 +34,7 @@ namespace py = pybind11;
 namespace Pedalboard {
 
 // For pybind11-stubgen to properly parse the docstrings,
-// we have to delcare all of the AudioFile subclasses first before using
+// we have to declare all of the AudioFile subclasses first before using
 // their types (i.e.: as return types from `__new__`).
 // See:
 // https://pybind11.readthedocs.io/en/latest/advanced/misc.html#avoiding-cpp-types-in-docstrings

--- a/pedalboard/plugins/Chorus.h
+++ b/pedalboard/plugins/Chorus.h
@@ -55,7 +55,7 @@ inline void init_chorus(py::module &m) {
       "control, a feedback control, and the centre delay of the modulation. "
       "\n\n"
       "Note: To get classic chorus sounds try to use a centre delay time "
-      "around 7-8 ms with a low feeback volume and a low depth. This effect "
+      "around 7-8 ms with a low feedback volume and a low depth. This effect "
       "can also be used as a flanger with a lower centre delay time and a "
       "lot of feedback, and as a vibrato effect if the mix value is 1.")
       .def(py::init([](float rateHz, float depth, float centreDelayMs,

--- a/pedalboard_native/__init__.pyi
+++ b/pedalboard_native/__init__.pyi
@@ -171,7 +171,7 @@ class Chorus(Plugin):
 
     This audio effect can be controlled via the speed and depth of the LFO controlling the frequency response, a mix control, a feedback control, and the centre delay of the modulation.
 
-    Note: To get classic chorus sounds try to use a centre delay time around 7-8 ms with a low feeback volume and a low depth. This effect can also be used as a flanger with a lower centre delay time and a lot of feedback, and as a vibrato effect if the mix value is 1.
+    Note: To get classic chorus sounds try to use a centre delay time around 7-8 ms with a low feedback volume and a low depth. This effect can also be used as a flanger with a lower centre delay time and a lot of feedback, and as a vibrato effect if the mix value is 1.
     """
 
     def __init__(

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -37,7 +37,7 @@ def test_fail_on_invalid_plugin():
 
 def test_fail_on_invalid_sample_rate():
     with pytest.raises(TypeError):
-        Pedalboard([]).process([], "fourty four one hundred")
+        Pedalboard([]).process([], "forty four one hundred")
 
 
 def test_fail_on_invalid_buffer_size():

--- a/vendors/lame_config.h
+++ b/vendors/lame_config.h
@@ -49,7 +49,7 @@
 /* Define if compiler has function prototypes */
 #define PROTOTYPES 1
 
-/* faster log implementation with less but enough precission */
+/* faster log implementation with less but enough precision */
 #define USE_FAST_LOG 1
 
 #define HAVE_STRCHR

--- a/vendors/lame_overrides.c
+++ b/vendors/lame_overrides.c
@@ -148,7 +148,7 @@ int decode1_headersB_clipchoice(
 /*
  * For hip_decode:  return code
  *  -1     error
- *   0     ok, but need more data before outputing any samples
+ *   0     ok, but need more data before outputting any samples
  *   n     number of samples output.  a multiple of 576 or 1152 depending on MP3
  * file.
  */

--- a/vendors/lame_overrides.h
+++ b/vendors/lame_overrides.h
@@ -9,7 +9,7 @@
 /*
  * For hip_decode:  return code
  *  -1     error
- *   0     ok, but need more data before outputing any samples
+ *   0     ok, but need more data before outputting any samples
  *   n     number of samples output.  a multiple of 576 or 1152 depending on MP3
  * file.
  */


### PR DESCRIPTION
Found via `codespell -S docs -L bu,caf`