### PR TITLE
Fix for reading certain Ogg files on Linux via file-like objects.

### DIFF
--- a/pedalboard/io/PythonInputStream.h
+++ b/pedalboard/io/PythonInputStream.h
@@ -63,6 +63,7 @@ public:
 
   juce::int64 getTotalLength() noexcept override {
     ScopedDowngradeToReadLockWithGIL lock(objectLock);
+    ClearErrnoBeforeReturn clearErrnoBeforeReturn;
     py::gil_scoped_acquire acquire;
 
     if (PythonException::isPending())
@@ -99,6 +100,7 @@ public:
     // sign that something is broken!
     jassert(buffer != nullptr && bytesToRead >= 0);
     ScopedDowngradeToReadLockWithGIL lock(objectLock);
+    ClearErrnoBeforeReturn clearErrnoBeforeReturn;
 
     py::gil_scoped_acquire acquire;
     if (PythonException::isPending())
@@ -161,6 +163,7 @@ public:
     juce::int64 totalLength = getTotalLength();
 
     ScopedDowngradeToReadLockWithGIL lock(objectLock);
+    ClearErrnoBeforeReturn clearErrnoBeforeReturn;
     py::gil_scoped_acquire acquire;
 
     if (PythonException::isPending())
@@ -183,6 +186,7 @@ public:
 
   juce::int64 getPosition() noexcept override {
     ScopedDowngradeToReadLockWithGIL lock(objectLock);
+    ClearErrnoBeforeReturn clearErrnoBeforeReturn;
     py::gil_scoped_acquire acquire;
 
     if (PythonException::isPending())
@@ -201,6 +205,7 @@ public:
 
   bool setPosition(juce::int64 pos) noexcept override {
     ScopedDowngradeToReadLockWithGIL lock(objectLock);
+    ClearErrnoBeforeReturn clearErrnoBeforeReturn;
     py::gil_scoped_acquire acquire;
 
     if (PythonException::isPending())

--- a/pedalboard/io/ReadableAudioFile.h
+++ b/pedalboard/io/ReadableAudioFile.h
@@ -155,7 +155,7 @@ public:
         } else {
           ss << " has its stream position set to the end of the stream ("
              << originalStreamPosition;
-          ss << "bytes).";
+          ss << " bytes).";
         }
         ss << " Try seeking this file-like object back to its start before "
               "passing it to AudioFile";


### PR DESCRIPTION
This PR fixes a subtle bug where certain Ogg Vorbis files can fail to decode when passed to Pedalboard via Python file-like objects, particularly on Linux. 

The bug stems from an interaction between three layers of code:

1. When Pedalboard reads audio from a Python file-like object (i.e.: a network stream, custom wrapper, etc), it calls Python methods like `read()`, `seek()`, and `tell()`.
2. These Python objects can internally call other native C/C++ code that sets [the thread-local `errno` variable](https://en.wikipedia.org/wiki/Errno.h) as part of normal operation, but this error is not enough to cause the Python wrapper(s) to throw exceptions.
3. The `libvorbis` decoder (specifically in [`vorbisfile.c`](https://github.com/juce-framework/JUCE/blob/ddaa09110392a4419fecbb6d3022bede89b7e841/modules/juce_audio_formats/codecs/oggvorbis/libvorbis-1.3.7/lib/vorbisfile.c#L79)) checks `errno` after I/O operations to detect errors:
   ```c
   errno=0;  // Clear errno before the read
   // ... perform read operation ...
   if(bytes==0 && errno)return(-1);  // Treat errno!=0 as an error
   ```

This results in valid Ogg Vorbis files failing to parse, as - if that last `libvorbis` read returns 0 bytes, but some other code set `errno` - then the entire `read` call fails. This can be spurred on by appending a couple null bytes to the end of the file, which I do in test here.