### PR TITLE
Raise any Python exceptions thrown during seek operations on file-like objects.

### DIFF
--- a/pedalboard/io/PythonFileLike.h
+++ b/pedalboard/io/PythonFileLike.h
@@ -109,10 +109,7 @@ public:
 
     if (!PythonException::isPending()) {
       try {
-        if (fileLike.attr("seekable")().cast<bool>()) {
-          fileLike.attr("seek")(pos);
-        }
-
+        fileLike.attr("seek")(pos);
         return fileLike.attr("tell")().cast<juce::int64>() == pos;
       } catch (py::error_already_set e) {
         e.restore();

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -398,6 +398,19 @@ def test_no_crash_if_type_error_on_file_like():
     assert "bool" in str(e)
 
 
+def test_file_like_must_be_seekable_for_write():
+    stream = io.BytesIO()
+    stream.seek = lambda x: (_ for _ in ()).throw(
+        ValueError(f"Failed to seek from {stream.tell():,} to {x:,} because I don't wanna")
+    )
+
+    with pytest.raises(ValueError) as e:
+        with pedalboard.io.AudioFile(stream, "w", 44100, 2, format="flac"):
+            pass
+
+    assert "I don't wanna" in str(e)
+
+
 def test_write_fails_without_extension(tmp_path: pathlib.Path):
     dest_path = str(tmp_path / "no_extension")
     with pytest.raises(ValueError):


### PR DESCRIPTION
When writing audio to a Python file-like object, Pedalboard (prior to this PR) would call the `seekable` function on that object to determine if it could be seeked. If `seekable` returned `False`, Pedalboard would no longer call `seek`; but many of JUCE's file write handlers silently continue if the underlying file is not seekable.

This PR changes this behaviour to always fail if the C++ tries to call `seek` and Python throws an exception on `seek`.