### PR TITLE
Methods added to plugin classes which simplify changing programs on plugins.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/timothytylee/libgsm.git
 [submodule "vendors/pybind11"]
 	path = vendors/pybind11
-	url = git@github.com:pybind/pybind11.git
+	url = https://github.com/pybind/pybind11.git

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -1394,6 +1394,15 @@ public:
   std::string getProgramName(int index) {
     return pluginInstance->getProgramName(index).toStdString();
   }
+  
+  std::vector<std::string> getProgramList() {
+    std::vector<std::string> list;
+    int numPrograms = getNumPrograms();
+    for (int i = 0; i < numPrograms; ++i) {
+      list.push_back(getProgramName(i));
+    }
+    return list;
+  }
 
   ExternalPluginReloadType reloadType = ExternalPluginReloadType::Unknown;
   juce::PluginDescription foundPluginDescription;
@@ -1864,7 +1873,7 @@ example: a Windows VST3 plugin bundle will not load on Linux or macOS.)
           "This is an internal attribute which gets set on plugin "
           "instantiation and should only be accessed for debugging and "
           "testing.")
-       .def("get_num_programs",
+       .def_property_readonly("num_programs",
             &ExternalPlugin<juce::PatchedVST3PluginFormat>::getNumPrograms,
             "Return the number of programs supported by this plugin")
        .def_property("current_program",
@@ -1872,7 +1881,10 @@ example: a Windows VST3 plugin bundle will not load on Linux or macOS.)
                      &ExternalPlugin<juce::PatchedVST3PluginFormat>::setCurrentProgram)
        .def("get_program_name",
             &ExternalPlugin<juce::PatchedVST3PluginFormat>::getProgramName,
-            "Return the name of the program at the specified index");
+            "Return the name of the program at the specified index")
+       .def_property_readonly("program_list",
+            &ExternalPlugin<juce::PatchedVST3PluginFormat>::getProgramList,
+            "The list of programs reported by the plugin");
 #endif
 
 #if JUCE_PLUGINHOST_AU && JUCE_MAC
@@ -2099,15 +2111,18 @@ see :class:`pedalboard.VST3Plugin`.)
           "This is an internal attribute which gets set on plugin "
           "instantiation and should only be accessed for debugging and "
           "testing.")
-      .def("get_num_programs",
+      .def_property_readonly("num_programs",
            &ExternalPlugin<juce::AudioUnitPluginFormat>::getNumPrograms,
-           "Return the number of programs supported by this plugin")
+           "The number of programs supported by this plugin")
       .def_property("current_program",
-                    &ExternalPlugin<juce::AudioUnitPluginFormat>::getCurrentProgram,
-                    &ExternalPlugin<juce::AudioUnitPluginFormat>::setCurrentProgram)
+           &ExternalPlugin<juce::AudioUnitPluginFormat>::getCurrentProgram,
+           &ExternalPlugin<juce::AudioUnitPluginFormat>::setCurrentProgram)
       .def("get_program_name",
            &ExternalPlugin<juce::AudioUnitPluginFormat>::getProgramName,
-           "Return the name of the program at the specified index");
+           "Return the name of the program at the specified index")
+      .def_property_readonly("program_list",
+           &ExternalPlugin<juce::AudioUnitPluginFormat>::getProgramList,
+           "The list of programs reported by the plugin");
 #endif
 }
 

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -1378,6 +1378,22 @@ public:
 
     StandalonePluginWindow::openWindowAndWait(*pluginInstance, optionalEvent);
   }
+ 
+  int getNumPrograms() {
+    return pluginInstance->getNumPrograms();
+  }
+  
+  int getCurrentProgram() {
+    return pluginInstance->getCurrentProgram();
+  }
+  
+  void setCurrentProgram(int index) {
+    pluginInstance->setCurrentProgram(index);
+  }
+  
+  std::string getProgramName(int index) {
+    return pluginInstance->getProgramName(index).toStdString();
+  }
 
   ExternalPluginReloadType reloadType = ExternalPluginReloadType::Unknown;
   juce::PluginDescription foundPluginDescription;
@@ -1847,7 +1863,16 @@ example: a Windows VST3 plugin bundle will not load on Linux or macOS.)
           "The behavior that this plugin exhibits when .reset() is called. "
           "This is an internal attribute which gets set on plugin "
           "instantiation and should only be accessed for debugging and "
-          "testing.");
+          "testing.")
+       .def("get_num_programs",
+            &ExternalPlugin<juce::PatchedVST3PluginFormat>::getNumPrograms,
+            "Return the number of programs supported by this plugin")
+       .def_property("current_program",
+                     &ExternalPlugin<juce::PatchedVST3PluginFormat>::getCurrentProgram,
+                     &ExternalPlugin<juce::PatchedVST3PluginFormat>::setCurrentProgram)
+       .def("get_program_name",
+            &ExternalPlugin<juce::PatchedVST3PluginFormat>::getProgramName,
+            "Return the name of the program at the specified index");
 #endif
 
 #if JUCE_PLUGINHOST_AU && JUCE_MAC
@@ -2073,7 +2098,16 @@ see :class:`pedalboard.VST3Plugin`.)
           "The behavior that this plugin exhibits when .reset() is called. "
           "This is an internal attribute which gets set on plugin "
           "instantiation and should only be accessed for debugging and "
-          "testing.");
+          "testing.")
+      .def("get_num_programs",
+           &ExternalPlugin<juce::AudioUnitPluginFormat>::getNumPrograms,
+           "Return the number of programs supported by this plugin")
+      .def_property("current_program",
+                    &ExternalPlugin<juce::AudioUnitPluginFormat>::getCurrentProgram,
+                    &ExternalPlugin<juce::AudioUnitPluginFormat>::setCurrentProgram)
+      .def("get_program_name",
+           &ExternalPlugin<juce::AudioUnitPluginFormat>::getProgramName,
+           "Return the name of the program at the specified index");
 #endif
 }
 


### PR DESCRIPTION
This patch adds these methods to both AudioUnit and VST3Plugin classes:

num_programs: "Return the number of programs supported by this plugin"
current_program: "Get and set the index of the current program"
get_program_name: "Return the name of the program at the specified index"
program_list: "The list of programs reported by the plugin"

This is much easier than creating "program_change" MIDI messages (except that process has to be called with reset=False to prevent the program change being reverted) and enables easy access to more than 128 programs in plugins which don't support bank messages (such as Sylenth1)