### PR TITLE
docs: correct supported OSes for `pedalboard.io.Audiostream`

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ board = Pedalboard([
 
 ### Running Pedalboard on Live Audio
 
-On macOS or Windows, Pedalboard supports streaming live audio through
+`pedalboard` supports streaming live audio through
 <a href="https://spotify.github.io/pedalboard/reference/pedalboard.io.html#pedalboard.io.AudioStream">
 an <code class="docutils literal"><span class="pre">AudioStream</span></code> object</a>,
 allowing for real-time manipulation of audio by adding effects in Python.


### PR DESCRIPTION
I think https://github.com/spotify/pedalboard/commit/0ba5f9e278c21a67896b38fcb4b7227c6d6c7912 missed this string 🙂 

(Almost skipped over this project as well, until the commit history showed that Linux supported was merged a mere two days ago!) 

Also took the liberty of downcasing "pedalboard" and putting it in a monospace font, since this is what the rest of the README does.