### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -900,7 +900,7 @@ public:
    * loading assets from disk, etc). These background tasks may depend on the
    * event loop, which Pedalboard does not pump by default.
    *
-   * Returns true if the plugin rendered audio within the alloted timeout; false
+   * Returns true if the plugin rendered audio within the allotted timeout; false
    * if no audio was received before the timeout expired.
    */
   bool attemptToWarmUp() {
@@ -919,7 +919,7 @@ public:
       return false;
     }
 
-    // Set input and output busses/channels appropriately:
+    // Set input and output buses/channels appropriately:
     int numOutputChannels =
         std::max(pluginInstance->getMainBusNumInputChannels(),
                  pluginInstance->getMainBusNumOutputChannels());
@@ -1019,7 +1019,7 @@ public:
       return ExternalPluginReloadType::Unknown;
     }
 
-    // Set input and output busses/channels appropriately:
+    // Set input and output buses/channels appropriately:
     setNumChannels(numInputChannels);
     pluginInstance->setNonRealtime(true);
     pluginInstance->prepareToPlay(sampleRate, bufferSize);

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -900,8 +900,8 @@ public:
    * loading assets from disk, etc). These background tasks may depend on the
    * event loop, which Pedalboard does not pump by default.
    *
-   * Returns true if the plugin rendered audio within the allotted timeout; false
-   * if no audio was received before the timeout expired.
+   * Returns true if the plugin rendered audio within the allotted timeout;
+   * false if no audio was received before the timeout expired.
    */
   bool attemptToWarmUp() {
     if (!pluginInstance || initializationTimeout <= 0)

--- a/pedalboard/io/AudioFileInit.h
+++ b/pedalboard/io/AudioFileInit.h
@@ -34,7 +34,7 @@ namespace py = pybind11;
 namespace Pedalboard {
 
 // For pybind11-stubgen to properly parse the docstrings,
-// we have to delcare all of the AudioFile subclasses first before using
+// we have to declare all of the AudioFile subclasses first before using
 // their types (i.e.: as return types from `__new__`).
 // See:
 // https://pybind11.readthedocs.io/en/latest/advanced/misc.html#avoiding-cpp-types-in-docstrings

--- a/pedalboard/plugins/Chorus.h
+++ b/pedalboard/plugins/Chorus.h
@@ -55,7 +55,7 @@ inline void init_chorus(py::module &m) {
       "control, a feedback control, and the centre delay of the modulation. "
       "\n\n"
       "Note: To get classic chorus sounds try to use a centre delay time "
-      "around 7-8 ms with a low feeback volume and a low depth. This effect "
+      "around 7-8 ms with a low feedback volume and a low depth. This effect "
       "can also be used as a flanger with a lower centre delay time and a "
       "lot of feedback, and as a vibrato effect if the mix value is 1.")
       .def(py::init([](float rateHz, float depth, float centreDelayMs,

--- a/pedalboard_native/__init__.pyi
+++ b/pedalboard_native/__init__.pyi
@@ -184,7 +184,7 @@ class Chorus(Plugin):
 
     This audio effect can be controlled via the speed and depth of the LFO controlling the frequency response, a mix control, a feedback control, and the centre delay of the modulation.
 
-    Note: To get classic chorus sounds try to use a centre delay time around 7-8 ms with a low feeback volume and a low depth. This effect can also be used as a flanger with a lower centre delay time and a lot of feedback, and as a vibrato effect if the mix value is 1.
+    Note: To get classic chorus sounds try to use a centre delay time around 7-8 ms with a low feedback volume and a low depth. This effect can also be used as a flanger with a lower centre delay time and a lot of feedback, and as a vibrato effect if the mix value is 1.
     """
 
     def __init__(

--- a/setup.py
+++ b/setup.py
@@ -404,7 +404,7 @@ def patch_compile(original_compile):
         # Remove the Python header from most files; we only need it when compiling
         # This speeds up compile times on CI as most of the objects don't need Python
         # headers at all, and including -I/include/python3.x/Python.h prevents us from
-        # re-using the same object file for different Python versions.
+        # reusing the same object file for different Python versions.
         if any("include/python3" in arg for arg in _cc_args) and should_omit_python_header:
             _cc_args = [arg for arg in _cc_args if "include/python3" not in arg]
 

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -42,7 +42,7 @@ def test_fail_on_invalid_plugin():
 
 def test_fail_on_invalid_sample_rate():
     with pytest.raises(TypeError):
-        Pedalboard([]).process([], "fourty four one hundred")  # type: ignore
+        Pedalboard([]).process([], "forty four one hundred")  # type: ignore
 
 
 def test_fail_on_invalid_buffer_size():


### PR DESCRIPTION
% `codespell --ignore-words-list=bu,bufferin,caf,lockin,recuse --skip="./vendors" --write-changes`
* https://pypi.org/project/codespell