### PR TITLE
Add check for empty name_chars list when normalizing param names

### DIFF
--- a/pedalboard/_pedalboard.py
+++ b/pedalboard/_pedalboard.py
@@ -608,6 +608,8 @@ def normalize_python_parameter_name(name: str) -> str:
         c if (c.isalpha() or c.isnumeric()) and c.isprintable() and ord(c) < 128 else "_"
         for c in name
     ]
+    if not name_chars:  # Unhandled/Weird param name
+        return ""
     # Remove any double-underscores:
     name_chars = [a for a, b in zip(name_chars, name_chars[1:]) if a != b or b != "_"] + [
         name_chars[-1]

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -899,7 +899,7 @@ def test_wrapped_bool_requires_bool():
         ("Azimuth (º)", "azimuth"),
         ("Normal String", "normal_string"),
         ("", ""),
-        ("Δ", "")
+        ("Δ", ""),
     ],
 )
 def test_parameter_name_normalization(_input: str, expected: str):

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -898,6 +898,8 @@ def test_wrapped_bool_requires_bool():
         ("B♭", "b_flat"),
         ("Azimuth (º)", "azimuth"),
         ("Normal String", "normal_string"),
+        ("", ""),
+        ("Δ", "")
     ],
 )
 def test_parameter_name_normalization(_input: str, expected: str):


### PR DESCRIPTION
Intent is to fix issue described here at https://github.com/spotify/pedalboard/issues/319
  
