### PR TITLE
Allow MIDI messages for all external instrument plugins

### DIFF
--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -1232,7 +1232,7 @@ public:
       spec.numChannels = (juce::uint32)numChannels;
       prepare(spec);
 
-      if (pluginInstance->getMainBusNumInputChannels() > 0) {
+      if (!foundPluginDescription.isInstrument) {
         throw std::invalid_argument(
             "Plugin '" + pluginInstance->getName().toStdString() +
             "' expects audio as input, but was provided MIDI messages.");


### PR DESCRIPTION
Problem

Some external instrument plugins have audio inputs on the main bus when loaded in pedalboard. This has been observed with AU and VST3 versions of Native Instruments Reaktor 6 and Arturia ARP 2600 V3, for example. When attempting to send MIDI inputs to such plugins, pedalboard throws an error like "ValueError: Plugin '[name]' expects audio as input, but was provided MIDI messages."

Solution

Instead of using the presence of audio inputs to determine whether a plugin accepts MIDI messages, use the `isInstrument` value from the plugin description object.