### PR TITLE
Add `ChannelConvertedReadableAudioFile` for `.mono()` support when reading files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,25 @@ with AudioFile('processed-output.wav', 'w', samplerate, effected.shape[0]) as f:
   f.write(effected)
 ```
 
+### Resampling and Channel Conversion
+
+Audio files can be resampled on-the-fly and have their channels converted
+for maximum efficiency using chainable methods:
+
+```python
+from pedalboard.io import AudioFile
+
+# Read a file, resampling to 22,050 Hz and converting to mono:
+with AudioFile('some-file.mp3').resampled_to(22_050).mono() as f:
+    audio = f.read(f.frames)
+    print(f.samplerate)    # => 22050
+    print(f.num_channels)  # => 1
+
+# Resampling and channel conversion can be done in either order:
+with AudioFile('some-file.mp3').mono().resampled_to(22_050) as f:
+    audio = f.read(f.frames)  # Also works! (And may be faster for stereo inputs)
+```
+
 ### Using VST3® or Audio Unit instrument and effect plugins
 
 ```python

--- a/docs/source/reference/pedalboard.io.rst
+++ b/docs/source/reference/pedalboard.io.rst
@@ -30,10 +30,53 @@ a regular file in Python::
 
    - Writing to a file can be accomplished by passing ``"w"`` as a second argument, just like with regular files in Python.
    - Changing the sample rate of a file can be accomplished by calling :py:meth:`pedalboard.io.ReadableAudioFile.resampled_to`.
+   - Changing the number of channels can be accomplished by calling :py:meth:`pedalboard.io.ReadableAudioFile.mono`, :py:meth:`pedalboard.io.ReadableAudioFile.stereo`, or :py:meth:`pedalboard.io.ReadableAudioFile.with_channels`.
 
    If you find yourself importing :class:`pedalboard.io.ReadableAudioFile`,
-   :class:`pedalboard.io.WriteableAudioFile`, or :class:`pedalboard.io.ResampledReadableAudioFile` directly,
+   :class:`pedalboard.io.WriteableAudioFile`, :class:`pedalboard.io.ResampledReadableAudioFile`,
+   or :class:`pedalboard.io.ChannelConvertedReadableAudioFile` directly,
    you *probably don't need to do that* - :class:`pedalboard.io.AudioFile` has you covered.
+
+Resampling and Channel Conversion
+---------------------------------
+
+Audio files can be resampled and have their channel count converted on-the-fly
+using chainable methods. These operations stream audio efficiently without
+loading the entire file into memory::
+
+   from pedalboard.io import AudioFile
+
+   # Resample a file to 22,050 Hz:
+   with AudioFile("my_file.mp3").resampled_to(22_050) as f:
+       audio = f.read(f.frames)  # audio is now at 22,050 Hz
+
+   # Convert a stereo file to mono:
+   with AudioFile("stereo_file.wav").mono() as f:
+       audio = f.read(f.frames)  # audio is now shape (1, num_samples)
+
+   # Convert a mono file to stereo:
+   with AudioFile("mono_file.wav").stereo() as f:
+       audio = f.read(f.frames)  # audio is now shape (2, num_samples)
+
+These methods can be chained together in any order::
+
+   # Resample and convert to mono:
+   with AudioFile("my_file.mp3").resampled_to(22_050).mono() as f:
+       audio = f.read(f.frames)
+
+   # Or convert to mono first, then resample (slightly more efficient):
+   with AudioFile("my_file.mp3").mono().resampled_to(22_050) as f:
+       audio = f.read(f.frames)
+
+.. note::
+   Channel conversion is only well-defined for conversions to and from mono.
+   Converting between stereo and multichannel formats (e.g., 5.1 surround)
+   is not supported, as the mapping between channels is ambiguous.
+   To convert multichannel audio to stereo, first convert to mono::
+
+      # Convert 5.1 surround to stereo via mono:
+      with AudioFile("surround.wav").mono().stereo() as f:
+          audio = f.read(f.frames)
 
 The following documentation lists all of the available I/O classes.
 

--- a/pedalboard/io/ChannelConvertedReadableAudioFile.h
+++ b/pedalboard/io/ChannelConvertedReadableAudioFile.h
@@ -1,0 +1,421 @@
+/*
+ * pedalboard
+ * Copyright 2026 Spotify AB
+ *
+ * Licensed under the GNU Public License, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <mutex>
+#include <optional>
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+
+#include "../BufferUtils.h"
+#include "../JuceHeader.h"
+#include "AudioFile.h"
+#include "PythonInputStream.h"
+#include "ReadableAudioFile.h"
+#include "ResampledReadableAudioFile.h"
+
+namespace py = pybind11;
+
+namespace Pedalboard {
+
+/**
+ * A wrapper class that converts audio channel counts on-the-fly.
+ * Wraps any AbstractReadableAudioFile (ReadableAudioFile, ResampledReadableAudioFile, etc.)
+ */
+class ChannelConvertedReadableAudioFile
+    : public AbstractReadableAudioFile,
+      public std::enable_shared_from_this<ChannelConvertedReadableAudioFile> {
+public:
+  ChannelConvertedReadableAudioFile(
+      std::shared_ptr<AbstractReadableAudioFile> audioFile, int targetNumChannels)
+      : wrappedFile(audioFile), targetNumChannels(targetNumChannels) {
+    if (targetNumChannels < 1) {
+      throw std::domain_error("Target number of channels must be at least 1.");
+    }
+
+    int sourceNumChannels = wrappedFile->getNumChannels();
+
+    // Only allow well-defined channel conversions:
+    // - Any -> mono (average all channels)
+    // - Mono -> any (duplicate mono to all channels)
+    // - Same channel count (no conversion needed)
+    // Disallow ambiguous conversions like stereo <-> multichannel
+    if (sourceNumChannels != targetNumChannels && sourceNumChannels != 1 &&
+        targetNumChannels != 1) {
+      throw std::domain_error(
+          "Channel conversion from " + std::to_string(sourceNumChannels) +
+          " to " + std::to_string(targetNumChannels) +
+          " channels is not supported. Only conversions to/from mono (1 "
+          "channel) are well-defined. To convert to mono first, use "
+          ".mono().with_channels(" +
+          std::to_string(targetNumChannels) + ").");
+    }
+  }
+
+  std::variant<double, long> getSampleRate() const override {
+    return wrappedFile->getSampleRate();
+  }
+
+  double getSampleRateAsDouble() const override {
+    return wrappedFile->getSampleRateAsDouble();
+  }
+
+  long long getLengthInSamples() const override {
+    return wrappedFile->getLengthInSamples();
+  }
+
+  double getDuration() const override {
+    return wrappedFile->getDuration();
+  }
+
+  long getNumChannels() const override { return targetNumChannels; }
+
+  bool exactDurationKnown() const override {
+    return wrappedFile->exactDurationKnown();
+  }
+
+  std::string getFileFormat() const override {
+    return wrappedFile->getFileFormat();
+  }
+
+  std::string getFileDatatype() const override {
+    return wrappedFile->getFileDatatype();
+  }
+
+  py::array_t<float> read(std::variant<double, long long> numSamplesVariant) override {
+    long long numSamples = parseNumSamples(numSamplesVariant);
+    if (numSamples == 0)
+      throw std::domain_error(
+          "ChannelConvertedReadableAudioFile will not read an entire file "
+          "at once, "
+          "due to the possibility that a file may be larger than available "
+          "memory. Please pass a number of frames to read (available from "
+          "the 'frames' attribute).");
+
+    juce::AudioBuffer<float> convertedBuffer;
+    {
+      py::gil_scoped_release release;
+      convertedBuffer = readInternal(numSamples);
+    }
+
+    PythonException::raise();
+    return copyJuceBufferIntoPyArray(convertedBuffer,
+                                     ChannelLayout::NotInterleaved, 0);
+  }
+
+  /**
+   * Read samples from the underlying audio file, convert channels, and return a
+   * juce::AudioBuffer containing the result without holding the GIL.
+   *
+   * @param numSamples The number of samples to read.
+   * @return juce::AudioBuffer<float> The resulting audio.
+   */
+  juce::AudioBuffer<float> readInternal(long long numSamples) {
+    // Note: We take a "write" lock here as calling readInternal will
+    // advance internal state:
+    ScopedTryWriteLock scopedTryWriteLock(objectLock);
+    if (!scopedTryWriteLock.isLocked()) {
+      throw std::runtime_error(
+          "Another thread is currently reading from this AudioFile. Note "
+          "that using multiple concurrent readers on the same AudioFile "
+          "object will produce nondeterministic results.");
+    }
+
+    int sourceNumChannels = wrappedFile->getNumChannels();
+
+    // Read from the underlying file and copy data while holding the GIL
+    juce::AudioBuffer<float> outputBuffer;
+    {
+      py::gil_scoped_acquire acquire;
+      py::array_t<float> sourceArray = wrappedFile->read(numSamples);
+
+      auto sourceInfo = sourceArray.request();
+      long long actualSamplesRead = sourceInfo.shape[1];
+
+      if (actualSamplesRead == 0) {
+        return juce::AudioBuffer<float>(targetNumChannels, 0);
+      }
+
+      // Create output buffer and copy data while we still have access to the array
+      outputBuffer.setSize(targetNumChannels, actualSamplesRead);
+      float *sourcePtr = static_cast<float *>(sourceInfo.ptr);
+      copyChannelData(outputBuffer, sourcePtr, sourceNumChannels, actualSamplesRead);
+    }
+
+    return outputBuffer;
+  }
+
+  void copyChannelData(juce::AudioBuffer<float> &outputBuffer, float *sourcePtr,
+                       int sourceNumChannels, long long actualSamplesRead) {
+    // Note: The constructor validates that only well-defined conversions are
+    // allowed (to/from mono, or same channel count), so we only need to handle
+    // those cases here.
+
+    if (targetNumChannels == sourceNumChannels) {
+      // No conversion needed, just copy
+      for (int c = 0; c < targetNumChannels; c++) {
+        outputBuffer.copyFrom(c, 0, sourcePtr + (c * actualSamplesRead),
+                              actualSamplesRead);
+      }
+    } else if (targetNumChannels == 1) {
+      // Mix down to mono: average all channels (SIMD-optimized)
+      float *outputPtr = outputBuffer.getWritePointer(0);
+      float channelVolume = 1.0f / sourceNumChannels;
+
+      // Start with first channel
+      juce::FloatVectorOperations::copy(outputPtr, sourcePtr,
+                                        (int)actualSamplesRead);
+
+      // Add remaining channels
+      for (int c = 1; c < sourceNumChannels; c++) {
+        float *channelPtr = sourcePtr + (c * actualSamplesRead);
+        juce::FloatVectorOperations::add(outputPtr, channelPtr,
+                                         (int)actualSamplesRead);
+      }
+
+      // Apply volume scaling
+      juce::FloatVectorOperations::multiply(outputPtr, channelVolume,
+                                            (int)actualSamplesRead);
+    } else {
+      // Upmix from mono (sourceNumChannels == 1): duplicate to all channels
+      float *monoPtr = sourcePtr;
+      for (int c = 0; c < targetNumChannels; c++) {
+        outputBuffer.copyFrom(c, 0, monoPtr, actualSamplesRead);
+      }
+    }
+  }
+
+  void seek(long long targetPosition) override {
+    wrappedFile->seek(targetPosition);
+    PythonException::raise();
+  }
+
+  void seekInternal(long long targetPosition) override {
+    wrappedFile->seekInternal(targetPosition);
+  }
+
+  long long tell() const override {
+    return wrappedFile->tell();
+  }
+
+  void close() override {
+    py::gil_scoped_release release;
+    ScopedTryWriteLock scopedTryWriteLock(objectLock);
+    if (!scopedTryWriteLock.isLocked()) {
+      throw std::runtime_error(
+          "Another thread is currently reading from this AudioFile; it cannot "
+          "be closed until the other thread completes its operation.");
+    }
+    _isClosed = true;
+  }
+
+  bool isClosed() const override {
+    if (wrappedFile->isClosed())
+      return true;
+
+    py::gil_scoped_release release;
+    const juce::ScopedReadLock scopedReadLock(objectLock);
+    return _isClosed;
+  }
+
+  bool isSeekable() const override {
+    return wrappedFile->isSeekable();
+  }
+
+  std::optional<std::string> getFilename() const override {
+    return wrappedFile->getFilename();
+  }
+
+  PythonInputStream *getPythonInputStream() const override {
+    return wrappedFile->getPythonInputStream();
+  }
+
+  std::shared_ptr<AbstractReadableAudioFile> enter() override {
+    return shared_from_this();
+  }
+
+  void exit(const py::object &type, const py::object &value,
+            const py::object &traceback) override {
+    bool shouldThrow = PythonException::isPending();
+    close();
+
+    if (shouldThrow || PythonException::isPending())
+      throw py::error_already_set();
+  }
+
+  std::string getClassName() const override {
+    return "ChannelConvertedReadableAudioFile";
+  }
+
+private:
+  const std::shared_ptr<AbstractReadableAudioFile> wrappedFile;
+  const int targetNumChannels;
+  juce::ReadWriteLock objectLock;
+  bool _isClosed = false;
+};
+
+inline py::class_<ChannelConvertedReadableAudioFile, AbstractReadableAudioFile,
+                  std::shared_ptr<ChannelConvertedReadableAudioFile>>
+declare_readable_audio_file_with_channel_conversion(py::module &m) {
+  return py::class_<ChannelConvertedReadableAudioFile, AbstractReadableAudioFile,
+                    std::shared_ptr<ChannelConvertedReadableAudioFile>>(
+      m, "ChannelConvertedReadableAudioFile",
+      R"(
+A class that wraps an audio file for reading, while converting
+the audio stream on-the-fly to a new channel count.
+
+*Introduced in v0.9.22.*
+
+Reading, seeking, and all other basic file I/O operations are supported (except for
+:meth:`read_raw`).
+
+:class:`ChannelConvertedReadableAudioFile` should usually
+be used via the :meth:`with_channels` method on :class:`ReadableAudioFile`
+or :class:`ResampledReadableAudioFile`:
+
+::
+
+   with AudioFile("my_stereo_file.mp3").mono() as f:
+       f.num_channels # => 1
+       mono_audio = f.read(int(f.samplerate * 10))
+
+   with AudioFile("my_mono_file.wav").stereo() as f:
+       f.num_channels # => 2
+       stereo_audio = f.read(int(f.samplerate * 10))
+
+   with AudioFile("my_file.wav").with_channels(6) as f:
+       f.num_channels # => 6
+       surround_audio = f.read(int(f.samplerate * 10))
+
+When converting from stereo (or multi-channel) to mono, all channels are
+averaged together with equal weighting. When converting from mono to
+stereo (or multi-channel), the mono signal is duplicated to all output
+channels. Other conversions (stereo to multi-channel, multi-channel to
+stereo, etc) are not currently supported.
+)");
+}
+
+inline void init_readable_audio_file_with_channel_conversion(
+    py::module &m,
+    py::class_<ChannelConvertedReadableAudioFile, AbstractReadableAudioFile,
+               std::shared_ptr<ChannelConvertedReadableAudioFile>>
+        &pyChannelConvertedReadableAudioFile) {
+  // Note: Most methods are inherited from AbstractReadableAudioFile.
+  // We only define class-specific methods here.
+  pyChannelConvertedReadableAudioFile
+      .def(py::init([](std::shared_ptr<AbstractReadableAudioFile> audioFile,
+                       int targetNumChannels)
+                        -> ChannelConvertedReadableAudioFile * {
+             // This definition is only here to provide nice docstrings.
+             throw std::runtime_error(
+                 "Internal error: __init__ should never be called, as this "
+                 "class implements __new__.");
+           }),
+           py::arg("audio_file"), py::arg("num_channels"))
+      .def_static(
+          "__new__",
+          [](const py::object *, std::shared_ptr<AbstractReadableAudioFile> audioFile,
+             int targetNumChannels) {
+            return std::make_shared<ChannelConvertedReadableAudioFile>(
+                audioFile, targetNumChannels);
+          },
+          py::arg("cls"), py::arg("audio_file"), py::arg("num_channels"));
+}
+
+// Implementation of init_abstract_readable_audio_file_methods declared in
+// AudioFileInit.h
+inline void init_abstract_readable_audio_file_methods(
+    py::class_<AbstractReadableAudioFile, AudioFile,
+               std::shared_ptr<AbstractReadableAudioFile>>
+        &pyAbstractReadableAudioFile) {
+  pyAbstractReadableAudioFile
+      .def(
+          "resampled_to",
+          [](std::shared_ptr<AbstractReadableAudioFile> file,
+             double targetSampleRate, ResamplingQuality quality)
+              -> std::shared_ptr<AbstractReadableAudioFile> {
+            if (file->getSampleRateAsDouble() == targetSampleRate)
+              return file;
+
+            return std::make_shared<ResampledReadableAudioFile>(
+                file, targetSampleRate, quality);
+          },
+          py::arg("target_sample_rate"),
+          py::arg("quality") = ResamplingQuality::WindowedSinc32,
+          "Return a :class:`ResampledReadableAudioFile` that will "
+          "automatically resample this audio file to the provided "
+          "`target_sample_rate`, using a constant amount of memory.\n\nIf "
+          "`target_sample_rate` matches the existing sample rate of the file, "
+          "the original file will be returned.\n\n*Introduced in v0.6.0.*")
+      .def(
+          "with_channels",
+          [](std::shared_ptr<AbstractReadableAudioFile> file,
+             int targetNumChannels)
+              -> std::shared_ptr<AbstractReadableAudioFile> {
+            if (file->getNumChannels() == targetNumChannels)
+              return file;
+
+            return std::make_shared<ChannelConvertedReadableAudioFile>(
+                file, targetNumChannels);
+          },
+          py::arg("num_channels"),
+          "Return a :class:`ChannelConvertedReadableAudioFile` that will "
+          "automatically convert the channel count of this audio file to the "
+          "provided `num_channels`.\n\nIf `num_channels` matches the existing "
+          "channel count of the file, the original file will be "
+          "returned.\n\nWhen converting from stereo (or multi-channel) to "
+          "mono, all channels are averaged together with equal weighting. When "
+          "converting from mono to stereo (or multi-channel), the mono signal "
+          "is duplicated to all output channels.\n\n*Introduced in v0.9.17.*")
+      .def(
+          "mono",
+          [](std::shared_ptr<AbstractReadableAudioFile> file)
+              -> std::shared_ptr<AbstractReadableAudioFile> {
+            if (file->getNumChannels() == 1)
+              return file;
+
+            return std::make_shared<ChannelConvertedReadableAudioFile>(
+                file, 1);
+          },
+          "Return a :class:`ChannelConvertedReadableAudioFile` that will "
+          "automatically convert this audio file to mono (1 channel).\n\nIf "
+          "this file is already mono, the original file will be "
+          "returned.\n\nWhen converting from stereo (or multi-channel) to "
+          "mono, all channels are averaged together with equal "
+          "weighting.\n\n*Introduced in v0.9.17.*")
+      .def(
+          "stereo",
+          [](std::shared_ptr<AbstractReadableAudioFile> file)
+              -> std::shared_ptr<AbstractReadableAudioFile> {
+            if (file->getNumChannels() == 2)
+              return file;
+
+            return std::make_shared<ChannelConvertedReadableAudioFile>(
+                file, 2);
+          },
+          "Return a :class:`ChannelConvertedReadableAudioFile` that will "
+          "automatically convert this audio file to stereo (2 "
+          "channels).\n\nIf this file is already stereo, the original file "
+          "will be returned.\n\nWhen converting from mono to stereo, the mono "
+          "signal is duplicated to both channels. When converting from "
+          "multi-channel (3 or more channels) to stereo, only the first two "
+          "channels are kept.\n\n*Introduced in v0.9.17.*");
+}
+
+} // namespace Pedalboard

--- a/pedalboard/io/ResampledReadableAudioFile.h
+++ b/pedalboard/io/ResampledReadableAudioFile.h
@@ -256,11 +256,14 @@ public:
           py::buffer_info bufInfo = readResult.request();
           samplesRead = bufInfo.shape[1]; // shape is (channels, samples)
 
-          // Copy data from the numpy array to our contiguous buffer
+          // Copy data from the numpy array to our contiguous buffer.
+          // Use samplesRead for the stride (not inputSamplesRequired) to match
+          // the layout expected by the pointer update below when the read is
+          // shorter than requested.
           float *srcPtr = static_cast<float *>(bufInfo.ptr);
           for (int c = 0; c < audioFile->getNumChannels(); c++) {
             for (long long i = 0; i < samplesRead; i++) {
-              contiguousSourceSampleBuffer[c * inputSamplesRequired + i] =
+              contiguousSourceSampleBuffer[c * samplesRead + i] =
                   srcPtr[c * samplesRead + i];
             }
           }

--- a/pedalboard/python_bindings.cpp
+++ b/pedalboard/python_bindings.cpp
@@ -67,6 +67,7 @@ namespace py = pybind11;
 #include "io/AudioStream.h"
 #include "io/ReadableAudioFile.h"
 #include "io/ResampledReadableAudioFile.h"
+#include "io/ChannelConvertedReadableAudioFile.h"
 #include "io/StreamResampler.h"
 #include "io/WriteableAudioFile.h"
 
@@ -249,13 +250,20 @@ If the number of samples and the number of channels are the same, each
              "writing audio files or streams.\n\n*Introduced in v0.5.1.*";
 
   auto pyAudioFile = declare_audio_file(io);
+  auto pyAbstractReadableAudioFile = declare_ireadable_audio_file(io);
   auto pyReadableAudioFile = declare_readable_audio_file(io);
+  auto pyChannelConvertedReadableAudioFile =
+      declare_readable_audio_file_with_channel_conversion(io);
   auto pyResampledReadableAudioFile = declare_resampled_readable_audio_file(io);
   auto pyWriteableAudioFile = declare_writeable_audio_file(io);
 
   init_audio_file(pyAudioFile);
+  init_ireadable_audio_file(pyAbstractReadableAudioFile);
   init_readable_audio_file(io, pyReadableAudioFile);
+  init_readable_audio_file_with_channel_conversion(
+      io, pyChannelConvertedReadableAudioFile);
   init_resampled_readable_audio_file(io, pyResampledReadableAudioFile);
+  init_abstract_readable_audio_file_methods(pyAbstractReadableAudioFile);
   init_writeable_audio_file(io, pyWriteableAudioFile);
 
   init_stream_resampler(io);

--- a/tests/test_channel_converted_io.py
+++ b/tests/test_channel_converted_io.py
@@ -1,0 +1,414 @@
+#! /usr/bin/env python
+#
+# Copyright 2022 Spotify AB
+#
+# Licensed under the GNU Public License, Version 3.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.gnu.org/licenses/gpl-3.0.html
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from io import BytesIO
+
+import numpy as np
+import pytest
+
+from pedalboard.io import AudioFile, ChannelConvertedReadableAudioFile
+
+from .utils import generate_sine_at
+
+
+def test_mono_constructor():
+    """Test that .mono() returns a ChannelConvertedReadableAudioFile."""
+    stereo = np.random.rand(2, 44100).astype(np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 2, bit_depth=32) as f:
+        f.write(stereo)
+
+    with AudioFile(BytesIO(buf.getvalue())) as f:
+        with f.mono() as m:
+            assert isinstance(m, ChannelConvertedReadableAudioFile)
+            assert m.num_channels == 1
+        assert m.closed
+        assert not f.closed
+    assert f.closed
+
+
+def test_stereo_constructor():
+    """Test that .stereo() returns a ChannelConvertedReadableAudioFile."""
+    mono = np.random.rand(1, 44100).astype(np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 1, bit_depth=32) as f:
+        f.write(mono)
+
+    with AudioFile(BytesIO(buf.getvalue())) as f:
+        with f.stereo() as s:
+            assert isinstance(s, ChannelConvertedReadableAudioFile)
+            assert s.num_channels == 2
+        assert s.closed
+        assert not f.closed
+    assert f.closed
+
+
+def test_with_channels_constructor():
+    """Test that .with_channels() returns a ChannelConvertedReadableAudioFile."""
+    mono = np.random.rand(1, 44100).astype(np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 1, bit_depth=32) as f:
+        f.write(mono)
+
+    with AudioFile(BytesIO(buf.getvalue())) as f:
+        with f.with_channels(4) as c:
+            assert isinstance(c, ChannelConvertedReadableAudioFile)
+            assert c.num_channels == 4
+        assert c.closed
+        assert not f.closed
+    assert f.closed
+
+
+def test_mono_does_nothing_if_already_mono():
+    """Test that .mono() returns self if already mono."""
+    mono = np.random.rand(1, 44100).astype(np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 1, bit_depth=32) as f:
+        f.write(mono)
+
+    with AudioFile(BytesIO(buf.getvalue())) as f:
+        with f.mono() as m:
+            assert m is f
+
+
+def test_stereo_does_nothing_if_already_stereo():
+    """Test that .stereo() returns self if already stereo."""
+    stereo = np.random.rand(2, 44100).astype(np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 2, bit_depth=32) as f:
+        f.write(stereo)
+
+    with AudioFile(BytesIO(buf.getvalue())) as f:
+        with f.stereo() as s:
+            assert s is f
+
+
+def test_with_channels_does_nothing_if_same():
+    """Test that .with_channels(n) returns self if already n channels."""
+    stereo = np.random.rand(2, 44100).astype(np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 2, bit_depth=32) as f:
+        f.write(stereo)
+
+    with AudioFile(BytesIO(buf.getvalue())) as f:
+        with f.with_channels(2) as c:
+            assert c is f
+
+
+def test_read_zero_raises():
+    """Test that read() without arguments raises ValueError."""
+    stereo = np.random.rand(2, 44100).astype(np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 2, bit_depth=32) as f:
+        f.write(stereo)
+
+    with AudioFile(BytesIO(buf.getvalue())).mono() as f:
+        with pytest.raises(ValueError):
+            f.read()
+
+
+@pytest.mark.parametrize("source_channels", [2, 4, 6, 8])
+def test_stereo_to_mono_averages_channels(source_channels: int):
+    """Test that converting to mono averages all channels."""
+    # Create audio where each channel has a different constant value
+    num_samples = 44100
+    audio = np.zeros((source_channels, num_samples), dtype=np.float32)
+    for c in range(source_channels):
+        audio[c, :] = float(c + 1) / source_channels  # 0.5, 1.0 for stereo
+
+    expected_mono_value = np.mean([float(c + 1) / source_channels for c in range(source_channels)])
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, source_channels, bit_depth=32) as f:
+        f.write(audio)
+
+    with AudioFile(BytesIO(buf.getvalue())).mono() as f:
+        mono = f.read(f.frames)
+        assert mono.shape == (1, num_samples)
+        np.testing.assert_allclose(mono[0, 1000], expected_mono_value, rtol=1e-5)
+
+
+def test_mono_to_stereo_duplicates():
+    """Test that converting mono to stereo duplicates the channel."""
+    mono_value = 0.5
+    mono = np.full((1, 44100), mono_value, dtype=np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 1, bit_depth=32) as f:
+        f.write(mono)
+
+    with AudioFile(BytesIO(buf.getvalue())).stereo() as f:
+        stereo = f.read(f.frames)
+        assert stereo.shape == (2, 44100)
+        np.testing.assert_allclose(stereo[0, :], mono_value, rtol=1e-5)
+        np.testing.assert_allclose(stereo[1, :], mono_value, rtol=1e-5)
+
+
+@pytest.mark.parametrize("target_channels", [2, 4, 6, 8])
+def test_mono_to_multichannel_duplicates(target_channels: int):
+    """Test that converting mono to multiple channels duplicates to all."""
+    mono_value = 0.75
+    mono = np.full((1, 44100), mono_value, dtype=np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 1, bit_depth=32) as f:
+        f.write(mono)
+
+    with AudioFile(BytesIO(buf.getvalue())).with_channels(target_channels) as f:
+        audio = f.read(f.frames)
+        assert audio.shape == (target_channels, 44100)
+        for c in range(target_channels):
+            np.testing.assert_allclose(audio[c, :], mono_value, rtol=1e-5)
+
+
+def test_stereo_to_multichannel_raises():
+    """Test that converting stereo to multichannel raises an error."""
+    stereo = np.random.rand(2, 44100).astype(np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 2, bit_depth=32) as f:
+        f.write(stereo)
+
+    with pytest.raises(ValueError, match="not supported"):
+        AudioFile(BytesIO(buf.getvalue())).with_channels(6)
+
+
+def test_multichannel_to_stereo_raises():
+    """Test that converting multichannel to stereo raises an error."""
+    surround = np.random.rand(6, 44100).astype(np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 6, bit_depth=32) as f:
+        f.write(surround)
+
+    with pytest.raises(ValueError, match="not supported"):
+        AudioFile(BytesIO(buf.getvalue())).stereo()
+
+
+def test_invalid_channel_count_raises():
+    """Test that requesting 0 or negative channels raises an error."""
+    mono = np.random.rand(1, 44100).astype(np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 1, bit_depth=32) as f:
+        f.write(mono)
+
+    with pytest.raises(ValueError):
+        AudioFile(BytesIO(buf.getvalue())).with_channels(0)
+
+    with pytest.raises(ValueError):
+        AudioFile(BytesIO(buf.getvalue())).with_channels(-1)
+
+
+@pytest.mark.parametrize("chunk_size", [100, 1000, 10000])
+def test_tell_after_read(chunk_size: int):
+    """Test that tell() returns correct position after reads."""
+    stereo = np.random.rand(2, 44100).astype(np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 2, bit_depth=32) as f:
+        f.write(stereo)
+
+    with AudioFile(BytesIO(buf.getvalue())).mono() as f:
+        for i in range(0, f.frames, chunk_size):
+            assert f.tell() == i
+            if f.read(chunk_size).shape[-1] < chunk_size:
+                break
+
+
+@pytest.mark.parametrize("offset", [0, 100, 1000, 22050])
+def test_seek(offset: int):
+    """Test that seek() works correctly."""
+    stereo = np.random.rand(2, 44100).astype(np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 2, bit_depth=32) as f:
+        f.write(stereo)
+
+    with AudioFile(BytesIO(buf.getvalue())).mono() as f:
+        # Read from start to offset position
+        if offset > 0:
+            f.read(offset)
+        expected = f.read(1000)
+
+        # Seek back and verify
+        f.seek(offset)
+        assert f.tell() == offset
+        actual = f.read(1000)
+
+        np.testing.assert_allclose(expected, actual)
+
+
+def test_properties_accessible():
+    """Test that all standard properties are accessible."""
+    stereo = np.random.rand(2, 44100).astype(np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 2, bit_depth=32) as f:
+        f.write(stereo)
+
+    with AudioFile(BytesIO(buf.getvalue())).mono() as f:
+        assert f.samplerate == 44100
+        assert f.num_channels == 1
+        assert f.frames == 44100
+        assert f.duration == 1.0
+        assert f.exact_duration_known is True
+        assert f.file_dtype == "float32"
+        assert f.closed is False
+        assert f.seekable() is True
+
+    assert f.closed is True
+
+
+def test_repr():
+    """Test that __repr__ returns expected format."""
+    stereo = np.random.rand(2, 44100).astype(np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 2, bit_depth=32) as f:
+        f.write(stereo)
+
+    with AudioFile(BytesIO(buf.getvalue())).mono() as f:
+        repr_str = repr(f)
+        assert "ChannelConvertedReadableAudioFile" in repr_str
+        assert "samplerate=44100" in repr_str
+        assert "num_channels=1" in repr_str
+
+
+# Chaining tests
+
+
+def test_chain_resampled_to_then_mono():
+    """Test chaining .resampled_to().mono()."""
+    stereo = generate_sine_at(44100, 440, num_seconds=1, num_channels=2).astype(np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 2, bit_depth=32) as f:
+        f.write(stereo)
+
+    with AudioFile(BytesIO(buf.getvalue())).resampled_to(22050).mono() as f:
+        assert f.samplerate == 22050
+        assert f.num_channels == 1
+        audio = f.read(f.frames)
+        assert audio.shape[0] == 1
+        # Allow for some variation due to resampling
+        assert abs(audio.shape[1] - 22050) <= 10
+
+
+def test_chain_mono_then_resampled_to():
+    """Test chaining .mono().resampled_to()."""
+    stereo = generate_sine_at(44100, 440, num_seconds=1, num_channels=2).astype(np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 2, bit_depth=32) as f:
+        f.write(stereo)
+
+    with AudioFile(BytesIO(buf.getvalue())).mono().resampled_to(22050) as f:
+        assert f.samplerate == 22050
+        assert f.num_channels == 1
+        audio = f.read(f.frames)
+        assert audio.shape[0] == 1
+        # Allow for some variation due to resampling
+        assert abs(audio.shape[1] - 22050) <= 10
+
+
+def test_chain_mono_resampled_stereo():
+    """Test triple chaining: .mono().resampled_to().stereo()."""
+    stereo = generate_sine_at(44100, 440, num_seconds=1, num_channels=2).astype(np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 2, bit_depth=32) as f:
+        f.write(stereo)
+
+    with AudioFile(BytesIO(buf.getvalue())).mono().resampled_to(22050).stereo() as f:
+        assert f.samplerate == 22050
+        assert f.num_channels == 2
+        audio = f.read(f.frames)
+        assert audio.shape[0] == 2
+        # Both channels should be identical (duplicated from mono)
+        np.testing.assert_allclose(audio[0], audio[1])
+
+
+def test_multichannel_to_stereo_via_mono():
+    """Test the recommended workaround: multichannel -> mono -> stereo."""
+    surround = np.random.rand(6, 44100).astype(np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 6, bit_depth=32) as f:
+        f.write(surround)
+
+    # Direct conversion should fail
+    with pytest.raises(ValueError):
+        AudioFile(BytesIO(buf.getvalue())).stereo()
+
+    # But via mono should work
+    with AudioFile(BytesIO(buf.getvalue())).mono().stereo() as f:
+        assert f.num_channels == 2
+        audio = f.read(f.frames)
+        assert audio.shape == (2, 44100)
+
+
+@pytest.mark.parametrize("chunk_size", [100, 1000, 10000, 44100])
+def test_read_in_chunks(chunk_size: int):
+    """Test reading in chunks produces same result as reading all at once."""
+    stereo = np.random.rand(2, 44100).astype(np.float32)
+
+    buf = BytesIO()
+    buf.name = "test.wav"
+    with AudioFile(buf, "w", 44100, 2, bit_depth=32) as f:
+        f.write(stereo)
+
+    # Read all at once
+    with AudioFile(BytesIO(buf.getvalue())).mono() as f:
+        all_at_once = f.read(f.frames)
+
+    # Read in chunks
+    with AudioFile(BytesIO(buf.getvalue())).mono() as f:
+        chunks = []
+        while f.tell() < f.frames:
+            chunk = f.read(chunk_size)
+            chunks.append(chunk)
+        in_chunks = np.concatenate(chunks, axis=1)
+
+    np.testing.assert_allclose(all_at_once, in_chunks)


### PR DESCRIPTION
We've had `ResampledReadableAudioFile` for a while now, providing a nice interface for on-the-fly resampling with `.resampled_to(new_sample_rate)`. However, a common complaint is that there's no corresponding method for changing channel counts; users have to do `np.mean(chunk, axis=0)` instead to downmix.

This PR adds `ChannelConvertedReadableAudioFile`, which adds three new helpers for this:
 - `.mono()`, which downmixes to a single channel
 - `.stereo()`, which upmixes mono to stereo
 - `.with_channels(channel_count: int)`, which upmixes mono to any number of channels (or downmixes any number to mono).

Downmixing to any number of channels other than 1 is currently not supported; there are multiple methods to go from 5.1 or other multichannel formats to stereo, and Pedalboard should not (yet) be opinionated about them.

Under the hood, to make this chaining work, I had to pull out `AbstractReadableAudioFile` as a base class and do a bit of class hierarchy refactoring.