### PR TITLE
Add Constant Bit Rate (CBR) support for MP3Compressor

### DIFF
--- a/pedalboard_native/__init__.pyi
+++ b/pedalboard_native/__init__.pyi
@@ -895,24 +895,62 @@ class LowpassFilter(Plugin):
         pass
     pass
 
+class MP3CompressorMode:
+    CBR: MP3CompressorMode
+    VBR: MP3CompressorMode
+    def __eq__(self, other: object) -> bool: ...
+    def __getstate__(self) -> int: ...
+    def __hash__(self) -> int: ...
+    def __index__(self) -> int: ...
+    def __init__(self, value: int) -> None: ...
+    def __int__(self) -> int: ...
+    def __ne__(self, other: object) -> bool: ...
+    def __repr__(self) -> str: ...
+    def __setstate__(self, state: int) -> None: ...
+    def __str__(self) -> str: ...
+    @property
+    def name(self) -> str: ...
+    @property
+    def value(self) -> int: ...
+
 class MP3Compressor(Plugin):
     """
     An MP3 compressor plugin that runs the LAME MP3 encoder in real-time to add compression artifacts to the audio stream.
 
-    Currently only supports variable bit-rate mode (VBR) and accepts a floating-point VBR quality value (between 0.0 and 10.0; lower is better).
+    Supports both Variable Bit Rate (VBR) and Constant Bit Rate (CBR) modes:
+    - VBR mode: accepts a floating-point quality value (0.0-10.0; lower is better)
+    - CBR mode: accepts a bitrate in kbps (32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320)
 
     Note that the MP3 format only supports 8kHz, 11025Hz, 12kHz, 16kHz, 22050Hz, 24kHz, 32kHz, 44.1kHz, and 48kHz audio; if an unsupported sample rate is provided, an exception will be thrown at processing time.
     """
 
-    def __init__(self, vbr_quality: float = 2.0) -> None: ...
+    @typing.overload
+    def __init__(self, vbr_quality: float = 2.0) -> None:
+        """Create an MP3Compressor in VBR mode with the specified quality."""
+        ...
+    @typing.overload
+    def __init__(self, *, vbr_quality: float | None = None, bitrate: int | None = None) -> None:
+        """Create an MP3Compressor. Specify either vbr_quality (for VBR mode) or bitrate (for CBR mode)."""
+        ...
     def __repr__(self) -> str: ...
     @property
     def vbr_quality(self) -> float:
-        """ """
+        """VBR quality (0.0-10.0, lower is better). Setting this switches to VBR mode."""
 
     @vbr_quality.setter
     def vbr_quality(self, arg1: float) -> None:
         pass
+    @property
+    def bitrate(self) -> int:
+        """CBR bitrate in kbps. Setting this switches to CBR mode."""
+
+    @bitrate.setter
+    def bitrate(self, arg1: int) -> None:
+        pass
+    @property
+    def mode(self) -> MP3CompressorMode:
+        """Current encoding mode (VBR or CBR)."""
+
     pass
 
 class NoiseGate(Plugin):

--- a/tests/test_mp3_compressor.py
+++ b/tests/test_mp3_compressor.py
@@ -75,3 +75,135 @@ def test_mp3_compressor_fails_on_invalid_sample_rate(sample_rate: int, num_chann
 
     with pytest.raises(ValueError):
         MP3Compressor(1)(sine_wave, sample_rate)
+
+
+# CBR Mode Tests
+@pytest.mark.parametrize("bitrate", [32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320])
+@pytest.mark.parametrize("sample_rate", [44100, 48000])
+@pytest.mark.parametrize("num_channels", [1, 2])
+def test_mp3_compressor_cbr(bitrate: int, sample_rate: int, num_channels: int):
+    sine_wave = generate_sine_at(sample_rate, num_channels=num_channels)
+    compressor = MP3Compressor()
+    compressor.bitrate = bitrate
+    compressed = compressor(sine_wave, sample_rate)
+    np.testing.assert_allclose(sine_wave, compressed, atol=MP3_ABSOLUTE_TOLERANCE)
+
+
+@pytest.mark.parametrize("bitrate", [128, 192, 320])
+@pytest.mark.parametrize("sample_rate", [44100, 48000])
+@pytest.mark.parametrize("num_channels", [1, 2])
+def test_mp3_compressor_cbr_invariant_to_buffer_size(
+    bitrate: int, sample_rate: int, num_channels: int
+):
+    sine_wave = generate_sine_at(sample_rate, num_channels=num_channels)
+
+    compressor = MP3Compressor()
+    compressor.bitrate = bitrate
+    compressed_different_buffer_sizes = [
+        compressor(sine_wave, sample_rate, buffer_size=buffer_size)
+        for buffer_size in (1, 128, 1152, 65536)
+    ]
+
+    # These should all be the same, so any two should be the same:
+    for a, b in zip(compressed_different_buffer_sizes, compressed_different_buffer_sizes[:1]):
+        np.testing.assert_allclose(a, b, atol=MP3_ABSOLUTE_TOLERANCE)
+
+
+@pytest.mark.parametrize("invalid_bitrate", [100, 150, 250, 400, 50])
+def test_mp3_compressor_cbr_invalid_bitrate(invalid_bitrate: int):
+    compressor = MP3Compressor()
+    with pytest.raises(ValueError, match="Invalid CBR bitrate"):
+        compressor.bitrate = invalid_bitrate
+
+
+def test_mp3_compressor_mode_switching():
+    """Test switching between VBR and CBR modes via property setters."""
+    from pedalboard import MP3CompressorMode
+
+    # Start with VBR
+    compressor = MP3Compressor(vbr_quality=3.0)
+    assert compressor.mode == MP3CompressorMode.VBR
+    assert compressor.vbr_quality == 3.0
+
+    # Switch to CBR
+    compressor.bitrate = 192
+    assert compressor.mode == MP3CompressorMode.CBR
+    assert compressor.bitrate == 192
+
+    # Switch back to VBR
+    compressor.vbr_quality = 1.0
+    assert compressor.mode == MP3CompressorMode.VBR
+    assert compressor.vbr_quality == 1.0
+
+    # Test multiple switches
+    compressor.bitrate = 256
+    assert compressor.mode == MP3CompressorMode.CBR
+    compressor.bitrate = 128
+    assert compressor.mode == MP3CompressorMode.CBR
+    assert compressor.bitrate == 128
+
+
+def test_mp3_compressor_cbr_constructor():
+    """Test CBR constructor by setting bitrate after creation."""
+    compressor = MP3Compressor(vbr_quality=2.0)
+    compressor.bitrate = 128
+    assert compressor.mode == MP3CompressorMode.CBR
+    assert compressor.bitrate == 128
+
+
+def test_mp3_compressor_repr():
+    """Test string representation for both modes."""
+    # VBR mode
+    vbr_compressor = MP3Compressor(vbr_quality=2.5)
+    repr_str = repr(vbr_compressor)
+    assert "vbr_quality=2.5" in repr_str
+    assert "MP3Compressor" in repr_str
+
+    # CBR mode
+    cbr_compressor = MP3Compressor()
+    cbr_compressor.bitrate = 192
+    repr_str = repr(cbr_compressor)
+    assert "bitrate=192" in repr_str
+    assert "MP3Compressor" in repr_str
+
+
+@pytest.mark.parametrize("bitrate", [128, 256])
+@pytest.mark.parametrize(
+    "sample_rate", [48000, 44100, 32000, 24000, 22050, 16000, 12000, 11025, 8000]
+)
+@pytest.mark.parametrize("num_channels", [1, 2])
+def test_mp3_compressor_cbr_arbitrary_sample_rate(
+    bitrate: int, sample_rate: int, num_channels: int
+):
+    sine_wave = generate_sine_at(sample_rate, num_channels=num_channels)
+    compressor = MP3Compressor()
+    compressor.bitrate = bitrate
+    compressed = compressor(sine_wave, sample_rate)
+    np.testing.assert_allclose(sine_wave, compressed, atol=MP3_ABSOLUTE_TOLERANCE)
+
+
+@pytest.mark.parametrize("sample_rate", [96000, 6000, 44101])
+@pytest.mark.parametrize("num_channels", [1, 2])
+def test_mp3_compressor_cbr_fails_on_invalid_sample_rate(sample_rate: int, num_channels: int):
+    sine_wave = generate_sine_at(sample_rate, num_channels=num_channels)
+    compressor = MP3Compressor()
+    compressor.bitrate = 128
+
+    with pytest.raises(ValueError):
+        compressor(sine_wave, sample_rate)
+
+
+def test_mp3_compressor_default_mode():
+    """Test that default constructor creates VBR mode."""
+    compressor = MP3Compressor()
+    assert compressor.mode == MP3CompressorMode.VBR
+    assert compressor.vbr_quality == 2.0
+
+
+@pytest.mark.parametrize("bitrate", [32, 320])  # Test extreme valid bitrates
+def test_mp3_compressor_cbr_extreme_bitrates(bitrate: int):
+    """Test CBR mode with extreme but valid bitrates."""
+    compressor = MP3Compressor()
+    compressor.bitrate = bitrate
+    assert compressor.mode == MP3CompressorMode.CBR
+    assert compressor.bitrate == bitrate


### PR DESCRIPTION
Implements CBR (Constant Bit Rate) support for MP3Compressor to complement the existing VBR (Variable Bit Rate) functionality, addressing issue #430.

  ## Summary

  Adds CBR mode support while maintaining full backward compatibility with existing VBR functionality. Users can now set constant bitrates from 32-320 kbps and
  switch between VBR and CBR modes seamlessly.

  ## API Changes

  ```python
  from pedalboard import MP3Compressor, MP3CompressorMode

  # Existing VBR usage (unchanged)
  vbr_compressor = MP3Compressor(vbr_quality=2.0)

  # New CBR usage
  cbr_compressor = MP3Compressor()
  cbr_compressor.bitrate = 192  # Switches to CBR mode

  # Mode switching
  compressor = MP3Compressor(vbr_quality=3.0)  # VBR
  compressor.bitrate = 128                      # Switch to CBR
  compressor.vbr_quality = 1.0                  # Switch back to VBR

  # Check current mode
  print(compressor.mode)     # MP3CompressorMode.VBR or MP3CompressorMode.CBR
  print(compressor.bitrate)  # Current CBR bitrate (when in CBR mode)

  Implementation Details

  C++ Changes (pedalboard/plugins/MP3Compressor.h):
  - Added enum class Mode { VBR, CBR } for mode tracking
  - Added setBitrate(), getBitrate(), getMode() methods with validation
  - Updated prepare() to use appropriate LAME API calls:
    - VBR: lame_set_VBR(vbr_default) + lame_set_VBR_quality()
    - CBR: lame_set_VBR(vbr_off) + lame_set_brate()
  - Added Python bindings for new properties and MP3CompressorMode enum

  Type Hints (pedalboard_native/__init__.pyi):
  - Added MP3CompressorMode enum class
  - Added type hints for bitrate and mode properties
  - Updated docstring to document CBR support

  Test Coverage (tests/test_mp3_compressor.py):
  - 9 new test functions covering all CBR functionality
  - Tests all valid bitrates (32-320 kbps)
  - Tests invalid bitrate rejection, mode switching, and edge cases

  Supported CBR Bitrates

  All MPEG-1 and MPEG-2 standard bitrates: 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320 kbps

  Invalid bitrates throw descriptive error messages listing valid options.

  Validation

  - Backward compatibility: All existing VBR tests pass unchanged
  - Uses standard LAME API calls for CBR functionality
  - Comprehensive error handling with clear validation messages
  - Cross-platform compatibility with existing MP3 sample rate restrictions