### PR TITLE
Add missing py.typed for pedalboard_native

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,5 +6,6 @@ recursive-include tests *.py
 graft pedalboard
 graft JUCE
 graft tests
+include pedalboard_native/py.typed
 
 exclude build-info.yaml service-info.yaml mkdocs.yml


### PR DESCRIPTION
Add missing `py.typed` in `pedalboard_native` to solve mypy import errors.

### Details

Before this fix, mypy doesn't recognize any imports that come from pedalboard_native (e.g. `pedalboard.io.AudioFile`).

To reproduce, run:
```shell
mypy -c "from pedalboard.io import AudioFile"
```
You get the error: `Module "pedalboard.io" has no attribute "AudioFile"`. If you add `--follow-untyped-imports`, the error goes away:
```shell
mypy -c "from pedalboard.io import AudioFile" --follow-untyped-imports
```

After this fix, `--follow-untyped-imports` is no longer necessary.