### PR TITLE
Fix device disconnect

### DIFF
--- a/pedalboard/io/__init__.py
+++ b/pedalboard/io/__init__.py
@@ -1,19 +1,12 @@
-# 預載 NumPy，避免 Pybind11 懶載入死鎖
 import numpy  # noqa: F401
-
-# 星號匯入仍保留
 from pedalboard_native.io import *  # noqa: F403, F401
 
-# 顯式匯入 AudioStream，給 Ruff 一個確定參照
-from pedalboard_native.io import AudioStream as _AudioStream  # noqa: F401
-
-# ------------------------------------------------------------------
-# Monkey-patch AudioStream.write：裝置斷線時拋 RuntimeError
-# ------------------------------------------------------------------
+from pedalboard_native.io import AudioStream as _AudioStream  # 顯式給 Ruff
 
 from ._device_helpers import is_device_alive  # noqa: E402
 
-_original_write = _AudioStream.write  # 保存原方法，Ruff 不再抱怨 F405
+# ----- monkey-patch -----
+_original_write = _AudioStream.write  # noqa: F401
 
 
 def _patched_write(self, samples, sample_rate):
@@ -22,5 +15,5 @@ def _patched_write(self, samples, sample_rate):
     return _original_write(self, samples, sample_rate)
 
 
-_AudioStream.write = _patched_write  # 套用補丁
-# ------------------------------------------------------------------
+_AudioStream.write = _patched_write
+# ------------------------

--- a/pedalboard/io/__init__.py
+++ b/pedalboard/io/__init__.py
@@ -5,3 +5,21 @@
 # process so that Pybind11's lazy import is effectively a no-op.
 import numpy  # noqa
 from pedalboard_native.io import *  # noqa: F403, F401 # type: ignore
+
+# ➜ 新增這一行，讓 Ruff 確定 AudioStream 是誰
+from pedalboard.io import AudioStream as _AudioStream
+
+# ----- Monkey-patch AudioStream.write：裝置斷線時丟 RuntimeError -----
+from ._device_helpers import is_device_alive  # noqa: E402
+
+_original_write = AudioStream.write  # 保存原本的方法
+
+
+def _patched_write(self, samples, sample_rate):
+    if not is_device_alive(self._output_device_name):
+        raise RuntimeError(f"Output device '{self._output_device_name}' disconnected.")
+    return _original_write(self, samples, sample_rate)
+
+
+AudioStream.write = _patched_write
+# --------------------------------------------------------------------

--- a/pedalboard/io/__init__.py
+++ b/pedalboard/io/__init__.py
@@ -1,7 +1,7 @@
 import numpy  # noqa: F401
 from pedalboard_native.io import *  # noqa: F403, F401
 
-from pedalboard_native.io import AudioStream as _AudioStream  # 顯式給 Ruff
+from pedalboard_native.io import AudioStream as _AudioStream  # Explicitly alias for Ruff (linter)
 
 from ._device_helpers import is_device_alive  # noqa: E402
 

--- a/pedalboard/io/_device_helpers.py
+++ b/pedalboard/io/_device_helpers.py
@@ -1,20 +1,15 @@
 """Utilities for querying PortAudio devices."""
 
-# PortAudio 可能根本沒裝（CI 或雲端機器）；因此包在 try/except。
 try:
-    import sounddevice as sd  # type: ignore
-except Exception:  # PortAudio 不在 → 匯入失敗
-    sd = None  # 讓下游程式 fail-open
+    import sounddevice as sd  # 可能找不到 PortAudio
+except Exception:
+    sd = None  # 無聲卡環境 fail-open
 
 
 def is_device_alive(name: str) -> bool:
-    """
-    回傳 True 代表 PortAudio 仍能找到指定 `name` 裝置。
-    若 sounddevice/PortAudio 不可用，保守回 True 以避免在無聲卡環境崩潰。
-    """
+    """True ↔ 裝置仍存在；PortAudio 不可用時保守回 True。"""
     if sd is None:
         return True
-
     try:
         return any(d["name"] == name for d in sd.query_devices())
     except Exception:

--- a/pedalboard/io/_device_helpers.py
+++ b/pedalboard/io/_device_helpers.py
@@ -1,14 +1,16 @@
-try:
-    import sounddevice as sd
-except Exception:  # PortAudio 不在 → 匯入失敗
-    sd = None  # 設為 None，後面走「fail-open」邏輯
+"""Utilities for querying PortAudio devices."""
 
-_original_write = _AudioStream.write
+# PortAudio 可能根本沒裝（CI 或雲端機器）；因此包在 try/except。
+try:
+    import sounddevice as sd  # type: ignore
+except Exception:  # PortAudio 不在 → 匯入失敗
+    sd = None  # 讓下游程式 fail-open
+
 
 def is_device_alive(name: str) -> bool:
     """
-    若 `sounddevice` / PortAudio 不可用，就直接回 True，
-    讓程式在無聲卡環境仍可運行與測試。
+    回傳 True 代表 PortAudio 仍能找到指定 `name` 裝置。
+    若 sounddevice/PortAudio 不可用，保守回 True 以避免在無聲卡環境崩潰。
     """
     if sd is None:
         return True
@@ -17,5 +19,3 @@ def is_device_alive(name: str) -> bool:
         return any(d["name"] == name for d in sd.query_devices())
     except Exception:
         return True
-
-_AudioStream.write = _patched_write

--- a/pedalboard/io/_device_helpers.py
+++ b/pedalboard/io/_device_helpers.py
@@ -1,13 +1,13 @@
 """Utilities for querying PortAudio devices."""
 
 try:
-    import sounddevice as sd  # 可能找不到 PortAudio
+    import sounddevice as sd  # Might not find PortAudio
 except Exception:
-    sd = None  # 無聲卡環境 fail-open
+    sd = None  # Fail-open in environments without a sound card
 
 
 def is_device_alive(name: str) -> bool:
-    """True ↔ 裝置仍存在；PortAudio 不可用時保守回 True。"""
+    """True: device still available; PortAudio fallback to True when device not available."""
     if sd is None:
         return True
     try:

--- a/pedalboard/io/_device_helpers.py
+++ b/pedalboard/io/_device_helpers.py
@@ -1,0 +1,21 @@
+try:
+    import sounddevice as sd
+except Exception:  # PortAudio 不在 → 匯入失敗
+    sd = None  # 設為 None，後面走「fail-open」邏輯
+
+_original_write = _AudioStream.write
+
+def is_device_alive(name: str) -> bool:
+    """
+    若 `sounddevice` / PortAudio 不可用，就直接回 True，
+    讓程式在無聲卡環境仍可運行與測試。
+    """
+    if sd is None:
+        return True
+
+    try:
+        return any(d["name"] == name for d in sd.query_devices())
+    except Exception:
+        return True
+
+_AudioStream.write = _patched_write

--- a/tests/test_device_disconnect.py
+++ b/tests/test_device_disconnect.py
@@ -3,12 +3,11 @@ import pytest
 from pedalboard.io import AudioStream
 
 
-def test_write_should_raise():
+def test_write_raises_if_device_missing():
     buf = np.zeros(512, np.float32)
-    fake = "___FAKE_DEVICE___"  # 不存在的裝置名
+    fake = "___FAKE_DEVICE___"
 
-    # 現階段程式不會拋 RuntimeError，因此這個測試會失敗
-    with pytest.raises(RuntimeError):
-        with AudioStream() as s:  # 不指定，讓它挑預設裝置
-            s._output_device_name = fake  # 手動改成假裝置
+    with pytest.raises(RuntimeError, match="disconnected"):
+        with AudioStream() as s:  # 啟動預設裝置
+            s._output_device_name = fake  # 假裝裝置「消失」
             s.write(buf, 44100)

--- a/tests/test_device_disconnect.py
+++ b/tests/test_device_disconnect.py
@@ -1,0 +1,14 @@
+import numpy as np
+import pytest
+from pedalboard.io import AudioStream
+
+
+def test_write_should_raise():
+    buf = np.zeros(512, np.float32)
+    fake = "___FAKE_DEVICE___"  # 不存在的裝置名
+
+    # 現階段程式不會拋 RuntimeError，因此這個測試會失敗
+    with pytest.raises(RuntimeError):
+        with AudioStream() as s:  # 不指定，讓它挑預設裝置
+            s._output_device_name = fake  # 手動改成假裝置
+            s.write(buf, 44100)

--- a/tests/test_device_disconnect.py
+++ b/tests/test_device_disconnect.py
@@ -4,7 +4,7 @@ from pedalboard.io import AudioStream
 
 
 def _first_usable_output_device() -> str | None:
-    """嘗試用幾個常見名稱開 AudioStream；成功就回傳，失敗回 None。"""
+    """Try opening AudioStream with a few common device names; return the name if successful, or None if all fail."""
     for name in ("Built-in Output", "default"):
         try:
             with AudioStream(output_device_name=name):
@@ -25,6 +25,6 @@ def test_write_raises_if_device_missing():
 
     with pytest.raises(RuntimeError, match="disconnected"):
         with AudioStream(output_device_name=real_device) as s:
-            # 模擬「裝置被拔掉」
+            # Simulate "device being unplugged"
             s._output_device_name = fake
             s.write(buf, 44_100)

--- a/tests/test_device_disconnect.py
+++ b/tests/test_device_disconnect.py
@@ -3,11 +3,28 @@ import pytest
 from pedalboard.io import AudioStream
 
 
+def _first_usable_output_device() -> str | None:
+    """嘗試用幾個常見名稱開 AudioStream；成功就回傳，失敗回 None。"""
+    for name in ("Built-in Output", "default"):
+        try:
+            with AudioStream(output_device_name=name):
+                return name
+        except Exception:
+            continue
+    return None
+
+
 def test_write_raises_if_device_missing():
     buf = np.zeros(512, np.float32)
+
+    real_device = _first_usable_output_device()
+    if real_device is None:
+        pytest.skip("No output device available on this host")
+
     fake = "___FAKE_DEVICE___"
 
     with pytest.raises(RuntimeError, match="disconnected"):
-        with AudioStream() as s:  # 啟動預設裝置
-            s._output_device_name = fake  # 假裝裝置「消失」
-            s.write(buf, 44100)
+        with AudioStream(output_device_name=real_device) as s:
+            # 模擬「裝置被拔掉」
+            s._output_device_name = fake
+            s.write(buf, 44_100)

--- a/tests/test_type_hints.py
+++ b/tests/test_type_hints.py
@@ -21,7 +21,7 @@ import subprocess
 import sys
 from glob import glob
 from subprocess import STDOUT
-from typing import Dict, List, Tuple
+from typing import Dict
 
 import pytest
 from psutil import Process


### PR DESCRIPTION
### What
* Monkey-patch `AudioStream.write` so that it raises **RuntimeError("…disconnected")**
  when the configured output device disappears.
* Adds `_device_helpers.is_device_alive()` (sounddevice-based).
* Adds unit-test `test_device_disconnect.py`.

### Why
Fixes #411.  
Previously, if the user unplugged speakers/headphones during streaming,
`AudioStream.write()` blocked forever.  This killed Safe-and-Sound pipelines
(and any real-time player) because there was no way to detect the failure.

### How to reproduce (before this patch)
```python
with AudioStream(output_device_name="Built-in Output") as s:
    s.write(audio, 44100)  # ← unplug device here → hangs forever
```

### After (with this patch)
`AudioStream.write()` now raises:
RuntimeError: Output device '…' disconnected.

### Test plan
pytest -q tests/test_device_disconnect.py   # 1 passed (or skipped on headless)
CI matrix (Linux/macOS/Windows) is green.
