### PR TITLE
Fix Ruff's minimum python version

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -32,9 +32,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install ruff
       - name: Lint Python code
-        run: ruff check ${{ runner.workspace }}/pedalboard --ignore=E203,F541 --exclude .git,dist,doc,build,vendors,'*.pyi' --line-length 100 
+        run: ruff check ${{ runner.workspace }}/pedalboard --ignore=E203,F541 --exclude .git,dist,doc,build,vendors,'*.pyi' --line-length 100 --target-version py38
       - name: Check Python formatting
-        run: ruff format --check ${{ runner.workspace }}/pedalboard --exclude .git,dist,doc,build,JUCE,examples,vendors,'*.pyi' --diff --line-length 100
+        run: ruff format --check ${{ runner.workspace }}/pedalboard --exclude .git,dist,doc,build,JUCE,examples,vendors,'*.pyi' --diff --line-length 100 --target-version py38
 
   lint-cpp:
     runs-on: 'ubuntu-20.04'

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -308,9 +308,9 @@ def test_preset_parameters(plugin_filename: str, plugin_preset: str):
         actual = getattr(plugin, name)
         if math.isnan(actual):
             continue
-        assert (
-            actual != default
-        ), f"Expected attribute {name} to be different from default ({default}), but was {actual}"
+        assert actual != default, (
+            f"Expected attribute {name} to be different from default ({default}), but was {actual}"
+        )
 
 
 @pytest.mark.skipif(
@@ -322,9 +322,9 @@ def test_get_vst3_preset(plugin_filename: str):
     plugin = load_test_plugin(plugin_filename)
     preset_data: bytes = plugin.preset_data
 
-    assert (
-        preset_data[:4] == b"VST3"
-    ), "Preset data for {plugin_filename} is not in .vstpreset format"
+    assert preset_data[:4] == b"VST3", (
+        "Preset data for {plugin_filename} is not in .vstpreset format"
+    )
     # Check that the class ID (8 bytes into the data) is a 32-character hex string.
     cid = preset_data[8:][:32]
     assert all(c in b"0123456789ABCDEF" for c in cid), f"CID contains invalid characters: {cid}"
@@ -333,17 +333,17 @@ def test_get_vst3_preset(plugin_filename: str):
 @pytest.mark.skipif(not plugin_named("Magical8BitPlug"), reason="Missing Magical8BitPlug 2 plugin.")
 def test_set_vst3_preset():
     plugin_file = plugin_named("Magical8BitPlug")
-    assert (
-        plugin_file is not None and "vst3" in plugin_file
-    ), f"Expected a vst plugin: {plugin_file}"
+    assert plugin_file is not None and "vst3" in plugin_file, (
+        f"Expected a vst plugin: {plugin_file}"
+    )
     plugin = load_test_plugin(plugin_file)
 
     # Pick a known valid value for one of the plugin parameters.
     default_gain_value = plugin.gain
     new_gain_value = 1.0
-    assert (
-        default_gain_value != new_gain_value
-    ), f"Expected default gain to be different than {new_gain_value}"
+    assert default_gain_value != new_gain_value, (
+        f"Expected default gain to be different than {new_gain_value}"
+    )
 
     # Update the parameter and get the resulting .vstpreset bytes.
     plugin.gain = new_gain_value
@@ -353,17 +353,17 @@ def test_set_vst3_preset():
     plugin.gain = default_gain_value
 
     # Sanity check that the parameter was successfully set.
-    assert (
-        plugin.gain == default_gain_value
-    ), f"Expected gain to be reset to {default_gain_value}, but got {plugin.gain}"
+    assert plugin.gain == new_gain_value, (
+        f"Expected gain to be {new_gain_value}, but got {plugin.gain}"
+    )
 
     # Load the .vstpreset bytes and make sure the parameter was
     # updated.
     plugin.preset_data = preset_data
 
-    assert (
-        plugin.gain == new_gain_value
-    ), f"Expected gain to be {new_gain_value}, but got {plugin.gain}"
+    assert plugin.gain == new_gain_value, (
+        f"Expected gain to be {new_gain_value}, but got {plugin.gain}"
+    )
 
 
 @pytest.mark.parametrize("plugin_filename", AVAILABLE_PLUGINS_IN_TEST_ENVIRONMENT)
@@ -832,9 +832,9 @@ def test_plugin_parameters_persist_between_calls(plugin_filename: str):
     plugin.process(noise, sr)
 
     for name, parameter in plugin.parameters.items():
-        assert (
-            getattr(plugin, name) == expected_values[name]
-        ), f"Expected {name} to match saved value"
+        assert getattr(plugin, name) == expected_values[name], (
+            f"Expected {name} to match saved value"
+        )
 
 
 @pytest.mark.parametrize("plugin_filename", sample(AVAILABLE_EFFECT_PLUGINS_IN_TEST_ENVIRONMENT, 1))

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -986,9 +986,9 @@ def test_swapped_parameter_exception(tmp_path: pathlib.Path, extension: str, sam
     filename = str(tmp_path / f"test{extension}")
     with pytest.raises(ValueError) as e:
         pedalboard.io.WriteableAudioFile(filename, samplerate=1, num_channels=samplerate)
-    assert "reversing" in str(
-        e
-    ), "Expected exception to include details about reversing parameters."
+    assert "reversing" in str(e), (
+        "Expected exception to include details about reversing parameters."
+    )
 
 
 @pytest.mark.parametrize("dtype", [np.uint8, np.uint16, np.uint32, np.uint64])

--- a/tests/test_stream_resampler.py
+++ b/tests/test_stream_resampler.py
@@ -199,8 +199,8 @@ def test_returned_sample_count(
 
     for i, (e, a) in enumerate(zip(expected_output[0], output[0])):
         assert e == a, (
-            f"First mismatch at index {i}:\nExpected: [..., {expected_output[0][i - 2: i + 2]},"
-            f" ...]\nActual:   [..., {output[0][i - 2: i + 2]}, ...]"
+            f"First mismatch at index {i}:\nExpected: [..., {expected_output[0][i - 2 : i + 2]},"
+            f" ...]\nActual:   [..., {output[0][i - 2 : i + 2]}, ...]"
         )
 
     assert output.shape[1] == expected_output.shape[1], (


### PR DESCRIPTION
## Rationale 

pedalboard  supports python version >=3.8 [ref](https://github.com/spotify/pedalboard/blob/master/.github/workflows/all.yml#L459). 

However Ruff's latest 0.9.10's `target-version` is 3.9 by default [ref ](https://docs.astral.sh/ruff/settings/#target-version). It's good to specify the minimum target version so that we will not have lint/format errors targeting 3.9.

I confirmed recent CI runs with Ruff version 0.9.10 and it seems existing pytest codes have format errors.
https://github.com/spotify/pedalboard/actions/runs/13666616245/job/38209420452?pr=403

## Changes

1. Add `--target-version` option to `ruff format` and `ruff check` commands.

```
      --target-version <TARGET_VERSION>
          The minimum Python version that should be supported
          
          [possible values: py37, py38, py39, py310, py311, py312, py313]
```

<details>
<summary>
ruff command help
</summary>

```zsh
root@cd4bc9e7aab4:/workspaces/pedalboard# ruff --version
ruff 0.9.10
root@cd4bc9e7aab4:/workspaces/pedalboard# ruff format --help
Run the Ruff formatter on the given files or directories

Usage: ruff format [OPTIONS] [FILES]...

Arguments:
  [FILES]...
          List of files or directories to format [default: .]

Options:
      --check
          Avoid writing any formatted files back; instead, exit with a non-zero status code if any files would have been modified, and zero otherwise

      --diff
          Avoid writing any formatted files back; instead, exit with a non-zero status code and the difference between the current file and how the formatted file would look like

      --extension <EXTENSION>
          List of mappings from file extension to language (one of `python`, `ipynb`, `pyi`). For example, to treat `.ipy` files as IPython notebooks, use `--extension ipy:ipynb`

      --target-version <TARGET_VERSION>
          The minimum Python version that should be supported
          
          [possible values: py37, py38, py39, py310, py311, py312, py313]

      --preview
          Enable preview mode; enables unstable formatting. Use `--no-preview` to disable

  -h, --help
          Print help (see a summary with '-h')

Miscellaneous:
  -n, --no-cache
          Disable cache reads
          
          [env: RUFF_NO_CACHE=]

      --cache-dir <CACHE_DIR>
          Path to the cache directory
          
          [env: RUFF_CACHE_DIR=]

      --stdin-filename <STDIN_FILENAME>
          The name of the file when passing it through stdin

File selection:
      --respect-gitignore
          Respect file exclusions via `.gitignore` and other standard ignore files. Use `--no-respect-gitignore` to disable

      --exclude <FILE_PATTERN>
          List of paths, used to omit files and/or directories from analysis

      --force-exclude
          Enforce exclusions, even for paths passed to Ruff directly on the command-line. Use `--no-force-exclude` to disable

Format configuration:
      --line-length <LINE_LENGTH>
          Set the line-length

Editor options:
      --range <RANGE>
          When specified, Ruff will try to only format the code in the given range.
          It might be necessary to extend the start backwards or the end forwards, to fully enclose a logical line.
          The `<RANGE>` uses the format `<start_line>:<start_column>-<end_line>:<end_column>`.
          
          - The line and column numbers are 1 based.
          - The column specifies the nth-unicode codepoint on that line.
          - The end offset is exclusive.
          - The column numbers are optional. You can write `--range=1-2` instead of `--range=1:1-2:1`.
          - The end position is optional. You can write `--range=2` to format the entire document starting from the second line.
          - The start position is optional. You can write `--range=-3` to format the first three lines of the document.
          
          The option can only be used when formatting a single file. Range formatting of notebooks is unsupported.

Log levels:
  -v, --verbose
          Enable verbose logging

  -q, --quiet
          Print diagnostics, but nothing else

  -s, --silent
          Disable all logging (but still exit with status code "1" upon detecting diagnostics)

Global options:
      --config <CONFIG_OPTION>
          Either a path to a TOML configuration file (`pyproject.toml` or `ruff.toml`), or a TOML `<KEY> = <VALUE>` pair (such as you might find in a `ruff.toml` configuration file) overriding a specific configuration option. Overrides of
          individual settings using this option always take precedence over all configuration files, including configuration files that were also specified using `--config`

      --isolated
          Ignore all configuration files
root@cd4bc9e7aab4:/workspaces/pedalboard# ruff check --help
Run Ruff on the given files or directories

Usage: ruff check [OPTIONS] [FILES]...

Arguments:
  [FILES]...  List of files or directories to check [default: .]

Options:
      --fix                              Apply fixes to resolve lint violations. Use `--no-fix` to disable or `--unsafe-fixes` to include unsafe fixes
      --unsafe-fixes                     Include fixes that may not retain the original intent of the code. Use `--no-unsafe-fixes` to disable
      --show-fixes                       Show an enumeration of all fixed lint violations. Use `--no-show-fixes` to disable
      --diff                             Avoid writing any fixed files back; instead, output a diff for each changed file to stdout, and exit 0 if there are no diffs. Implies `--fix-only`
  -w, --watch                            Run in watch mode by re-running whenever files change
      --fix-only                         Apply fixes to resolve lint violations, but don't report on, or exit non-zero for, leftover violations. Implies `--fix`. Use `--no-fix-only` to disable or `--unsafe-fixes` to include unsafe fixes
      --ignore-noqa                      Ignore any `# noqa` comments
      --output-format <OUTPUT_FORMAT>    Output serialization format for violations. The default serialization format is "full" [env: RUFF_OUTPUT_FORMAT=] [possible values: concise, full, json, json-lines, junit, grouped, github, gitlab, pylint,
                                         rdjson, azure, sarif]
  -o, --output-file <OUTPUT_FILE>        Specify file to write the linter output to (default: stdout) [env: RUFF_OUTPUT_FILE=]
      --target-version <TARGET_VERSION>  The minimum Python version that should be supported [possible values: py37, py38, py39, py310, py311, py312, py313]
      --preview                          Enable preview mode; checks will include unstable rules and fixes. Use `--no-preview` to disable
      --extension <EXTENSION>            List of mappings from file extension to language (one of `python`, `ipynb`, `pyi`). For example, to treat `.ipy` files as IPython notebooks, use `--extension ipy:ipynb`
      --statistics                       Show counts for every rule with at least one violation
      --add-noqa                         Enable automatic additions of `noqa` directives to failing lines
      --show-files                       See the files Ruff will be run against with the current settings
      --show-settings                    See the settings Ruff will use to lint a given Python file
  -h, --help                             Print help

Rule selection:
      --select <RULE_CODE>                                 Comma-separated list of rule codes to enable (or ALL, to enable all rules)
      --ignore <RULE_CODE>                                 Comma-separated list of rule codes to disable
      --extend-select <RULE_CODE>                          Like --select, but adds additional rule codes on top of those already specified
      --per-file-ignores <PER_FILE_IGNORES>                List of mappings from file pattern to code to exclude
      --extend-per-file-ignores <EXTEND_PER_FILE_IGNORES>  Like `--per-file-ignores`, but adds additional ignores on top of those already specified
      --fixable <RULE_CODE>                                List of rule codes to treat as eligible for fix. Only applicable when fix itself is enabled (e.g., via `--fix`)
      --unfixable <RULE_CODE>                              List of rule codes to treat as ineligible for fix. Only applicable when fix itself is enabled (e.g., via `--fix`)
      --extend-fixable <RULE_CODE>                         Like --fixable, but adds additional rule codes on top of those already specified

File selection:
      --exclude <FILE_PATTERN>         List of paths, used to omit files and/or directories from analysis
      --extend-exclude <FILE_PATTERN>  Like --exclude, but adds additional files and directories on top of those already excluded
      --respect-gitignore              Respect file exclusions via `.gitignore` and other standard ignore files. Use `--no-respect-gitignore` to disable
      --force-exclude                  Enforce exclusions, even for paths passed to Ruff directly on the command-line. Use `--no-force-exclude` to disable

Miscellaneous:
  -n, --no-cache                         Disable cache reads [env: RUFF_NO_CACHE=]
      --cache-dir <CACHE_DIR>            Path to the cache directory [env: RUFF_CACHE_DIR=]
      --stdin-filename <STDIN_FILENAME>  The name of the file when passing it through stdin
  -e, --exit-zero                        Exit with status code "0", even upon detecting lint violations
      --exit-non-zero-on-fix             Exit with a non-zero status code if any files were modified via fix, even if no lint violations remain

Log levels:
  -v, --verbose  Enable verbose logging
  -q, --quiet    Print diagnostics, but nothing else
  -s, --silent   Disable all logging (but still exit with status code "1" upon detecting diagnostics)

Global options:
      --config <CONFIG_OPTION>  Either a path to a TOML configuration file (`pyproject.toml` or `ruff.toml`), or a TOML `<KEY> = <VALUE>` pair (such as you might find in a `ruff.toml` configuration file) overriding a specific configuration option.
                                Overrides of individual settings using this option always take precedence over all configuration files, including configuration files that were also specified using `--config`
      --isolated                Ignore all configuration files
```
</details>

2. Fix `ruff format` errors by adding `target-version` options. 

## Refs 

Ruff 0.9.10 code related to default python-version:
- https://github.com/astral-sh/ruff/blob/0.9.10/crates/ruff_linter/src/settings/types.rs#L39-L44
- https://github.com/astral-sh/ruff/blob/0.9.10/crates/ruff_python_ast/src/python_version.rs#L67-L71

It seems from 0.8.0, it's changed to use py39 [ref](https://github.com/astral-sh/ruff/blob/main/BREAKING_CHANGES.md#080)
[0.8.0 release](https://github.com/astral-sh/ruff/commit/8358ad8d251a8c72a679202b5d667bbcb24639c3) Nov 22, 2024