### PR TITLE
Support `pathlib.Path` objects.

### DIFF
--- a/pedalboard/_pedalboard.py
+++ b/pedalboard/_pedalboard.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import platform
 import re
 import weakref
@@ -761,7 +762,7 @@ except ImportError:
 
 
 def load_plugin(
-    path_to_plugin_file: str,
+    path_to_plugin_file: Union[str, "os.PathLike[str]"],
     parameter_values: Dict[str, Union[str, int, float, bool]] = {},
     plugin_name: Union[str, None] = None,
     initialization_timeout: float = 10.0,
@@ -774,7 +775,7 @@ def load_plugin(
      - Audio Units are supported on macOS
 
     Args:
-        path_to_plugin_file (``str``): The path of a VST3® or Audio Unit plugin file or bundle.
+        path_to_plugin_file (``str`` or ``os.PathLike``): The path of a VST3® or Audio Unit plugin file or bundle.
 
         parameter_values (``Dict[str, Union[str, int, float, bool]]``):
             An optional dictionary of initial values to provide to the plugin

--- a/pedalboard/io/AudioFile.h
+++ b/pedalboard/io/AudioFile.h
@@ -17,42 +17,13 @@
 
 #pragma once
 
-#include <pybind11/pybind11.h>
-
 #include "../juce_overrides/juce_PatchedFLACAudioFormat.h"
 #include "../juce_overrides/juce_PatchedMP3AudioFormat.h"
 #include "../juce_overrides/juce_PatchedWavAudioFormat.h"
 #include "LameMP3AudioFormat.h"
-
-namespace py = pybind11;
+#include "PathUtils.h"
 
 namespace Pedalboard {
-
-/**
- * Convert a Python path-like object (str, bytes, or os.PathLike) to a
- * std::string. This mimics os.fspath() behavior without requiring
- * std::filesystem::path (which requires macOS 10.15+).
- *
- * NOTE: This function calls Python APIs and requires the GIL to be held.
- */
-inline std::string pathToString(py::object path) {
-  // If it's already a string, just return it
-  if (py::isinstance<py::str>(path)) {
-    return path.cast<std::string>();
-  }
-
-  // Try calling os.fspath() to handle PathLike objects
-  try {
-    py::object os = py::module_::import("os");
-    py::object fspath = os.attr("fspath");
-    py::object result = fspath(path);
-    return result.cast<std::string>();
-  } catch (py::error_already_set &e) {
-    throw py::type_error(
-        "expected str, bytes, or os.PathLike object, not " +
-        std::string(py::str(path.get_type().attr("__name__"))));
-  }
-}
 
 static constexpr const unsigned int DEFAULT_AUDIO_BUFFER_SIZE_FRAMES = 8192;
 

--- a/pedalboard/io/AudioFile.h
+++ b/pedalboard/io/AudioFile.h
@@ -17,13 +17,42 @@
 
 #pragma once
 
+#include <pybind11/pybind11.h>
+
 #include "../juce_overrides/juce_PatchedFLACAudioFormat.h"
 #include "../juce_overrides/juce_PatchedMP3AudioFormat.h"
 #include "../juce_overrides/juce_PatchedWavAudioFormat.h"
-#include "AudioFile.h"
 #include "LameMP3AudioFormat.h"
 
+namespace py = pybind11;
+
 namespace Pedalboard {
+
+/**
+ * Convert a Python path-like object (str, bytes, or os.PathLike) to a
+ * std::string. This mimics os.fspath() behavior without requiring
+ * std::filesystem::path (which requires macOS 10.15+).
+ *
+ * NOTE: This function calls Python APIs and requires the GIL to be held.
+ */
+inline std::string pathToString(py::object path) {
+  // If it's already a string, just return it
+  if (py::isinstance<py::str>(path)) {
+    return path.cast<std::string>();
+  }
+
+  // Try calling os.fspath() to handle PathLike objects
+  try {
+    py::object os = py::module_::import("os");
+    py::object fspath = os.attr("fspath");
+    py::object result = fspath(path);
+    return result.cast<std::string>();
+  } catch (py::error_already_set &e) {
+    throw py::type_error(
+        "expected str, bytes, or os.PathLike object, not " +
+        std::string(py::str(path.get_type().attr("__name__"))));
+  }
+}
 
 static constexpr const unsigned int DEFAULT_AUDIO_BUFFER_SIZE_FRAMES = 8192;
 

--- a/pedalboard/io/AudioFileInit.h
+++ b/pedalboard/io/AudioFileInit.h
@@ -150,10 +150,44 @@ inline void init_audio_file(
                          // instantiate subclasses via __new__.
       .def_static(
           "__new__",
-          [](const py::object *, py::object filename, std::string mode) {
+          [](const py::object *, py::object filename, std::string mode,
+             py::object file_like) {
+            // Handle both filename and file_like kwargs for backward compat
+            py::object target;
+            if (!filename.is_none() && !file_like.is_none()) {
+              throw py::type_error(
+                  "Cannot specify both 'filename' and 'file_like'");
+            } else if (!filename.is_none()) {
+              target = filename;
+            } else if (!file_like.is_none()) {
+              target = file_like;
+            } else {
+              throw py::type_error(
+                  "Must specify either 'filename' or 'file_like'");
+            }
+
             if (mode == "r") {
-              return std::make_shared<ReadableAudioFile>(
-                  pathToString(filename));
+              // Check if this is a path-like object (str or has __fspath__)
+              if (isPathLike(target)) {
+                return std::make_shared<ReadableAudioFile>(
+                    pathToString(target));
+              }
+              // Otherwise, try to handle as a file-like object or buffer
+              if (std::optional<py::buffer> buf =
+                      tryConvertingToBuffer(target)) {
+                return std::make_shared<ReadableAudioFile>(
+                    std::make_unique<PythonMemoryViewInputStream>(*buf,
+                                                                  target));
+              } else if (isReadableFileLike(target)) {
+                return std::make_shared<ReadableAudioFile>(
+                    std::make_unique<PythonInputStream>(target));
+              } else {
+                throw py::type_error(
+                    "Expected either a filename, a file-like object (with "
+                    "read, seek, seekable, and tell methods) or a memory view, "
+                    "but received: " +
+                    py::repr(target).cast<std::string>());
+              }
             } else if (mode == "w") {
               throw py::type_error("Opening an audio file for writing requires "
                                    "samplerate and num_channels arguments.");
@@ -162,44 +196,9 @@ inline void init_audio_file(
                                    "read mode (\"r\") or write mode (\"w\").");
             }
           },
-          py::arg("cls"), py::arg("filename"), py::arg("mode") = "r",
-          "Open an audio file for reading.")
-      .def_static(
-          "__new__",
-          [](const py::object *, py::object filelike, std::string mode) {
-            if (mode == "r") {
-              if (!isReadableFileLike(filelike) &&
-                  !tryConvertingToBuffer(filelike)) {
-                throw py::type_error(
-                    "Expected either a filename, a file-like object (with "
-                    "read, seek, seekable, and tell methods) or a memory view, "
-                    "but received: " +
-                    py::repr(filelike).cast<std::string>());
-              }
-
-              if (std::optional<py::buffer> buf =
-                      tryConvertingToBuffer(filelike)) {
-                return std::make_shared<ReadableAudioFile>(
-                    std::make_unique<PythonMemoryViewInputStream>(*buf,
-                                                                  filelike));
-              } else {
-                return std::make_shared<ReadableAudioFile>(
-                    std::make_unique<PythonInputStream>(filelike));
-              }
-            } else if (mode == "w") {
-              throw py::type_error(
-                  "Opening an audio file-like object for writing requires "
-                  "samplerate and num_channels arguments.");
-            } else {
-              throw py::type_error("AudioFile instances can only be opened in "
-                                   "read mode (\"r\") or write mode (\"w\").");
-            }
-          },
-          py::arg("cls"), py::arg("file_like"), py::arg("mode") = "r",
-          "Open a file-like object for reading. The provided object must have "
-          "``read``, ``seek``, ``tell``, and ``seekable`` methods, and must "
-          "return binary data (i.e.: ``open(..., \"w\")`` or ``io.BytesIO``, "
-          "etc.).")
+          py::arg("cls"), py::arg("filename") = py::none(),
+          py::arg("mode") = "r", py::kw_only(),
+          py::arg("file_like") = py::none(), "Open an audio file for reading.")
       .def_static(
           "__new__",
           [](const py::object *, py::object filename, std::string mode,

--- a/pedalboard/io/AudioFileInit.h
+++ b/pedalboard/io/AudioFileInit.h
@@ -17,11 +17,13 @@
 
 #pragma once
 
+#include <filesystem>
 #include <mutex>
 #include <optional>
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl/filesystem.h>
 
 #include "../JuceHeader.h"
 #include "AudioFile.h"
@@ -150,9 +152,10 @@ inline void init_audio_file(
                          // instantiate subclasses via __new__.
       .def_static(
           "__new__",
-          [](const py::object *, std::string filename, std::string mode) {
+          [](const py::object *, std::filesystem::path filename,
+             std::string mode) {
             if (mode == "r") {
-              return std::make_shared<ReadableAudioFile>(filename);
+              return std::make_shared<ReadableAudioFile>(filename.string());
             } else if (mode == "w") {
               throw py::type_error("Opening an audio file for writing requires "
                                    "samplerate and num_channels arguments.");
@@ -201,8 +204,9 @@ inline void init_audio_file(
           "etc.).")
       .def_static(
           "__new__",
-          [](const py::object *, std::string filename, std::string mode,
-             std::optional<double> sampleRate, int numChannels, int bitDepth,
+          [](const py::object *, std::filesystem::path filename,
+             std::string mode, std::optional<double> sampleRate, int numChannels,
+             int bitDepth,
              std::optional<std::variant<std::string, float>> quality) {
             if (mode == "r") {
               throw py::type_error(
@@ -218,7 +222,8 @@ inline void init_audio_file(
               }
 
               return std::make_shared<WriteableAudioFile>(
-                  filename, *sampleRate, numChannels, bitDepth, quality);
+                  filename.string(), *sampleRate, numChannels, bitDepth,
+                  quality);
             } else {
               throw py::type_error("AudioFile instances can only be opened in "
                                    "read mode (\"r\") or write mode (\"w\").");

--- a/pedalboard/io/AudioFileInit.h
+++ b/pedalboard/io/AudioFileInit.h
@@ -17,13 +17,11 @@
 
 #pragma once
 
-#include <filesystem>
 #include <mutex>
 #include <optional>
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
-#include <pybind11/stl/filesystem.h>
 
 #include "../JuceHeader.h"
 #include "AudioFile.h"
@@ -152,10 +150,10 @@ inline void init_audio_file(
                          // instantiate subclasses via __new__.
       .def_static(
           "__new__",
-          [](const py::object *, std::filesystem::path filename,
-             std::string mode) {
+          [](const py::object *, py::object filename, std::string mode) {
             if (mode == "r") {
-              return std::make_shared<ReadableAudioFile>(filename.string());
+              return std::make_shared<ReadableAudioFile>(
+                  pathToString(filename));
             } else if (mode == "w") {
               throw py::type_error("Opening an audio file for writing requires "
                                    "samplerate and num_channels arguments.");
@@ -204,9 +202,8 @@ inline void init_audio_file(
           "etc.).")
       .def_static(
           "__new__",
-          [](const py::object *, std::filesystem::path filename,
-             std::string mode, std::optional<double> sampleRate, int numChannels,
-             int bitDepth,
+          [](const py::object *, py::object filename, std::string mode,
+             std::optional<double> sampleRate, int numChannels, int bitDepth,
              std::optional<std::variant<std::string, float>> quality) {
             if (mode == "r") {
               throw py::type_error(
@@ -222,7 +219,7 @@ inline void init_audio_file(
               }
 
               return std::make_shared<WriteableAudioFile>(
-                  filename.string(), *sampleRate, numChannels, bitDepth,
+                  pathToString(filename), *sampleRate, numChannels, bitDepth,
                   quality);
             } else {
               throw py::type_error("AudioFile instances can only be opened in "

--- a/pedalboard/io/PathUtils.h
+++ b/pedalboard/io/PathUtils.h
@@ -24,6 +24,15 @@ namespace py = pybind11;
 namespace Pedalboard {
 
 /**
+ * Check if a Python object is path-like (str or has __fspath__ method).
+ *
+ * NOTE: This function requires the GIL to be held by the caller.
+ */
+inline bool isPathLike(py::object obj) {
+  return py::isinstance<py::str>(obj) || py::hasattr(obj, "__fspath__");
+}
+
+/**
  * Convert a Python path-like object (str, bytes, or os.PathLike) to a
  * std::string, without requiring std::filesystem::path.
  *

--- a/pedalboard/io/PathUtils.h
+++ b/pedalboard/io/PathUtils.h
@@ -1,0 +1,51 @@
+/*
+ * pedalboard
+ * Copyright 2022 Spotify AB
+ *
+ * Licensed under the GNU Public License, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace Pedalboard {
+
+/**
+ * Convert a Python path-like object (str, bytes, or os.PathLike) to a
+ * std::string, without requiring std::filesystem::path.
+ *
+ * NOTE: This function requires the GIL to be held by the caller.
+ */
+inline std::string pathToString(py::object path) {
+  // If it's already a string, just return it
+  if (py::isinstance<py::str>(path)) {
+    return path.cast<std::string>();
+  }
+
+  // Try calling os.fspath() to handle PathLike objects
+  try {
+    py::object os = py::module_::import("os");
+    py::object fspath = os.attr("fspath");
+    py::object result = fspath(path);
+    return result.cast<std::string>();
+  } catch (py::error_already_set &e) {
+    throw py::type_error(
+        "expected str, bytes, or os.PathLike object, not " +
+        std::string(py::str(path.get_type().attr("__name__"))));
+  }
+}
+
+} // namespace Pedalboard

--- a/pedalboard/io/ReadableAudioFile.h
+++ b/pedalboard/io/ReadableAudioFile.h
@@ -17,13 +17,11 @@
 
 #pragma once
 
-#include <filesystem>
 #include <mutex>
 #include <optional>
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
-#include <pybind11/stl/filesystem.h>
 
 #include "../BufferUtils.h"
 #include "../JuceHeader.h"
@@ -791,7 +789,7 @@ inline void init_readable_audio_file(
     py::class_<ReadableAudioFile, AudioFile, std::shared_ptr<ReadableAudioFile>>
         &pyReadableAudioFile) {
   pyReadableAudioFile
-      .def(py::init([](std::filesystem::path filename) -> ReadableAudioFile * {
+      .def(py::init([](py::object filename) -> ReadableAudioFile * {
              // This definition is only here to provide nice docstrings.
              throw std::runtime_error(
                  "Internal error: __init__ should never be called, as this "
@@ -807,8 +805,8 @@ inline void init_readable_audio_file(
            py::arg("file_like"))
       .def_static(
           "__new__",
-          [](const py::object *, std::filesystem::path filename) {
-            return std::make_shared<ReadableAudioFile>(filename.string());
+          [](const py::object *, py::object filename) {
+            return std::make_shared<ReadableAudioFile>(pathToString(filename));
           },
           py::arg("cls"), py::arg("filename"))
       .def_static(

--- a/pedalboard/io/ReadableAudioFile.h
+++ b/pedalboard/io/ReadableAudioFile.h
@@ -17,11 +17,13 @@
 
 #pragma once
 
+#include <filesystem>
 #include <mutex>
 #include <optional>
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl/filesystem.h>
 
 #include "../BufferUtils.h"
 #include "../JuceHeader.h"
@@ -789,7 +791,7 @@ inline void init_readable_audio_file(
     py::class_<ReadableAudioFile, AudioFile, std::shared_ptr<ReadableAudioFile>>
         &pyReadableAudioFile) {
   pyReadableAudioFile
-      .def(py::init([](std::string filename) -> ReadableAudioFile * {
+      .def(py::init([](std::filesystem::path filename) -> ReadableAudioFile * {
              // This definition is only here to provide nice docstrings.
              throw std::runtime_error(
                  "Internal error: __init__ should never be called, as this "
@@ -805,8 +807,8 @@ inline void init_readable_audio_file(
            py::arg("file_like"))
       .def_static(
           "__new__",
-          [](const py::object *, std::string filename) {
-            return std::make_shared<ReadableAudioFile>(filename);
+          [](const py::object *, std::filesystem::path filename) {
+            return std::make_shared<ReadableAudioFile>(filename.string());
           },
           py::arg("cls"), py::arg("filename"))
       .def_static(

--- a/pedalboard/io/ReadableAudioFile.h
+++ b/pedalboard/io/ReadableAudioFile.h
@@ -789,49 +789,53 @@ inline void init_readable_audio_file(
     py::class_<ReadableAudioFile, AudioFile, std::shared_ptr<ReadableAudioFile>>
         &pyReadableAudioFile) {
   pyReadableAudioFile
-      .def(py::init([](py::object filename) -> ReadableAudioFile * {
+      .def(py::init([](py::object filename,
+                       py::object file_like) -> ReadableAudioFile * {
              // This definition is only here to provide nice docstrings.
              throw std::runtime_error(
                  "Internal error: __init__ should never be called, as this "
                  "class implements __new__.");
            }),
-           py::arg("filename"))
-      .def(py::init([](py::object filelike) -> ReadableAudioFile * {
-             // This definition is only here to provide nice docstrings.
-             throw std::runtime_error(
-                 "Internal error: __init__ should never be called, as this "
-                 "class implements __new__.");
-           }),
-           py::arg("file_like"))
+           py::arg("filename") = py::none(), py::kw_only(),
+           py::arg("file_like") = py::none())
       .def_static(
           "__new__",
-          [](const py::object *, py::object filename) {
-            return std::make_shared<ReadableAudioFile>(pathToString(filename));
-          },
-          py::arg("cls"), py::arg("filename"))
-      .def_static(
-          "__new__",
-          [](const py::object *, py::object filelike) {
-            if (!isReadableFileLike(filelike) &&
-                !tryConvertingToBuffer(filelike)) {
+          [](const py::object *, py::object filename, py::object file_like) {
+            // Handle both filename and file_like kwargs for backward compat
+            py::object target;
+            if (!filename.is_none() && !file_like.is_none()) {
+              throw py::type_error(
+                  "Cannot specify both 'filename' and 'file_like'");
+            } else if (!filename.is_none()) {
+              target = filename;
+            } else if (!file_like.is_none()) {
+              target = file_like;
+            } else {
+              throw py::type_error(
+                  "Must specify either 'filename' or 'file_like'");
+            }
+
+            // Check if this is a path-like object (str or has __fspath__)
+            if (isPathLike(target)) {
+              return std::make_shared<ReadableAudioFile>(pathToString(target));
+            }
+            // Otherwise, try to handle as a file-like object or buffer
+            if (std::optional<py::buffer> buf = tryConvertingToBuffer(target)) {
+              return std::make_shared<ReadableAudioFile>(
+                  std::make_unique<PythonMemoryViewInputStream>(*buf, target));
+            } else if (isReadableFileLike(target)) {
+              return std::make_shared<ReadableAudioFile>(
+                  std::make_unique<PythonInputStream>(target));
+            } else {
               throw py::type_error(
                   "Expected either a filename, a file-like object (with "
                   "read, seek, seekable, and tell methods) or a memoryview, "
                   "but received: " +
-                  py::repr(filelike).cast<std::string>());
-            }
-
-            if (std::optional<py::buffer> buf =
-                    tryConvertingToBuffer(filelike)) {
-              return std::make_shared<ReadableAudioFile>(
-                  std::make_unique<PythonMemoryViewInputStream>(*buf,
-                                                                filelike));
-            } else {
-              return std::make_shared<ReadableAudioFile>(
-                  std::make_unique<PythonInputStream>(filelike));
+                  py::repr(target).cast<std::string>());
             }
           },
-          py::arg("cls"), py::arg("file_like"))
+          py::arg("cls"), py::arg("filename") = py::none(), py::kw_only(),
+          py::arg("file_like") = py::none())
       .def("read", &ReadableAudioFile::read, py::arg("num_frames") = 0, R"(
 Read the given number of frames (samples in each channel) from this audio file at its current position.
 

--- a/pedalboard/io/WriteableAudioFile.h
+++ b/pedalboard/io/WriteableAudioFile.h
@@ -17,13 +17,11 @@
 
 #pragma once
 
-#include <filesystem>
 #include <mutex>
 #include <optional>
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
-#include <pybind11/stl/filesystem.h>
 
 #include "../BufferUtils.h"
 #include "../JuceHeader.h"
@@ -939,8 +937,8 @@ inline void init_writeable_audio_file(
     py::class_<WriteableAudioFile, AudioFile,
                std::shared_ptr<WriteableAudioFile>> &pyWriteableAudioFile) {
   pyWriteableAudioFile
-      .def(py::init([](std::filesystem::path filename, double sampleRate,
-                       int numChannels, int bitDepth,
+      .def(py::init([](py::object filename, double sampleRate, int numChannels,
+                       int bitDepth,
                        std::optional<std::variant<std::string, float>> quality)
                         -> WriteableAudioFile * {
              // This definition is only here to provide nice docstrings.
@@ -966,7 +964,7 @@ inline void init_writeable_audio_file(
            py::arg("quality") = py::none(), py::arg("format") = py::none())
       .def_static(
           "__new__",
-          [](const py::object *, std::filesystem::path filename,
+          [](const py::object *, py::object filename,
              std::optional<double> sampleRate, int numChannels, int bitDepth,
              std::optional<std::variant<std::string, float>> quality) {
             if (!sampleRate) {
@@ -975,7 +973,8 @@ inline void init_writeable_audio_file(
                   "argument to be provided.");
             }
             return std::make_shared<WriteableAudioFile>(
-                filename.string(), *sampleRate, numChannels, bitDepth, quality);
+                pathToString(filename), *sampleRate, numChannels, bitDepth,
+                quality);
           },
           py::arg("cls"), py::arg("filename"),
           py::arg("samplerate") = py::none(), py::arg("num_channels") = 1,

--- a/pedalboard/io/WriteableAudioFile.h
+++ b/pedalboard/io/WriteableAudioFile.h
@@ -17,11 +17,13 @@
 
 #pragma once
 
+#include <filesystem>
 #include <mutex>
 #include <optional>
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl/filesystem.h>
 
 #include "../BufferUtils.h"
 #include "../JuceHeader.h"
@@ -937,8 +939,8 @@ inline void init_writeable_audio_file(
     py::class_<WriteableAudioFile, AudioFile,
                std::shared_ptr<WriteableAudioFile>> &pyWriteableAudioFile) {
   pyWriteableAudioFile
-      .def(py::init([](std::string filename, double sampleRate, int numChannels,
-                       int bitDepth,
+      .def(py::init([](std::filesystem::path filename, double sampleRate,
+                       int numChannels, int bitDepth,
                        std::optional<std::variant<std::string, float>> quality)
                         -> WriteableAudioFile * {
              // This definition is only here to provide nice docstrings.
@@ -964,7 +966,7 @@ inline void init_writeable_audio_file(
            py::arg("quality") = py::none(), py::arg("format") = py::none())
       .def_static(
           "__new__",
-          [](const py::object *, std::string filename,
+          [](const py::object *, std::filesystem::path filename,
              std::optional<double> sampleRate, int numChannels, int bitDepth,
              std::optional<std::variant<std::string, float>> quality) {
             if (!sampleRate) {
@@ -973,7 +975,7 @@ inline void init_writeable_audio_file(
                   "argument to be provided.");
             }
             return std::make_shared<WriteableAudioFile>(
-                filename, *sampleRate, numChannels, bitDepth, quality);
+                filename.string(), *sampleRate, numChannels, bitDepth, quality);
           },
           py::arg("cls"), py::arg("filename"),
           py::arg("samplerate") = py::none(), py::arg("num_channels") = 1,

--- a/pedalboard/plugins/Convolution.h
+++ b/pedalboard/plugins/Convolution.h
@@ -15,11 +15,8 @@
  * limitations under the License.
  */
 
-#include <filesystem>
-
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <pybind11/stl/filesystem.h>
 
 namespace py = pybind11;
 
@@ -105,15 +102,49 @@ inline void init_convolution(py::module &m) {
       "the ``sample_rate`` argument must also be provided to indicate the "
       "sample rate of the impulse response.\n\n*Support for passing NumPy "
       "arrays as impulse responses introduced in v0.9.10.*")
-      .def(py::init([](std::variant<std::filesystem::path,
-                                    py::array_t<float, py::array::c_style>>
-                           impulseResponse,
-                       float mix, std::optional<double> sampleRate) {
+      .def(py::init([](py::object impulseResponse, float mix,
+                       std::optional<double> sampleRate) {
              auto plugin = std::make_unique<JucePlugin<ConvolutionWithMix>>();
 
-             if (auto *impulseResponsePath =
-                     std::get_if<std::filesystem::path>(&impulseResponse)) {
-               std::string impulseResponseFilename = impulseResponsePath->string();
+             // Check if it's a numpy array first
+             if (py::isinstance<py::array_t<float, py::array::c_style>>(
+                     impulseResponse)) {
+               auto inputArray =
+                   impulseResponse.cast<py::array_t<float, py::array::c_style>>();
+               if (!sampleRate) {
+                 throw std::runtime_error(
+                     "sample_rate must be provided when passing a numpy array "
+                     "as an impulse response.");
+               }
+               plugin->getDSP().getConvolution().loadImpulseResponse(
+                   std::move(copyPyArrayIntoJuceBuffer(inputArray)), *sampleRate,
+                   juce::dsp::Convolution::Stereo::yes,
+                   juce::dsp::Convolution::Trim::no,
+                   juce::dsp::Convolution::Normalise::yes);
+
+               plugin->getDSP().setImpulseResponse(
+                   copyPyArrayIntoJuceBuffer(inputArray));
+               plugin->getDSP().setSampleRate(*sampleRate);
+             } else {
+               // Try to convert to a path string using os.fspath
+               std::string impulseResponseFilename;
+               if (py::isinstance<py::str>(impulseResponse)) {
+                 impulseResponseFilename = impulseResponse.cast<std::string>();
+               } else {
+                 try {
+                   py::object os = py::module_::import("os");
+                   py::object fspath = os.attr("fspath");
+                   py::object result = fspath(impulseResponse);
+                   impulseResponseFilename = result.cast<std::string>();
+                 } catch (py::error_already_set &) {
+                   throw py::type_error(
+                       "impulse_response_filename must be a str, os.PathLike "
+                       "object, or numpy array, not " +
+                       std::string(py::str(
+                           impulseResponse.get_type().attr("__name__"))));
+                 }
+               }
+
                py::gil_scoped_release release;
                // Load the IR file on construction, to handle errors
                auto inputFile = juce::File(impulseResponseFilename);
@@ -122,9 +153,8 @@ inline void init_convolution(py::module &m) {
                {
                  juce::FileInputStream stream(inputFile);
                  if (!stream.openedOk()) {
-                   throw std::runtime_error(
-                       "Unable to load impulse response: " +
-                       impulseResponseFilename);
+                   throw std::runtime_error("Unable to load impulse response: " +
+                                            impulseResponseFilename);
                  }
                }
 
@@ -133,23 +163,6 @@ inline void init_convolution(py::module &m) {
                    juce::dsp::Convolution::Trim::no, 0);
                plugin->getDSP().setImpulseResponseFilename(
                    impulseResponseFilename);
-             } else if (auto *inputArray =
-                            std::get_if<py::array_t<float, py::array::c_style>>(
-                                &impulseResponse)) {
-               if (!sampleRate) {
-                 throw std::runtime_error(
-                     "sample_rate must be provided when passing a numpy array "
-                     "as an impulse response.");
-               }
-               plugin->getDSP().getConvolution().loadImpulseResponse(
-                   std::move(copyPyArrayIntoJuceBuffer(*inputArray)),
-                   *sampleRate, juce::dsp::Convolution::Stereo::yes,
-                   juce::dsp::Convolution::Trim::no,
-                   juce::dsp::Convolution::Normalise::yes);
-
-               plugin->getDSP().setImpulseResponse(
-                   copyPyArrayIntoJuceBuffer(*inputArray));
-               plugin->getDSP().setSampleRate(*sampleRate);
              }
              plugin->getDSP().setMix(mix);
              return plugin;

--- a/pedalboard/plugins/Convolution.h
+++ b/pedalboard/plugins/Convolution.h
@@ -110,15 +110,16 @@ inline void init_convolution(py::module &m) {
              if (py::isinstance<py::array_t<float, py::array::c_style>>(
                      impulseResponse)) {
                auto inputArray =
-                   impulseResponse.cast<py::array_t<float, py::array::c_style>>();
+                   impulseResponse
+                       .cast<py::array_t<float, py::array::c_style>>();
                if (!sampleRate) {
                  throw std::runtime_error(
                      "sample_rate must be provided when passing a numpy array "
                      "as an impulse response.");
                }
                plugin->getDSP().getConvolution().loadImpulseResponse(
-                   std::move(copyPyArrayIntoJuceBuffer(inputArray)), *sampleRate,
-                   juce::dsp::Convolution::Stereo::yes,
+                   std::move(copyPyArrayIntoJuceBuffer(inputArray)),
+                   *sampleRate, juce::dsp::Convolution::Stereo::yes,
                    juce::dsp::Convolution::Trim::no,
                    juce::dsp::Convolution::Normalise::yes);
 
@@ -153,8 +154,9 @@ inline void init_convolution(py::module &m) {
                {
                  juce::FileInputStream stream(inputFile);
                  if (!stream.openedOk()) {
-                   throw std::runtime_error("Unable to load impulse response: " +
-                                            impulseResponseFilename);
+                   throw std::runtime_error(
+                       "Unable to load impulse response: " +
+                       impulseResponseFilename);
                  }
                }
 

--- a/pedalboard_native/__init__.pyi
+++ b/pedalboard_native/__init__.pyi
@@ -3,6 +3,7 @@
 For audio I/O classes (i.e.: reading and writing audio files), see ``pedalboard.io``."""
 
 from __future__ import annotations
+import pathlib
 import pedalboard_native
 import enum
 import typing
@@ -319,7 +320,7 @@ class Convolution(Plugin):
     def __init__(
         self,
         impulse_response_filename: typing.Union[
-            str, NDArray[float32]
+            str, pathlib.Path, NDArray[float32]
         ],
         mix: float = 1.0,
         sample_rate: typing.Optional[float] = None,
@@ -646,7 +647,7 @@ class ExternalPlugin(Plugin):
     pass
 
     @staticmethod
-    def get_plugin_names_for_file(filename: str) -> typing.List[str]:
+    def get_plugin_names_for_file(filename: str | pathlib.Path) -> typing.List[str]:
         """
         Return a list of plugin names contained within a given VST3 plugin (i.e.: a ".vst3"). If the provided file cannot be scanned, an ImportError will be raised.
         """
@@ -1123,7 +1124,7 @@ class AudioUnitPlugin(ExternalPlugin):
     ) -> NDArray[float32]: ...
     def __init__(
         self,
-        path_to_plugin_file: str,
+        path_to_plugin_file: str | pathlib.Path,
         parameter_values: object = None,
         plugin_name: typing.Optional[str] = None,
         initialization_timeout: float = 10.0,
@@ -1131,7 +1132,7 @@ class AudioUnitPlugin(ExternalPlugin):
     def __repr__(self) -> str: ...
     def _get_parameter(self, arg0: str) -> _AudioProcessorParameter: ...
     @staticmethod
-    def get_plugin_names_for_file(filename: str) -> typing.List[str]:
+    def get_plugin_names_for_file(filename: str | pathlib.Path) -> typing.List[str]:
         """
         Return a list of plugin names contained within a given Audio Unit bundle (i.e.: a ``.component`` or ``.appex`` file). If the provided file cannot be scanned, an ``ImportError`` will be raised.
 
@@ -1814,7 +1815,7 @@ class VST3Plugin(ExternalPlugin):
 
     def __init__(
         self,
-        path_to_plugin_file: str,
+        path_to_plugin_file: str | pathlib.Path,
         parameter_values: object = None,
         plugin_name: typing.Optional[str] = None,
         initialization_timeout: float = 10.0,
@@ -1822,12 +1823,12 @@ class VST3Plugin(ExternalPlugin):
     def __repr__(self) -> str: ...
     def _get_parameter(self, arg0: str) -> _AudioProcessorParameter: ...
     @staticmethod
-    def get_plugin_names_for_file(arg0: str) -> typing.List[str]:
+    def get_plugin_names_for_file(filename: str | pathlib.Path) -> typing.List[str]:
         """
         Return a list of plugin names contained within a given VST3 plugin (i.e.: a ".vst3"). If the provided file cannot be scanned, an ImportError will be raised.
         """
 
-    def load_preset(self, preset_file_path: str) -> None:
+    def load_preset(self, preset_file_path: str | pathlib.Path) -> None:
         """
         Load a VST3 preset file in .vstpreset format.
         """

--- a/pedalboard_native/io/__init__.pyi
+++ b/pedalboard_native/io/__init__.pyi
@@ -3,6 +3,7 @@
 *Introduced in v0.5.1.*"""
 
 from __future__ import annotations
+import pathlib
 import pedalboard_native.io
 
 import typing
@@ -124,13 +125,13 @@ class AudioFile:
 
     @classmethod
     @typing.overload
-    def __new__(cls, filename: str) -> ReadableAudioFile:
+    def __new__(cls, filename: str | pathlib.Path) -> ReadableAudioFile:
         """Open an audio file for reading (mode 'r' is implied)."""
         ...
 
     @classmethod
     @typing.overload
-    def __new__(cls, filename: str, mode: Literal["r"]) -> ReadableAudioFile:
+    def __new__(cls, filename: str | pathlib.Path, mode: Literal["r"]) -> ReadableAudioFile:
         """Open an audio file for reading with an explicit mode 'r'."""
         ...
 
@@ -144,7 +145,7 @@ class AudioFile:
     @typing.overload
     def __new__(
         cls,
-        filename: str,
+        filename: str | pathlib.Path,
         mode: Literal["w"],
         samplerate: typing.Optional[float] = None,
         num_channels: int = 1,
@@ -461,19 +462,19 @@ class ReadableAudioFile(AudioFile):
         """
 
     @typing.overload
-    def __init__(self, filename: str) -> None: ...
+    def __init__(self, filename: str | pathlib.Path) -> None: ...
     @typing.overload
     def __init__(self, file_like: typing.Union[typing.BinaryIO, memoryview]) -> None: ...
 
     # These don't exist, but Pyright assumes they do:
     @typing.overload
-    def __init__(self, filename: str, mode: Literal["r"]) -> None: ...
+    def __init__(self, filename: str | pathlib.Path, mode: Literal["r"]) -> None: ...
     @typing.overload
     def __init__(self, file_like: typing.Union[typing.BinaryIO, memoryview], mode: Literal["r"]) -> None: ...
 
     @classmethod
     @typing.overload
-    def __new__(cls, filename: str) -> ReadableAudioFile: ...
+    def __new__(cls, filename: str | pathlib.Path) -> ReadableAudioFile: ...
     @classmethod
     @typing.overload
     def __new__(cls, file_like: typing.Union[typing.BinaryIO, memoryview]) -> ReadableAudioFile: ...
@@ -1033,7 +1034,7 @@ class WriteableAudioFile(AudioFile):
     @typing.overload
     def __init__(
         self,
-        filename: str,
+        filename: str | pathlib.Path,
         samplerate: float,
         num_channels: int = 1,
         bit_depth: int = 16,
@@ -1053,7 +1054,7 @@ class WriteableAudioFile(AudioFile):
     @typing.overload
     def __new__(
         cls,
-        filename: str,
+        filename: str | pathlib.Path,
         samplerate: typing.Optional[float] = None,
         num_channels: int = 1,
         bit_depth: int = 16,
@@ -1076,7 +1077,7 @@ class WriteableAudioFile(AudioFile):
     @typing.overload
     def __init__(
         self,
-        filename: str,
+        filename: str | pathlib.Path,
         mode: Literal["w"],
         samplerate: float,
         num_channels: int = 1,

--- a/scripts/generate_type_stubs_and_docs.py
+++ b/scripts/generate_type_stubs_and_docs.py
@@ -58,22 +58,26 @@ MULTILINE_REPLACEMENTS = [
 ]
 
 REPLACEMENTS = [
-    # Path-like parameters in AudioFile constructors:
+    # AudioFile read mode: filename accepts paths OR file-likes (for positional compat),
+    # file_like is keyword-only alternative
     (
-        r"filename: object, mode: str = 'r'",
-        r"filename: str | os.PathLike[str], mode: str = 'r'",
+        r"filename: object = None, mode: str = 'r', \*, file_like: object = None",
+        r"filename: str | os.PathLike[str] | typing.BinaryIO | memoryview | None = None, mode: str = 'r', *, file_like: typing.BinaryIO | memoryview | None = None",
     ),
+    # ReadableAudioFile: filename accepts paths OR file-likes (for positional compat),
+    # file_like is keyword-only alternative
     (
-        r"filename: object, mode:",
-        r"filename: str | os.PathLike[str], mode:",
+        r"filename: object = None, \*, file_like: object = None\)",
+        r"filename: str | os.PathLike[str] | typing.BinaryIO | memoryview | None = None, *, file_like: typing.BinaryIO | memoryview | None = None)",
+    ),
+    # Path-like parameters in AudioFile/WriteableAudioFile constructors (write mode):
+    (
+        r"filename: object, mode: str = 'w'",
+        r"filename: str | os.PathLike[str], mode: str = 'w'",
     ),
     (
         r"filename: object, samplerate:",
         r"filename: str | os.PathLike[str], samplerate:",
-    ),
-    (
-        r"filename: object\) ->",
-        r"filename: str | os.PathLike[str]) ->",
     ),
     # Path-like parameters for external plugins:
     (
@@ -93,15 +97,7 @@ REPLACEMENTS = [
         r"impulse_response_filename: object,",
         r"impulse_response_filename: str | os.PathLike[str] | numpy.ndarray[typing.Any, numpy.dtype[numpy.float32]],",
     ),
-    # object is a superclass of `str`, which would make these declarations ambiguous:
-    (
-        r"file_like: object, mode: str = 'r'",
-        r"file_like: typing.Union[typing.BinaryIO, memoryview], mode: str = 'r'",
-    ),
-    (
-        r"file_like: object\) -> ReadableAudioFile:",
-        "file_like: typing.Union[typing.BinaryIO, memoryview]) -> ReadableAudioFile:",
-    ),
+    # file_like parameter for write mode (has format argument):
     ("file_like: object", "file_like: typing.BinaryIO"),
     # "r" is the default file open/reading mode:
     ("mode: str = 'r'", r'mode: Literal["r"] = "r"'),

--- a/scripts/generate_type_stubs_and_docs.py
+++ b/scripts/generate_type_stubs_and_docs.py
@@ -58,6 +58,41 @@ MULTILINE_REPLACEMENTS = [
 ]
 
 REPLACEMENTS = [
+    # Path-like parameters in AudioFile constructors:
+    (
+        r"filename: object, mode: str = 'r'",
+        r"filename: str | os.PathLike[str], mode: str = 'r'",
+    ),
+    (
+        r"filename: object, mode:",
+        r"filename: str | os.PathLike[str], mode:",
+    ),
+    (
+        r"filename: object, samplerate:",
+        r"filename: str | os.PathLike[str], samplerate:",
+    ),
+    (
+        r"filename: object\) ->",
+        r"filename: str | os.PathLike[str]) ->",
+    ),
+    # Path-like parameters for external plugins:
+    (
+        r"path_to_plugin_file: object,",
+        r"path_to_plugin_file: str | os.PathLike[str],",
+    ),
+    (
+        r"preset_file_path: object\)",
+        r"preset_file_path: str | os.PathLike[str])",
+    ),
+    (
+        r"get_plugin_names_for_file\(filename: object\)",
+        r"get_plugin_names_for_file(filename: str | os.PathLike[str])",
+    ),
+    # Convolution impulse response can be a path or numpy array:
+    (
+        r"impulse_response_filename: object,",
+        r"impulse_response_filename: str | os.PathLike[str] | numpy.ndarray[typing.Any, numpy.dtype[numpy.float32]],",
+    ),
     # object is a superclass of `str`, which would make these declarations ambiguous:
     (
         r"file_like: object, mode: str = 'r'",

--- a/scripts/generate_type_stubs_and_docs.py
+++ b/scripts/generate_type_stubs_and_docs.py
@@ -78,6 +78,7 @@ REPLACEMENTS = [
         r"import typing",
         "\n".join(
             [
+                "import os",
                 "import typing",
                 "from typing_extensions import Literal",
                 "from enum import Enum",
@@ -85,6 +86,9 @@ REPLACEMENTS = [
             ]
         ),
     ),
+    # pybind11 renders std::filesystem::path as os.PathLike[str]; pybind11 actually accepts
+    # str OR any os.PathLike object, so we use the union type for accuracy:
+    (r"os\.PathLike\[str\]", r"str | os.PathLike[str]"),
     (
         r"default_input_device_name = [\"'].*?[\"']",
         "default_input_device_name: Optional[str] = None",


### PR DESCRIPTION
Relies on [PyBind11's built-in support for translating `pathlib.Path` objects into `std::filesystem` objects on the C++ side](https://pybind11.readthedocs.io/en/stable/advanced/cast/overview.html#id1).