### PR TITLE
tests: Fix `input_signal` variable in `test_returned_sample_count` being too short

### DIFF
--- a/tests/test_stream_resampler.py
+++ b/tests/test_stream_resampler.py
@@ -181,7 +181,7 @@ def test_flush(sample_rate: float, target_sample_rate: float, quality: Resample.
 def test_returned_sample_count(
     sample_rate: float, target_sample_rate: float, chunk_size: int, quality
 ) -> np.ndarray:
-    input_signal = np.linspace(0, sample_rate, 3, dtype=np.float32)
+    input_signal = np.linspace(0, 3, num=int(sample_rate), dtype=np.float32)
     resampler = StreamResampler(sample_rate, target_sample_rate, 1, quality)
 
     print("input", input_signal)

--- a/tests/test_stream_resampler.py
+++ b/tests/test_stream_resampler.py
@@ -184,7 +184,6 @@ def test_returned_sample_count(
     input_signal = np.linspace(0, 3, num=int(sample_rate), dtype=np.float32)
     resampler = StreamResampler(sample_rate, target_sample_rate, 1, quality)
 
-    print("input", input_signal)
     expected_output = np.concatenate(
         [resampler.process(input_signal), resampler.process(None)], axis=-1
     )


### PR DESCRIPTION
## Problem

I believe the way the `input_signal` variable (in the `test_returned_sample_count` test) is currently defined on master may contain a typo.
I would expect `input_signal` to represent a realistic input that would contain 1s worth of samples for different sample rates.
Currently, it always contain 3 samples, which makes the different chunk sizes testing mostly worthless.

## Solution

Switching the order of parameters when calling `np.linspace` creates a more realistic input (mostly, a longer array).
I kept using np.linspace instead of switching to np.rand (that might be more realistic?) because `np.linspace` is probably faster to run.

## Result

The test is still green, but it now more accurately covers/tests all different chunk_sizes scenarios.

## Additional context

I was working on fixing issue #287 (which I believe I may have a fix for) and I wanted to amend the `returned_sample_count` test to make it cover the problem highlighted in #287. The way np.linspace was called surprised me so I first want to make sure Im understanding this properly :) 