### PR TITLE
Seems like this `jmin` should be `jmax` to leave enough space for the…

### DIFF
--- a/pedalboard/juce_overrides/juce_BlockingConvolution.cpp
+++ b/pedalboard/juce_overrides/juce_BlockingConvolution.cpp
@@ -489,7 +489,7 @@ static AudioBuffer<float> trimImpulseResponse(const AudioBuffer<float> &buf) {
                             std::make_reverse_iterator(channelBegin));
 
     offsetBegin = jmin(offsetBegin, itStart);
-    offsetEnd = jmin(offsetEnd, itEnd);
+    offsetEnd = jmax(offsetEnd, itEnd);
   }
 
   if (offsetBegin == numSamples) {


### PR DESCRIPTION
Seems like this `jmin` should be `jmax` to leave enough space for the buffer