### PR TITLE
Add context manager stubs to AudioFile class

### DIFF
--- a/pedalboard_native/io/__init__.pyi
+++ b/pedalboard_native/io/__init__.pyi
@@ -122,6 +122,16 @@ class AudioFile:
         those classes below for documentation.
     """
 
+    def __enter__(self) -> typing.Union[ReadableAudioFile, WriteableAudioFile]:
+        """
+        Use this :class:`AudioFile` as a context manager, automatically closing the file and releasing resources when the context manager exits.
+        """
+
+    def __exit__(self, arg0: object, arg1: object, arg2: object) -> None:
+        """
+        Stop using this :class:`AudioFile` as a context manager, close the file, release its resources.
+        """
+
     @classmethod
     @typing.overload
     def __new__(cls, filename: str) -> ReadableAudioFile:


### PR DESCRIPTION
Type checkers report "invalid-context-manager" errors when using AudioFile as a context manager because the `AudioFile` class stub doesn't have `__enter__` and `__exit__` methods defined, even though all subclasses (`ReadableAudioFile`, `WriteableAudioFile`) and the runtime implementation do support the context manager protocol.

Add `__enter__` and `__exit__`method stubs to the AudioFile base class. The `__enter__` method returns `Union[ReadableAudioFile, WriteableAudioFile]` to match the existing `__new__` overloads, allowing type checkers to understand that `AudioFile` instances are valid context managers.
