### PR TITLE
Fix for the bug in JUCE submodule

### DIFF
--- a/pedalboard/juce_overrides/juce_PatchedVST3PluginFormat.cpp
+++ b/pedalboard/juce_overrides/juce_PatchedVST3PluginFormat.cpp
@@ -2445,8 +2445,8 @@ public:
   void releaseResources() override {
     const SpinLock::ScopedLockType lock(processMutex);
 
-    //if (!isActive)
-    //  return; // Avoids redundantly calling things like setActive
+    // if (!isActive)
+    //   return; // Avoids redundantly calling things like setActive
 
     isActive = false;
 

--- a/pedalboard/juce_overrides/juce_PatchedVST3PluginFormat.cpp
+++ b/pedalboard/juce_overrides/juce_PatchedVST3PluginFormat.cpp
@@ -2445,8 +2445,8 @@ public:
   void releaseResources() override {
     const SpinLock::ScopedLockType lock(processMutex);
 
-    if (!isActive)
-      return; // Avoids redundantly calling things like setActive
+    //if (!isActive)
+    //  return; // Avoids redundantly calling things like setActive
 
     isActive = false;
 


### PR DESCRIPTION
JUCE submodule has a bug in the code caused by unneeded optimization in VST3PluginInstance::releaseResources method. This causes tests failures on the plug-ins on our end. This fix overrides juce_VST3PluginFormat.cpp file.