### PR TITLE
Added an optional audio file parameter to the AudioStream class (issue #264)

### DIFF
--- a/pedalboard/io/AudioStream.h
+++ b/pedalboard/io/AudioStream.h
@@ -32,238 +32,330 @@
 
 namespace py = pybind11;
 
-namespace Pedalboard {
-
-class AudioStream : public std::enable_shared_from_this<AudioStream>
-#ifdef JUCE_MODULE_AVAILABLE_juce_audio_devices
-    ,
-                    public juce::AudioIODeviceCallback
-#endif
+namespace Pedalboard
 {
-public:
-  AudioStream(std::string inputDeviceName, std::string outputDeviceName,
-              std::optional<std::shared_ptr<Chain>> pedalboard,
-              std::optional<double> sampleRate, int bufferSize,
-              bool allowFeedback)
+
+    class AudioStream : public std::enable_shared_from_this<AudioStream>
 #ifdef JUCE_MODULE_AVAILABLE_juce_audio_devices
-      : pedalboard(pedalboard ? *pedalboard
-                              : std::make_shared<Chain>(
-                                    std::vector<std::shared_ptr<Plugin>>())),
-        livePedalboard(std::vector<std::shared_ptr<Plugin>>())
+        ,
+                        public juce::AudioIODeviceCallback
 #endif
-  {
+    {
+    public:
+        AudioStream(std::string inputDeviceName, std::string outputDeviceName,
+                    std::optional<std::shared_ptr<Chain>> pedalboard,
+                    std::optional<double> sampleRate, int bufferSize,
+                    bool allowFeedback, const std::string &audioFilePath = "")
 #ifdef JUCE_MODULE_AVAILABLE_juce_audio_devices
-    juce::AudioDeviceManager::AudioDeviceSetup setup;
-    setup.inputDeviceName = inputDeviceName;
-    setup.outputDeviceName = outputDeviceName;
-    // A value of 0 indicates we want to use whatever the device default is:
-    setup.sampleRate = sampleRate ? *sampleRate : 0;
-    setup.bufferSize = bufferSize;
-
-    if (!allowFeedback &&
-        juce::String(inputDeviceName).containsIgnoreCase("microphone") &&
-        juce::String(outputDeviceName).containsIgnoreCase("speaker")) {
-      throw std::runtime_error(
-          "The audio input device passed to AudioStream looks like a "
-          "microphone, and the output device looks like a speaker. This setup "
-          "may cause feedback. To create an AudioStream anyways, pass "
-          "`allow_feedback=True` to the AudioStream constructor.");
-    }
-
-    juce::String defaultDeviceName;
-    juce::String error = deviceManager.initialise(2, 2, nullptr, true,
-                                                  defaultDeviceName, &setup);
-    if (!error.isEmpty()) {
-      throw std::domain_error(error.toStdString());
-    }
-#else
-    throw std::runtime_error("AudioStream is not supported on this platform.");
+            : pedalboard(pedalboard ? *pedalboard
+                                    : std::make_shared<Chain>(
+                                          std::vector<std::shared_ptr<Plugin>>())),
+              livePedalboard(std::vector<std::shared_ptr<Plugin>>()),
+              audioFilePath(audioFilePath)
 #endif
-  }
-
+        {
 #ifdef JUCE_MODULE_AVAILABLE_juce_audio_devices
-  ~AudioStream() {
-    stop();
-    close();
-  }
+            juce::AudioDeviceManager::AudioDeviceSetup setup;
+            setup.inputDeviceName = inputDeviceName;
+            setup.outputDeviceName = outputDeviceName;
+            setup.sampleRate = sampleRate ? *sampleRate : 0;
+            setup.bufferSize = bufferSize;
 
-  std::shared_ptr<Chain> getPedalboard() { return pedalboard; }
-
-  void setPedalboard(std::shared_ptr<Chain> chain) { pedalboard = chain; }
-
-  void close() { deviceManager.closeAudioDevice(); }
-
-  void start() {
-    isRunning = true;
-    changeObserverThread =
-        std::thread(&AudioStream::propagateChangesToAudioThread, this);
-    deviceManager.addAudioCallback(this);
-  }
-
-  void stop() {
-    deviceManager.removeAudioCallback(this);
-    isRunning = false;
-    if (changeObserverThread.joinable()) {
-      changeObserverThread.join();
-    }
-  }
-
-  void propagateChangesToAudioThread() {
-    while (isRunning) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(50));
-
-      // Make sure nobody modifies the Python-side object while we're reading
-      // it (without taking the GIL, which would be expensive)
-      std::unique_lock<std::mutex> lock(pedalboard->mutex, std::try_to_lock);
-      if (lock.owns_lock()) {
-        // We can read livePedalboard's plugins without a lock, as we're the
-        // only writer:
-        if (pedalboard->getAllPlugins() != livePedalboard.getAllPlugins()) {
-          // But if we need to write, then we need to try to get the lock:
-          juce::SpinLock::ScopedTryLockType tryLock(livePedalboardMutex);
-          if (tryLock.isLocked()) {
-            livePedalboard.getPlugins().clear();
-
-            for (auto plugin : pedalboard->getPlugins()) {
-              plugin->prepare(spec);
-              livePedalboard.getPlugins().push_back(plugin);
+            if (!allowFeedback &&
+                juce::String(inputDeviceName).containsIgnoreCase("microphone") &&
+                juce::String(outputDeviceName).containsIgnoreCase("speaker"))
+            {
+                throw std::runtime_error(
+                    "The audio input device passed to AudioStream looks like a "
+                    "microphone, and the output device looks like a speaker. This setup "
+                    "may cause feedback. To create an AudioStream anyways, pass "
+                    "`allow_feedback=True` to the AudioStream constructor.");
             }
-          }
-        }
-      }
-    }
-  }
 
-  void stream() {
-    start();
-    while (isRunning) {
-      if (PyErr_CheckSignals() != 0) {
-        break;
-      }
-
-      {
-        py::gil_scoped_release release;
-
-        // Let other Python threads run:
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-      }
-    }
-    stop();
-    throw py::error_already_set();
-  }
-
-  std::shared_ptr<AudioStream> enter() {
-    start();
-    return shared_from_this();
-  }
-
-  void exit(const py::object &type, const py::object &value,
-            const py::object &traceback) {
-    bool shouldThrow = PythonException::isPending();
-    stop();
-
-    if (shouldThrow || PythonException::isPending())
-      throw py::error_already_set();
-  }
-
-  static std::vector<std::string> getDeviceNames(bool isInput) {
-    juce::AudioDeviceManager deviceManager;
-
-    std::vector<std::string> names;
-    for (auto *type : deviceManager.getAvailableDeviceTypes()) {
-      for (juce::String name : type->getDeviceNames(isInput)) {
-        names.push_back(name.toStdString());
-      }
-    }
-    return names;
-  }
-
-  virtual void audioDeviceIOCallback(const float **inputChannelData,
-                                     int numInputChannels,
-                                     float **outputChannelData,
-                                     int numOutputChannels, int numSamples) {
-    for (int i = 0; i < numOutputChannels; i++) {
-      const float *inputChannel = inputChannelData[i % numInputChannels];
-      std::memcpy((char *)outputChannelData[i], (char *)inputChannel,
-                  numSamples * sizeof(float));
-    }
-
-    auto ioBlock = juce::dsp::AudioBlock<float>(
-        outputChannelData, numOutputChannels, 0, numSamples);
-    juce::dsp::ProcessContextReplacing<float> context(ioBlock);
-
-    juce::SpinLock::ScopedTryLockType tryLock(livePedalboardMutex);
-    if (tryLock.isLocked()) {
-      for (auto plugin : livePedalboard.getPlugins()) {
-        std::unique_lock<std::mutex> lock(pedalboard->mutex, std::try_to_lock);
-        // If someone's running audio through this plugin in parallel (offline,
-        // or in a different AudioStream object) then don't corrupt its state by
-        // calling it here too; instead, just skip it:
-        if (lock.owns_lock()) {
-          plugin->process(context);
-        }
-      }
-    }
-  }
-
-  virtual void audioDeviceAboutToStart(juce::AudioIODevice *device) {
-    spec.sampleRate = deviceManager.getAudioDeviceSetup().sampleRate;
-    spec.maximumBlockSize = static_cast<juce::uint32>(
-        deviceManager.getAudioDeviceSetup().bufferSize);
-    spec.numChannels = static_cast<juce::uint32>(
-        device->getActiveOutputChannels().countNumberOfSetBits());
-
-    juce::SpinLock::ScopedLockType lock(livePedalboardMutex);
-    for (auto plugin : livePedalboard.getPlugins()) {
-      plugin->prepare(spec);
-    }
-  }
-
-  virtual void audioDeviceStopped() {
-    juce::SpinLock::ScopedLockType lock(livePedalboardMutex);
-
-    for (auto plugin : livePedalboard.getPlugins()) {
-      plugin->reset();
-    }
-  }
-
-  bool getIsRunning() const { return isRunning; }
-
-  juce::AudioDeviceManager::AudioDeviceSetup getAudioDeviceSetup() const {
-    return deviceManager.getAudioDeviceSetup();
-  }
-
-private:
-  juce::AudioDeviceManager deviceManager;
-  juce::dsp::ProcessSpec spec;
-  bool isRunning = false;
-
-  std::shared_ptr<Chain> pedalboard;
-
-  // A simple spin-lock mutex that we can try to acquire from
-  // the audio thread, allowing us to avoid modifying state that's
-  // currently being used for rendering.
-  // The `livePedalboard` object already has a std::mutex on it,
-  // but we want something that's faster and callable from the
-  // dudio thread.
-  juce::SpinLock livePedalboardMutex;
-
-  // A "live" pedalboard, called from the audio thread.
-  // This is not exposed to Python, and is only updated from C++.
-  Chain livePedalboard;
-
-  // A background thread, independent of the audio thread, that
-  // watches for any changes to the Pedalboard object (which may
-  // happen in Python) and copies those changes over to data
-  // structures used by the audio thread.
-  std::thread changeObserverThread;
+            juce::String defaultDeviceName;
+            juce::String error = deviceManager.initialise(2, 2, nullptr, true,
+                                                          defaultDeviceName, &setup);
+            if (!error.isEmpty())
+            {
+                throw std::domain_error(error.toStdString());
+            }
+            audioBuffer.setSize(2, setup.bufferSize);
+            if (!this->audioFilePath.empty())
+            {
+                juce::File file(audioFilePath);
+                juce::AudioFormatManager formatManager;
+                formatManager.registerBasicFormats();
+                std::unique_ptr<juce::AudioFormatReader> reader(formatManager.createReaderFor(file));
+                if (reader != nullptr)
+                {
+                    audioBuffer.setSize(reader->numChannels, (int)reader->lengthInSamples);
+                    reader->read(&audioBuffer, 0, (int)reader->lengthInSamples, 0, true, true);
+                }
+                else
+                {
+                    throw std::runtime_error("Failed to load audio file.");
+                }
+            }
+#else
+            throw std::runtime_error("AudioStream is not supported on this platform.");
 #endif
-};
+        }
 
-inline void init_audio_stream(py::module &m) {
-  auto audioStream =
-      py::class_<AudioStream, std::shared_ptr<AudioStream>>(m, "AudioStream",
-                                                            R"(
+#ifdef JUCE_MODULE_AVAILABLE_juce_audio_devices
+        ~AudioStream()
+        {
+            stop();
+            close();
+        }
+
+        std::shared_ptr<Chain> getPedalboard() { return pedalboard; }
+
+        void setPedalboard(std::shared_ptr<Chain> chain) { pedalboard = chain; }
+
+        void close() { deviceManager.closeAudioDevice(); }
+
+        void start()
+        {
+            isRunning = true;
+            changeObserverThread =
+                std::thread(&AudioStream::propagateChangesToAudioThread, this);
+            deviceManager.addAudioCallback(this);
+        }
+
+        void stop()
+        {
+            deviceManager.removeAudioCallback(this);
+            isRunning = false;
+            if (changeObserverThread.joinable())
+            {
+                changeObserverThread.join();
+            }
+        }
+
+        void propagateChangesToAudioThread()
+        {
+            while (isRunning)
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+                // Make sure nobody modifies the Python-side object while we're reading
+                // it (without taking the GIL, which would be expensive)
+                std::unique_lock<std::mutex> lock(pedalboard->mutex, std::try_to_lock);
+                if (lock.owns_lock())
+                {
+                    // We can read livePedalboard's plugins without a lock, as we're the
+                    // only writer:
+                    if (pedalboard->getAllPlugins() != livePedalboard.getAllPlugins())
+                    {
+                        // But if we need to write, then we need to try to get the lock:
+                        juce::SpinLock::ScopedTryLockType tryLock(livePedalboardMutex);
+                        if (tryLock.isLocked())
+                        {
+                            livePedalboard.getPlugins().clear();
+
+                            for (auto plugin : pedalboard->getPlugins())
+                            {
+                                plugin->prepare(spec);
+                                livePedalboard.getPlugins().push_back(plugin);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        void stream()
+        {
+            start();
+            while (isRunning)
+            {
+                if (PyErr_CheckSignals() != 0)
+                {
+                    break;
+                }
+
+                {
+                    py::gil_scoped_release release;
+
+                    // Let other Python threads run:
+                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                }
+            }
+            stop();
+            throw py::error_already_set();
+        }
+
+        std::shared_ptr<AudioStream> enter()
+        {
+            start();
+            return shared_from_this();
+        }
+
+        void exit(const py::object &type, const py::object &value,
+                  const py::object &traceback)
+        {
+            bool shouldThrow = PythonException::isPending();
+            stop();
+
+            if (shouldThrow || PythonException::isPending())
+                throw py::error_already_set();
+        }
+
+        int getNumSamples() const
+        {
+            return audioBuffer.getNumSamples(); // Assuming audioBuffer is accessible and has getNumSamples method
+        }
+
+        int getAudioBufferPosition()
+        {
+            return audioBufferPosition;
+        }
+
+        static std::vector<std::string> getDeviceNames(bool isInput)
+        {
+            juce::AudioDeviceManager deviceManager;
+
+            std::vector<std::string> names;
+            for (auto *type : deviceManager.getAvailableDeviceTypes())
+            {
+                for (juce::String name : type->getDeviceNames(isInput))
+                {
+                    names.push_back(name.toStdString());
+                }
+            }
+            return names;
+        }
+
+        virtual void audioDeviceIOCallback(const float **inputChannelData,
+                                           int numInputChannels,
+                                           float **outputChannelData,
+                                           int numOutputChannels, int numSamples)
+        {
+
+            if (!audioFilePath.empty())
+            {
+                int remainingSamples = audioBuffer.getNumSamples() - audioBufferPosition;
+                int samplesToCopy = std::min(numSamples, remainingSamples);
+
+                // Ensure we do not attempt to process more than the designated buffer size
+                samplesToCopy = std::min(samplesToCopy, remainingSamples);
+
+                if (samplesToCopy > 0)
+                {
+                    for (int channel = 0; channel < numOutputChannels; ++channel)
+                    {
+                        int sourceChannel = channel % audioBuffer.getNumChannels();
+                        std::memcpy(outputChannelData[channel],
+                                    audioBuffer.getReadPointer(sourceChannel, audioBufferPosition),
+                                    samplesToCopy * sizeof(float));
+                    }
+                    audioBufferPosition += samplesToCopy;
+                }
+
+                // Handling buffer looping or reset
+                if (audioBufferPosition >= audioBuffer.getNumSamples())
+                {
+                    audioBufferPosition = 0; // Optionally reset or handle as needed
+                }
+            }
+            else
+            {
+                // If no preloaded data or playback is complete, pass through input to output directly
+                for (int i = 0; i < numOutputChannels; i++)
+                {
+                    const float *inputChannel = inputChannelData[i % numInputChannels];
+                    std::memcpy(outputChannelData[i], inputChannel, numSamples * sizeof(float));
+                }
+            }
+
+            auto ioBlock = juce::dsp::AudioBlock<float>(
+                outputChannelData, numOutputChannels, 0, numSamples);
+            juce::dsp::ProcessContextReplacing<float> context(ioBlock);
+
+            juce::SpinLock::ScopedTryLockType tryLock(livePedalboardMutex);
+            if (tryLock.isLocked())
+            {
+                for (auto plugin : livePedalboard.getPlugins())
+                {
+                    std::unique_lock<std::mutex> lock(pedalboard->mutex, std::try_to_lock);
+                    // If someone's running audio through this plugin in parallel (offline,
+                    // or in a different AudioStream object) then don't corrupt its state by
+                    // calling it here too; instead, just skip it:
+                    if (lock.owns_lock())
+                    {
+                        plugin->process(context);
+                    }
+                }
+            }
+        }
+
+        virtual void audioDeviceAboutToStart(juce::AudioIODevice *device)
+        {
+            spec.sampleRate = deviceManager.getAudioDeviceSetup().sampleRate;
+            spec.maximumBlockSize = static_cast<juce::uint32>(
+                deviceManager.getAudioDeviceSetup().bufferSize);
+            spec.numChannels = static_cast<juce::uint32>(
+                device->getActiveOutputChannels().countNumberOfSetBits());
+
+            juce::SpinLock::ScopedLockType lock(livePedalboardMutex);
+            for (auto plugin : livePedalboard.getPlugins())
+            {
+                plugin->prepare(spec);
+            }
+        }
+
+        virtual void audioDeviceStopped()
+        {
+            juce::SpinLock::ScopedLockType lock(livePedalboardMutex);
+
+            for (auto plugin : livePedalboard.getPlugins())
+            {
+                plugin->reset();
+            }
+        }
+
+        bool getIsRunning() const { return isRunning; }
+
+        juce::AudioDeviceManager::AudioDeviceSetup getAudioDeviceSetup() const
+        {
+            return deviceManager.getAudioDeviceSetup();
+        }
+
+    private:
+        juce::AudioDeviceManager deviceManager;
+        juce::dsp::ProcessSpec spec;
+        juce::AudioBuffer<float> audioBuffer;
+        int audioBufferPosition = 0;
+        bool isRunning = false;
+        std::string audioFilePath;
+
+        std::shared_ptr<Chain> pedalboard;
+
+        // A simple spin-lock mutex that we can try to acquire from
+        // the audio thread, allowing us to avoid modifying state that's
+        // currently being used for rendering.
+        // The `livePedalboard` object already has a std::mutex on it,
+        // but we want something that's faster and callable from the
+        // dudio thread.
+        juce::SpinLock livePedalboardMutex;
+
+        // A "live" pedalboard, called from the audio thread.
+        // This is not exposed to Python, and is only updated from C++.
+        Chain livePedalboard;
+
+        // A background thread, independent of the audio thread, that
+        // watches for any changes to the Pedalboard object (which may
+        // happen in Python) and copies those changes over to data
+        // structures used by the audio thread.
+        std::thread changeObserverThread;
+#endif
+    };
+
+    inline void init_audio_stream(py::module &m)
+    {
+        auto audioStream =
+            py::class_<AudioStream, std::shared_ptr<AudioStream>>(m, "AudioStream",
+                                                                  R"(
 A class that streams audio from an input audio device (i.e.: a microphone,
 audio interface, etc) to an output device (speaker, headphones),
 passing it through a :class:`pedalboard.Pedalboard` to add effects.
@@ -317,86 +409,93 @@ passing it through a :class:`pedalboard.Pedalboard` to add effects.
 
 *Introduced in v0.7.0. Not supported on Linux.*
 )")
-          .def(py::init([](std::string inputDeviceName,
-                           std::string outputDeviceName,
-                           std::optional<std::shared_ptr<Chain>> pedalboard,
-                           std::optional<double> sampleRate, int bufferSize,
-                           bool allowFeedback) {
-                 return std::make_shared<AudioStream>(
-                     inputDeviceName, outputDeviceName, pedalboard, sampleRate,
-                     bufferSize, allowFeedback);
-               }),
-               py::arg("input_device_name"), py::arg("output_device_name"),
-               py::arg("plugins") = py::none(),
-               py::arg("sample_rate") = py::none(),
-               py::arg("buffer_size") = 512, py::arg("allow_feedback") = false);
+                .def(py::init([](std::string inputDeviceName,
+                                 std::string outputDeviceName,
+                                 std::optional<std::shared_ptr<Chain>> pedalboard,
+                                 std::optional<double> sampleRate, int bufferSize,
+                                 bool allowFeedback, std::string audioFilePath = "")
+                              { return std::make_shared<AudioStream>(
+                                    inputDeviceName, outputDeviceName, pedalboard, sampleRate,
+                                    bufferSize, allowFeedback, audioFilePath); }),
+                     py::arg("input_device_name"), py::arg("output_device_name"),
+                     py::arg("plugins") = py::none(),
+                     py::arg("sample_rate") = py::none(),
+                     py::arg("buffer_size") = 512, py::arg("allow_feedback") = false, py::arg("audio_file_path") = "");
 #ifdef JUCE_MODULE_AVAILABLE_juce_audio_devices
-  audioStream
-      .def("run", &AudioStream::stream,
-           "Start streaming audio from input to output, passing the audio "
-           "stream  through the :py:attr:`plugins` on this AudioStream object. "
-           "This call will block the current thread until a "
-           ":py:exc:`KeyboardInterrupt` (``Ctrl-C``) is received.")
-      .def_property_readonly(
-          "running", &AudioStream::getIsRunning,
-          ":py:const:`True` if this stream is currently streaming live "
-          "audio from input to output, :py:const:`False` otherwise.")
-      .def("__enter__", &AudioStream::enter,
-           "Use this :class:`AudioStream` as a context manager. Entering the "
-           "context manager will immediately start the audio stream, sending "
-           "audio through to the output device.")
-      .def("__exit__", &AudioStream::exit,
-           "Exit the context manager, ending the audio stream. Once called, "
-           "the audio stream will be stopped (i.e.: :py:attr:`running` will be "
-           ":py:const:`False`).")
-      .def("__repr__",
-           [](const AudioStream &stream) {
-             std::ostringstream ss;
-             ss << "<pedalboard.io.AudioStream";
-             auto audioDeviceSetup = stream.getAudioDeviceSetup();
-             ss << " input_device_name="
-                << audioDeviceSetup.inputDeviceName.toStdString();
-             ss << " output_device_name="
-                << audioDeviceSetup.outputDeviceName.toStdString();
-             ss << " sample_rate="
-                << juce::String(audioDeviceSetup.sampleRate, 2).toStdString();
-             ss << " buffer_size=" << audioDeviceSetup.bufferSize;
-             if (stream.getIsRunning()) {
-               ss << " running";
-             } else {
-               ss << " not running";
-             }
-             ss << " at " << &stream;
-             ss << ">";
-             return ss.str();
-           })
-      .def_property("plugins", &AudioStream::getPedalboard,
-                    &AudioStream::setPedalboard,
-                    "The Pedalboard object that this AudioStream will use to "
-                    "process audio.");
+        audioStream
+            .def("run", &AudioStream::stream,
+                 "Start streaming audio from input to output, passing the audio "
+                 "stream  through the :py:attr:`plugins` on this AudioStream object. "
+                 "This call will block the current thread until a "
+                 ":py:exc:`KeyboardInterrupt` (``Ctrl-C``) is received.")
+            .def_property_readonly(
+                "running", &AudioStream::getIsRunning,
+                ":py:const:`True` if this stream is currently streaming live "
+                "audio from input to output, :py:const:`False` otherwise.")
+            .def("get_num_samples", &AudioStream::getNumSamples, "Get the number of samples in the audio buffer")
+            .def("get_buffer_position", &AudioStream::getAudioBufferPosition, "Get the position of the audio buffer")
+            .def("__enter__", &AudioStream::enter,
+                 "Use this :class:`AudioStream` as a context manager. Entering the "
+                 "context manager will immediately start the audio stream, sending "
+                 "audio through to the output device.")
+            .def("__exit__", &AudioStream::exit,
+                 "Exit the context manager, ending the audio stream. Once called, "
+                 "the audio stream will be stopped (i.e.: :py:attr:`running` will be "
+                 ":py:const:`False`).")
+            .def("__repr__",
+                 [](const AudioStream &stream)
+                 {
+                     std::ostringstream ss;
+                     ss << "<pedalboard.io.AudioStream";
+                     auto audioDeviceSetup = stream.getAudioDeviceSetup();
+                     ss << " input_device_name="
+                        << audioDeviceSetup.inputDeviceName.toStdString();
+                     ss << " output_device_name="
+                        << audioDeviceSetup.outputDeviceName.toStdString();
+                     ss << " sample_rate="
+                        << juce::String(audioDeviceSetup.sampleRate, 2).toStdString();
+                     ss << " buffer_size=" << audioDeviceSetup.bufferSize;
+                     if (stream.getIsRunning())
+                     {
+                         ss << " running";
+                     }
+                     else
+                     {
+                         ss << " not running";
+                     }
+                     ss << " at " << &stream;
+                     ss << ">";
+                     return ss.str();
+                 })
+            .def_property("plugins", &AudioStream::getPedalboard,
+                          &AudioStream::setPedalboard,
+                          "The Pedalboard object that this AudioStream will use to "
+                          "process audio.");
 #endif
-  audioStream
-      .def_property_readonly_static(
-          "input_device_names",
-          [](py::object *obj) -> std::vector<std::string> {
+        audioStream
+            .def_property_readonly_static(
+                "input_device_names",
+                [](py::object *obj) -> std::vector<std::string>
+                {
 #ifdef JUCE_MODULE_AVAILABLE_juce_audio_devices
-            return AudioStream::getDeviceNames(true);
+                    return AudioStream::getDeviceNames(true);
 #else
-            return {};
+                    return {};
 #endif
-          },
-          "The input devices (i.e.: microphones, audio interfaces, etc.) "
-          "currently available on the current machine.")
-      .def_property_readonly_static(
-          "output_device_names",
-          [](py::object *obj) -> std::vector<std::string> {
+                },
+                "The input devices (i.e.: microphones, audio interfaces, etc.) "
+                "currently available on the current machine.")
+            .def_property_readonly_static(
+                "output_device_names",
+                [](py::object *obj) -> std::vector<std::string>
+                {
 #ifdef JUCE_MODULE_AVAILABLE_juce_audio_devices
-            return AudioStream::getDeviceNames(false);
+                    return AudioStream::getDeviceNames(false);
 #else
-            return {};
+                    return {};
 #endif
-          },
-          "The output devices (i.e.: speakers, headphones, etc.) currently "
-          "available on the current machine.");
-}
+                },
+                "The output devices (i.e.: speakers, headphones, etc.) currently "
+                "available on the current machine.");
+    }
 } // namespace Pedalboard

--- a/tests/test_audio_stream.py
+++ b/tests/test_audio_stream.py
@@ -19,7 +19,8 @@ import time
 import pytest
 import platform
 import pedalboard
-
+import glob
+import os
 
 # Very silly: even just creating an AudioStream object that reads from an `iPhone Microphone``
 # will cause a locally-present iPhone to emit a sound. Running `pytest` on my laptop makes my
@@ -73,3 +74,94 @@ def test_create_stream(input_device_name: str, output_device_name: str):
 def test_create_stream_fails_on_linux():
     with pytest.raises(RuntimeError):
         pedalboard.io.AudioStream("input", "output")
+
+
+TEST_AUDIO_FILES = [
+    glob.glob(os.path.join(os.path.dirname(
+        __file__), "audio", "correct", '*.wav'))
+]
+
+
+@pytest.mark.skipif(platform.system() == "Linux", reason="AudioStream not supported on Linux.")
+@pytest.mark.parametrize("input_device_name", INPUT_DEVICE_NAMES)
+@pytest.mark.parametrize(
+    "wav_files",
+    [file for file in TEST_AUDIO_FILES],
+)
+@pytest.mark.parametrize("output_device_name", pedalboard.io.AudioStream.output_device_names)
+def test_initialize_audio_stream_with_files(wav_files: list, input_device_name: str, output_device_name: str):
+    # Initialization with an audio file should be successful
+    for file in wav_files:
+        stream = pedalboard.io.AudioStream(
+            input_device_name=input_device_name,
+            output_device_name=output_device_name,
+            audio_file_path=file,
+            allow_feedback=True
+        )
+        assert stream is not None
+        assert stream.get_num_samples() > 0  # Check if audio buffer is loaded
+        with stream:
+            assert stream.running
+        assert not stream.running
+
+
+@pytest.mark.skipif(platform.system() == "Linux", reason="AudioStream not supported on Linux.")
+@pytest.mark.parametrize("input_device_name", INPUT_DEVICE_NAMES)
+@pytest.mark.parametrize("output_device_name", pedalboard.io.AudioStream.output_device_names)
+@pytest.mark.parametrize(
+    "wav_files",
+    [file for file in TEST_AUDIO_FILES],
+)
+def test_playback_audio_stream_with_files(wav_files: list, input_device_name: str, output_device_name: str):
+    for file in wav_files:
+        stream = pedalboard.io.AudioStream(
+            input_device_name=input_device_name,
+            output_device_name=output_device_name,
+            audio_file_path=file,
+            allow_feedback=True
+        )
+        assert stream is not None
+        initial_position = stream.get_buffer_position()
+        with stream:
+            time.sleep(1)
+            assert stream.get_buffer_position() > initial_position
+        assert not stream.running
+
+
+@pytest.mark.skipif(platform.system() == "Linux", reason="AudioStream not supported on Linux.")
+@pytest.mark.parametrize("input_device_name", INPUT_DEVICE_NAMES)
+@pytest.mark.parametrize("output_device_name", pedalboard.io.AudioStream.output_device_names)
+def test_audio_stream_with_nonexistent_file(input_device_name: str, output_device_name: str):
+    with pytest.raises(RuntimeError, match="Failed to load audio file"):
+        pedalboard.io.AudioStream(
+            input_device_name=input_device_name,
+            output_device_name=output_device_name,
+            audio_file_path="nonexistent_file.wav",
+            allow_feedback=True
+        )
+
+
+@pytest.mark.skipif(platform.system() == "Linux", reason="AudioStream not supported on Linux.")
+@pytest.mark.parametrize("input_device_name", INPUT_DEVICE_NAMES)
+@pytest.mark.parametrize("output_device_name", pedalboard.io.AudioStream.output_device_names)
+@pytest.mark.parametrize(
+    "wav_files",
+    [file for file in TEST_AUDIO_FILES],
+)
+def test_audio_stream_multiple_plugins_with_file(wav_files: list, input_device_name: str, output_device_name: str):
+    for file in wav_files:
+        stream = pedalboard.io.AudioStream(
+            input_device_name=input_device_name,
+            output_device_name=output_device_name,
+            audio_file_path=file,
+            allow_feedback=True
+        )
+        with stream:
+            stream.plugins.append(pedalboard.Reverb(room_size=0.8))
+            stream.plugins.append(pedalboard.Delay(delay_seconds=0.3))
+            time.sleep(1)  # Let the stream process some audio
+            # Verify plugins are being processed
+            assert len(stream.plugins) == 2
+            del stream.plugins[0]  # Remove the first plugin
+            assert len(stream.plugins) == 1
+        assert not stream.running


### PR DESCRIPTION
Enhanced the AudioStream class by introducing an optional parameter to accept an audio file. 

Fixed #294.

Made alterations to the AudioStream class that now takes in an optional audio file parameter. If the parameter is not specific, it works as it did before.