### PR TITLE
Add channel mapping support

### DIFF
--- a/pedalboard/io/WriteableAudioFile.h
+++ b/pedalboard/io/WriteableAudioFile.h
@@ -356,9 +356,19 @@ public:
     }
 
     juce::StringPairArray emptyMetadata;
-    writer.reset(format->createWriterFor(outputStream.get(), writeSampleRate,
-                                         numChannels, bitDepth, emptyMetadata,
-                                         qualityOptionIndex));
+    juce::AudioChannelSet channelSet(
+        juce::AudioChannelSet::namedChannelSet(numChannels));
+
+    if (format->isChannelLayoutSupported(channelSet)) {
+      writer.reset(format->createWriterFor(outputStream.get(), writeSampleRate,
+                                           channelSet, bitDepth, emptyMetadata,
+                                           qualityOptionIndex));
+    } else {
+      writer.reset(format->createWriterFor(outputStream.get(), writeSampleRate,
+                                           numChannels, bitDepth, emptyMetadata,
+                                           qualityOptionIndex));
+    }
+
     if (!writer) {
       PythonException::raise();
 


### PR DESCRIPTION
Map channels to their respective speakers for supported audio formats. This change solves an issue where receivers can't determine how to map channels for multi channel audio files.