### PR TITLE
Fix MIDI overload resolution for ArrayLike support (#450)

### DIFF
--- a/pedalboard/ArrayUtils.h
+++ b/pedalboard/ArrayUtils.h
@@ -1,0 +1,121 @@
+/*
+ * pedalboard
+ * Copyright 2025 Spotify AB
+ *
+ * Licensed under the GNU Public License, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace Pedalboard {
+
+/**
+ * Utility function to convert various array-like objects to py::array.
+ * Supports:
+ * - NumPy arrays (pass-through)
+ * - PyTorch tensors (via .numpy() method)
+ * - JAX arrays (via .__array__() method)
+ * - TensorFlow tensors (via .numpy() method)
+ * - CuPy arrays (via .get() method for CPU copy)
+ * - Any object with __array__ interface
+ */
+inline py::array ensureArrayLike(py::object input) {
+  // If we were already given a numpy array, just return it
+  if (py::isinstance<py::array>(input)) {
+    return py::reinterpret_borrow<py::array>(input);
+  }
+
+  // Check if it's a PyTorch tensor (has a .numpy() method)
+  if (py::hasattr(input, "numpy") && py::hasattr(input, "dtype") &&
+      py::hasattr(input, "device")) {
+    // Check if tensor is on CPU
+    py::object device = input.attr("device");
+    std::string device_type = py::str(device.attr("type")).cast<std::string>();
+
+    if (device_type != "cpu") {
+      // Move tensor to CPU first
+      input = input.attr("cpu")();
+    }
+
+    // Call .numpy() to get the numpy array
+    // This shares memory with the tensor when possible
+    return input.attr("numpy")().cast<py::array>();
+  }
+
+  // Check if it's a TensorFlow tensor (has .numpy() method but no .device)
+  if (py::hasattr(input, "numpy") && !py::hasattr(input, "device")) {
+    try {
+      return input.attr("numpy")().cast<py::array>();
+    } catch (...) {
+      // Fall through to next option
+    }
+  }
+
+  // Check if it's a CuPy array (has .get() method)
+  if (py::hasattr(input, "get") && py::hasattr(input, "dtype") &&
+      py::hasattr(input, "ndim")) {
+    try {
+      // .get() copies from GPU to CPU and returns numpy array
+      return input.attr("get")().cast<py::array>();
+    } catch (...) {
+      // Fall through to next option
+    }
+  }
+
+  // Check if it implements the array protocol (__array__)
+  if (py::hasattr(input, "__array__")) {
+    try {
+      return input.attr("__array__")().cast<py::array>();
+    } catch (...) {
+      // Fall through to error
+    }
+  }
+
+  // Try to convert directly to array as a last resort
+  // py::array::ensure() will attempt to convert the object to an array
+  // or return an invalid array handle if conversion fails
+  py::array result = py::array::ensure(input);
+
+  if (!result) {
+    throw py::type_error(
+        "Expected an array-like object (numpy array, torch tensor, etc.), "
+        "but received: " +
+        py::repr(input).cast<std::string>());
+  }
+
+  return result;
+}
+
+/**
+ * Template version that ensures the array has a specific dtype
+ */
+template <typename T>
+inline py::array_t<T> ensureArrayLikeWithType(py::object input) {
+  py::array arr = ensureArrayLike(input);
+
+  // If the array already has the correct type, return it
+  if (py::isinstance<py::array_t<T>>(arr)) {
+    return py::reinterpret_borrow<py::array_t<T>>(arr);
+  }
+
+  // Otherwise, cast to the desired type
+  // Note: this may create a copy
+  return arr.cast<py::array_t<T>>();
+}
+
+} // namespace Pedalboard

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -1578,10 +1578,9 @@ inline void init_external_plugins(py::module &m) {
               py::arg("reset") = true)
           .def(
               "process",
-              [](std::shared_ptr<Plugin> self, const py::array inputArray,
+              [](std::shared_ptr<Plugin> self, py::object input,
                  double sampleRate, unsigned int bufferSize, bool reset) {
-                return process(inputArray, sampleRate, {self}, bufferSize,
-                               reset);
+                return process(input, sampleRate, {self}, bufferSize, reset);
               },
               EXTERNAL_PLUGIN_PROCESS_DOCSTRING, py::arg("input_array"),
               py::arg("sample_rate"),
@@ -1589,10 +1588,9 @@ inline void init_external_plugins(py::module &m) {
               py::arg("reset") = true)
           .def(
               "__call__",
-              [](std::shared_ptr<Plugin> self, const py::array inputArray,
+              [](std::shared_ptr<Plugin> self, py::object input,
                  double sampleRate, unsigned int bufferSize, bool reset) {
-                return process(inputArray, sampleRate, {self}, bufferSize,
-                               reset);
+                return process(input, sampleRate, {self}, bufferSize, reset);
               },
               "Run an audio or MIDI buffer through this plugin, returning "
               "audio. Alias for :py:meth:`process`.",
@@ -1809,18 +1807,18 @@ example: a Windows VST3 plugin bundle will not load on Linux or macOS.)
            SHOW_EDITOR_DOCSTRING, py::arg("close_event") = py::none())
       .def(
           "process",
-          [](std::shared_ptr<Plugin> self, const py::array inputArray,
-             double sampleRate, unsigned int bufferSize, bool reset) {
-            return process(inputArray, sampleRate, {self}, bufferSize, reset);
+          [](std::shared_ptr<Plugin> self, py::object input, double sampleRate,
+             unsigned int bufferSize, bool reset) {
+            return process(input, sampleRate, {self}, bufferSize, reset);
           },
           EXTERNAL_PLUGIN_PROCESS_DOCSTRING, py::arg("input_array"),
           py::arg("sample_rate"), py::arg("buffer_size") = DEFAULT_BUFFER_SIZE,
           py::arg("reset") = true)
       .def(
           "__call__",
-          [](std::shared_ptr<Plugin> self, const py::array inputArray,
-             double sampleRate, unsigned int bufferSize, bool reset) {
-            return process(inputArray, sampleRate, {self}, bufferSize, reset);
+          [](std::shared_ptr<Plugin> self, py::object input, double sampleRate,
+             unsigned int bufferSize, bool reset) {
+            return process(input, sampleRate, {self}, bufferSize, reset);
           },
           "Run an audio or MIDI buffer through this plugin, returning "
           "audio. Alias for :py:meth:`process`.",
@@ -2035,18 +2033,18 @@ see :class:`pedalboard.VST3Plugin`.)
            SHOW_EDITOR_DOCSTRING, py::arg("close_event") = py::none())
       .def(
           "process",
-          [](std::shared_ptr<Plugin> self, const py::array inputArray,
-             double sampleRate, unsigned int bufferSize, bool reset) {
-            return process(inputArray, sampleRate, {self}, bufferSize, reset);
+          [](std::shared_ptr<Plugin> self, py::object input, double sampleRate,
+             unsigned int bufferSize, bool reset) {
+            return process(input, sampleRate, {self}, bufferSize, reset);
           },
           EXTERNAL_PLUGIN_PROCESS_DOCSTRING, py::arg("input_array"),
           py::arg("sample_rate"), py::arg("buffer_size") = DEFAULT_BUFFER_SIZE,
           py::arg("reset") = true)
       .def(
           "__call__",
-          [](std::shared_ptr<Plugin> self, const py::array inputArray,
-             double sampleRate, unsigned int bufferSize, bool reset) {
-            return process(inputArray, sampleRate, {self}, bufferSize, reset);
+          [](std::shared_ptr<Plugin> self, py::object input, double sampleRate,
+             unsigned int bufferSize, bool reset) {
+            return process(input, sampleRate, {self}, bufferSize, reset);
           },
           "Run an audio or MIDI buffer through this plugin, returning "
           "audio. Alias for :py:meth:`process`.",

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -1811,8 +1811,7 @@ example: a Windows VST3 plugin bundle will not load on Linux or macOS.)
           "process",
           [](std::shared_ptr<Plugin> self, const py::array inputArray,
              double sampleRate, unsigned int bufferSize, bool reset) {
-            return process(inputArray, sampleRate, {self}, bufferSize,
-                           reset);
+            return process(inputArray, sampleRate, {self}, bufferSize, reset);
           },
           EXTERNAL_PLUGIN_PROCESS_DOCSTRING, py::arg("input_array"),
           py::arg("sample_rate"), py::arg("buffer_size") = DEFAULT_BUFFER_SIZE,
@@ -1821,8 +1820,7 @@ example: a Windows VST3 plugin bundle will not load on Linux or macOS.)
           "__call__",
           [](std::shared_ptr<Plugin> self, const py::array inputArray,
              double sampleRate, unsigned int bufferSize, bool reset) {
-            return process(inputArray, sampleRate, {self}, bufferSize,
-                           reset);
+            return process(inputArray, sampleRate, {self}, bufferSize, reset);
           },
           "Run an audio or MIDI buffer through this plugin, returning "
           "audio. Alias for :py:meth:`process`.",
@@ -2039,8 +2037,7 @@ see :class:`pedalboard.VST3Plugin`.)
           "process",
           [](std::shared_ptr<Plugin> self, const py::array inputArray,
              double sampleRate, unsigned int bufferSize, bool reset) {
-            return process(inputArray, sampleRate, {self}, bufferSize,
-                           reset);
+            return process(inputArray, sampleRate, {self}, bufferSize, reset);
           },
           EXTERNAL_PLUGIN_PROCESS_DOCSTRING, py::arg("input_array"),
           py::arg("sample_rate"), py::arg("buffer_size") = DEFAULT_BUFFER_SIZE,
@@ -2049,8 +2046,7 @@ see :class:`pedalboard.VST3Plugin`.)
           "__call__",
           [](std::shared_ptr<Plugin> self, const py::array inputArray,
              double sampleRate, unsigned int bufferSize, bool reset) {
-            return process(inputArray, sampleRate, {self}, bufferSize,
-                           reset);
+            return process(inputArray, sampleRate, {self}, bufferSize, reset);
           },
           "Run an audio or MIDI buffer through this plugin, returning "
           "audio. Alias for :py:meth:`process`.",

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -1578,9 +1578,10 @@ inline void init_external_plugins(py::module &m) {
               py::arg("reset") = true)
           .def(
               "process",
-              [](std::shared_ptr<Plugin> self, py::object input,
+              [](std::shared_ptr<Plugin> self, const py::array inputArray,
                  double sampleRate, unsigned int bufferSize, bool reset) {
-                return process(input, sampleRate, {self}, bufferSize, reset);
+                return process(inputArray, sampleRate, {self}, bufferSize,
+                               reset);
               },
               EXTERNAL_PLUGIN_PROCESS_DOCSTRING, py::arg("input_array"),
               py::arg("sample_rate"),
@@ -1588,9 +1589,10 @@ inline void init_external_plugins(py::module &m) {
               py::arg("reset") = true)
           .def(
               "__call__",
-              [](std::shared_ptr<Plugin> self, py::object input,
+              [](std::shared_ptr<Plugin> self, const py::array inputArray,
                  double sampleRate, unsigned int bufferSize, bool reset) {
-                return process(input, sampleRate, {self}, bufferSize, reset);
+                return process(inputArray, sampleRate, {self}, bufferSize,
+                               reset);
               },
               "Run an audio or MIDI buffer through this plugin, returning "
               "audio. Alias for :py:meth:`process`.",
@@ -1807,18 +1809,20 @@ example: a Windows VST3 plugin bundle will not load on Linux or macOS.)
            SHOW_EDITOR_DOCSTRING, py::arg("close_event") = py::none())
       .def(
           "process",
-          [](std::shared_ptr<Plugin> self, py::object input, double sampleRate,
-             unsigned int bufferSize, bool reset) {
-            return process(input, sampleRate, {self}, bufferSize, reset);
+          [](std::shared_ptr<Plugin> self, const py::array inputArray,
+             double sampleRate, unsigned int bufferSize, bool reset) {
+            return process(inputArray, sampleRate, {self}, bufferSize,
+                           reset);
           },
           EXTERNAL_PLUGIN_PROCESS_DOCSTRING, py::arg("input_array"),
           py::arg("sample_rate"), py::arg("buffer_size") = DEFAULT_BUFFER_SIZE,
           py::arg("reset") = true)
       .def(
           "__call__",
-          [](std::shared_ptr<Plugin> self, py::object input, double sampleRate,
-             unsigned int bufferSize, bool reset) {
-            return process(input, sampleRate, {self}, bufferSize, reset);
+          [](std::shared_ptr<Plugin> self, const py::array inputArray,
+             double sampleRate, unsigned int bufferSize, bool reset) {
+            return process(inputArray, sampleRate, {self}, bufferSize,
+                           reset);
           },
           "Run an audio or MIDI buffer through this plugin, returning "
           "audio. Alias for :py:meth:`process`.",
@@ -2033,18 +2037,20 @@ see :class:`pedalboard.VST3Plugin`.)
            SHOW_EDITOR_DOCSTRING, py::arg("close_event") = py::none())
       .def(
           "process",
-          [](std::shared_ptr<Plugin> self, py::object input, double sampleRate,
-             unsigned int bufferSize, bool reset) {
-            return process(input, sampleRate, {self}, bufferSize, reset);
+          [](std::shared_ptr<Plugin> self, const py::array inputArray,
+             double sampleRate, unsigned int bufferSize, bool reset) {
+            return process(inputArray, sampleRate, {self}, bufferSize,
+                           reset);
           },
           EXTERNAL_PLUGIN_PROCESS_DOCSTRING, py::arg("input_array"),
           py::arg("sample_rate"), py::arg("buffer_size") = DEFAULT_BUFFER_SIZE,
           py::arg("reset") = true)
       .def(
           "__call__",
-          [](std::shared_ptr<Plugin> self, py::object input, double sampleRate,
-             unsigned int bufferSize, bool reset) {
-            return process(input, sampleRate, {self}, bufferSize, reset);
+          [](std::shared_ptr<Plugin> self, const py::array inputArray,
+             double sampleRate, unsigned int bufferSize, bool reset) {
+            return process(inputArray, sampleRate, {self}, bufferSize,
+                           reset);
           },
           "Run an audio or MIDI buffer through this plugin, returning "
           "audio. Alias for :py:meth:`process`.",

--- a/pedalboard/process.h
+++ b/pedalboard/process.h
@@ -21,6 +21,7 @@
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 
+#include "ArrayUtils.h"
 #include "BufferUtils.h"
 #include "Plugin.h"
 #include "PluginContainer.h"
@@ -275,9 +276,12 @@ processFloat32(const py::array_t<float, py::array::c_style> inputArray,
                                    inputArray.request().ndim);
 }
 
-py::array_t<float> process(py::array inputArray, double sampleRate,
+py::array_t<float> process(py::object input, double sampleRate,
                            const std::vector<std::shared_ptr<Plugin>> plugins,
                            unsigned int bufferSize, bool reset) {
+  // Convert the input to a numpy array (supports torch tensors, etc.)
+  py::array inputArray = ensureArrayLike(input);
+
   py::array_t<float, py::array::c_style> float32InputArray;
   switch (inputArray.dtype().char_()) {
   case 'f':

--- a/pedalboard/python_bindings.cpp
+++ b/pedalboard/python_bindings.cpp
@@ -87,15 +87,19 @@ PYBIND11_MODULE(pedalboard_native, m, py::mod_gil_not_used()) {
 
   m.def(
       "process",
-      [](const py::array inputArray, double sampleRate,
+      [](py::object input, double sampleRate,
          const std::vector<std::shared_ptr<Plugin>> plugins,
          unsigned int bufferSize, bool reset) {
-        return process(inputArray, sampleRate, plugins, bufferSize, reset);
+        return process(input, sampleRate, plugins, bufferSize, reset);
       },
       R"(
 Run a 32-bit or 64-bit floating point audio buffer through a
 list of Pedalboard plugins. If the provided buffer uses a 64-bit datatype,
 it will be converted to 32-bit for processing.
+
+The input audio buffer can be any array-like object, including NumPy arrays,
+PyTorch tensors, TensorFlow tensors, JAX arrays, or any other object that
+supports the buffer protocol or has a __array__ method.
 
 The provided ``buffer_size`` argument will be used to control the size of
 each chunk of audio provided into the plugins. Higher buffer sizes may speed up
@@ -134,14 +138,18 @@ or buffer, set ``reset`` to ``False``.
           "parameters will remain unchanged. ")
       .def(
           "process",
-          [](std::shared_ptr<Plugin> self, const py::array inputArray,
-             double sampleRate, unsigned int bufferSize, bool reset) {
-            return process(inputArray, sampleRate, {self}, bufferSize, reset);
+          [](std::shared_ptr<Plugin> self, py::object input, double sampleRate,
+             unsigned int bufferSize, bool reset) {
+            return process(input, sampleRate, {self}, bufferSize, reset);
           },
           R"(
 Run a 32-bit or 64-bit floating point audio buffer through this plugin.
 (If calling this multiple times with multiple plugins, consider creating a
 :class:`pedalboard.Pedalboard` object instead.)
+
+The input audio buffer can be any array-like object, including NumPy arrays,
+PyTorch tensors, TensorFlow tensors, JAX arrays, or any other object that
+supports the buffer protocol or has a __array__ method.
 
 The returned array may contain up to (but not more than) the same number of
 samples as were provided. If fewer samples were returned than expected, the
@@ -176,9 +184,9 @@ If the number of samples and the number of channels are the same, each
           py::arg("buffer_size") = DEFAULT_BUFFER_SIZE, py::arg("reset") = true)
       .def(
           "__call__",
-          [](std::shared_ptr<Plugin> self, const py::array inputArray,
-             double sampleRate, unsigned int bufferSize, bool reset) {
-            return process(inputArray, sampleRate, {self}, bufferSize, reset);
+          [](std::shared_ptr<Plugin> self, py::object input, double sampleRate,
+             unsigned int bufferSize, bool reset) {
+            return process(input, sampleRate, {self}, bufferSize, reset);
           },
           "Run an audio buffer through this plugin. Alias for "
           ":py:meth:`process`.",

--- a/pedalboard_native/_internal/__init__.pyi
+++ b/pedalboard_native/_internal/__init__.pyi
@@ -22,9 +22,22 @@ def patch_overload(func):
 
 typing.overload = patch_overload
 
+from typing import Optional
 from typing_extensions import Literal
 from enum import Enum
 import threading
+
+# Array-like type that includes numpy arrays, torch tensors, etc.
+# At runtime, we accept any array-like object (numpy arrays, torch tensors,
+# tensorflow tensors, jax arrays, or anything with __array__ method).
+# For type checking, we use numpy.typing.ArrayLike which covers most cases.
+if typing.TYPE_CHECKING:
+    import numpy
+    import numpy.typing
+
+    ArrayLike = numpy.typing.ArrayLike
+else:
+    ArrayLike = typing.Any
 import pedalboard_native
 
 __all__ = [

--- a/pedalboard_native/utils/__init__.pyi
+++ b/pedalboard_native/utils/__init__.pyi
@@ -22,9 +22,22 @@ def patch_overload(func):
 
 typing.overload = patch_overload
 
+from typing import Optional
 from typing_extensions import Literal
 from enum import Enum
 import threading
+
+# Array-like type that includes numpy arrays, torch tensors, etc.
+# At runtime, we accept any array-like object (numpy arrays, torch tensors,
+# tensorflow tensors, jax arrays, or anything with __array__ method).
+# For type checking, we use numpy.typing.ArrayLike which covers most cases.
+if typing.TYPE_CHECKING:
+    import numpy
+    import numpy.typing
+
+    ArrayLike = numpy.typing.ArrayLike
+else:
+    ArrayLike = typing.Any
 import numpy
 import pedalboard_native
 
@@ -37,9 +50,7 @@ class Chain(pedalboard_native.PluginContainer, pedalboard_native.Plugin):
     Run zero or more plugins as a plugin. Useful when used with the Mix plugin.
     """
 
-    @typing.overload
     def __init__(self, plugins: typing.List[pedalboard_native.Plugin]) -> None: ...
-    @typing.overload
     def __repr__(self) -> str: ...
     pass
 
@@ -48,9 +59,7 @@ class Mix(pedalboard_native.PluginContainer, pedalboard_native.Plugin):
     A utility plugin that allows running other plugins in parallel. All plugins provided will be mixed equally.
     """
 
-    @typing.overload
     def __init__(self, plugins: typing.List[pedalboard_native.Plugin]) -> None: ...
-    @typing.overload
     def __repr__(self) -> str: ...
     pass
 

--- a/scripts/generate_type_stubs_and_docs.py
+++ b/scripts/generate_type_stubs_and_docs.py
@@ -49,15 +49,61 @@ OMIT_LINES_CONTAINING = [
 ]
 
 MULTILINE_REPLACEMENTS = [
-    # Users don't want "Peter Sobot’s iPhone Microphone" to show up in their type hints:
+    # Users don't want "Peter Sobot's iPhone Microphone" to show up in their type hints:
     (r"input_device_names = \[[^]]*\]\n", "input_device_names: typing.List[str] = []\n"),
     (
         r"output_device_names = \[[^]]*\]\n",
         "output_device_names: typing.List[str] = []\n",
     ),
+    # Remove _reload_type property blocks (internal implementation detail using ExternalPluginReloadType)
+    # Match @property followed by def _reload_type and its docstring (using [\s\S] for multiline)
+    (r'    @property\n    def _reload_type\(self\)[^\n]*\n        """[\s\S]*?"""\n', ""),
+    (r'    @_reload_type\.setter\n    def _reload_type\(self[^\n]*\n        """[\s\S]*?"""\n', ""),
+    # MyPy chokes on classes that contain both __new__ and __init__.
+    # Remove all bare, arg-free inits (and their @typing.overload decorators):
+    (r"    @typing\.overload\n    def __init__\(self\) -> None: \.\.\.\n", ""),
+    # After removing one overload from a pair in Chain/Mix classes, a single @typing.overload
+    # remains which is invalid. Remove it ONLY for the plugins: parameter pattern (from utils)
+    (
+        r"    @typing\.overload\n(    def __init__\(self, plugins:)",
+        r"\1",
+    ),
+    # Fix VST3Plugin __call__ overload order to match ExternalPlugin (midi_messages first)
+    # The raw stubs have input_array first, but parent has midi_messages first.
+    # Raw stubs have single-line signatures before black formatting.
+    (
+        r'(class VST3Plugin\(ExternalPlugin, Plugin\):[\s\S]*?"""\n)'
+        r'(    @typing\.overload\n    def __call__\(self, input_array: object[^\n]*\n        """[\s\S]*?"""\n)'
+        r'(    @typing\.overload\n    def __call__\(self, midi_messages[^\n]*\.\.\.)',
+        r'\1\3\n\2',
+    ),
+    # Fix VST3Plugin process overload order similarly
+    (
+        r'(    def load_preset\(self, preset_file_path: str\)[^\n]*\n        """[\s\S]*?"""\n)'
+        r'(    @typing\.overload\n    def process\(self, input_array: object[^\n]*\n        """[\s\S]*?"""\n)'
+        r'(    @typing\.overload\n    def process\(self, midi_messages[^\n]*\.\.\.)',
+        r'\1\3\n\2',
+    ),
+    # Fix AudioUnitPlugin __call__ and process overload order similarly
+    (
+        r'(class AudioUnitPlugin\(ExternalPlugin, Plugin\):[\s\S]*?"""\n)'
+        r'(    @typing\.overload\n    def __call__\(self, input_array: object[^\n]*\n        """[\s\S]*?"""\n)'
+        r'(    @typing\.overload\n    def __call__\(self, midi_messages[^\n]*\.\.\.)',
+        r'\1\3\n\2',
+    ),
+    (
+        r'(class AudioUnitPlugin[\s\S]*?def load_preset\(self, preset_file_path: str\)[^\n]*\n        """[\s\S]*?"""\n)'
+        r'(    @typing\.overload\n    def process\(self, input_array: object[^\n]*\n        """[\s\S]*?"""\n)'
+        r'(    @typing\.overload\n    def process\(self, midi_messages[^\n]*\.\.\.)',
+        r'\1\3\n\2',
+    ),
 ]
 
 REPLACEMENTS = [
+    # Replace generic 'object' with a proper ArrayLike type hint for audio data:
+    (r"input_array: object", r"input_array: ArrayLike"),
+    (r"input: object", r"input: ArrayLike"),
+    (r"samples: object", r"samples: ArrayLike"),
     # object is a superclass of `str`, which would make these declarations ambiguous:
     (
         r"file_like: object, mode: str = 'r'",
@@ -79,9 +125,21 @@ REPLACEMENTS = [
         "\n".join(
             [
                 "import typing",
+                "from typing import Optional",
                 "from typing_extensions import Literal",
                 "from enum import Enum",
                 "import threading",
+                "",
+                "# Array-like type that includes numpy arrays, torch tensors, etc.",
+                "# At runtime, we accept any array-like object (numpy arrays, torch tensors,",
+                "# tensorflow tensors, jax arrays, or anything with __array__ method).",
+                "# For type checking, we use numpy.typing.ArrayLike which covers most cases.",
+                "if typing.TYPE_CHECKING:",
+                "    import numpy",
+                "    import numpy.typing",
+                "    ArrayLike = numpy.typing.ArrayLike",
+                "else:",
+                "    ArrayLike = typing.Any",
             ]
         ),
     ),
@@ -104,7 +162,8 @@ REPLACEMENTS = [
         "pedalboard_native.Resample.Quality = pedalboard_native.Resample.Quality",
     ),
     (
-        r".*: pedalboard_native.ExternalPluginReloadType.*",
+        # Remove any lines referencing ExternalPluginReloadType (internal implementation detail)
+        r".*ExternalPluginReloadType.*",
         "",
     ),
     # Enum values that should not be in __all__:
@@ -115,8 +174,8 @@ REPLACEMENTS = [
     # Remove type hints in docstrings, added unnecessarily by pybind11-stubgen
     (r".*?:type:.*$", ""),
     # MyPy chokes on classes that contain both __new__ and __init__.
-    # Remove all bare, arg-free inits:
-    (r"def __init__\(self\) -> None: ...", ""),
+    # Remove all bare, arg-free inits (moved to MULTILINE_REPLACEMENTS):
+    (r"def __init__\(self\) -> None: \.\.\.", ""),
     # Sphinx gets confused when inheriting twice from the same base class:
     (r"\(ExternalPlugin, Plugin\)", "(ExternalPlugin)"),
     # Python <3.9 doesn't like bare lists in type hints:

--- a/stubtest.allowlist
+++ b/stubtest.allowlist
@@ -1,18 +1,25 @@
-pedalboard.Plugin.__call__
-pedalboard.__all__
-pedalboard.io.__all__
-pedalboard._pedalboard.Dict
-pedalboard._pedalboard.Iterable
-pedalboard._pedalboard.List
-pedalboard._pedalboard.Plugin.__call__
-pedalboard._pedalboard.WeakTypeWrapper@\d+
-pedalboard._pedalboard._AudioProcessorParameter.__init__
-pedalboard._pedalboard.Pedalboard
-pedalboard._pedalboard.VST3Plugin
-pedalboard.utils.Chain
-pedalboard.utils.Mix
-pedalboard.utils.__all__
-pedalboard.version.__all__
-.*?AudioUnitPlugin.*
+# Allowlist for stubtest - these are expected differences between stubs and runtime
+# Metaclass differences are expected with pybind11
 .*?metaclass.*
+# AudioUnitPlugin is macOS-only
+.*?AudioUnitPlugin.*
+# ExternalPluginReloadType is internal
 .*?ExternalPluginReloadType.*
+.*?ClearsAudioOnReset.*
+.*?PersistsAudioOnReset.*
+.*?Unknown.*
+# ArrayLike is a type alias for type checking only
+.*?ArrayLike.*
+# __all__ is stub-only
+.*?__all__.*
+# original_overload and patch_overload are stub helpers
+.*?original_overload.*
+.*?patch_overload.*
+# _AudioProcessorParameter has variadic __init__
+.*?_AudioProcessorParameter.__init__.*
+# Enum methods that pybind11 adds at runtime
+.*?__index__.*
+.*?__int__.*
+.*?__members__.*
+# installed_plugins is a runtime-populated list
+.*?installed_plugins.*


### PR DESCRIPTION
## Summary

- Fixes the macOS/Windows test failures introduced by #450 (psobot's ArrayLike support PR)
- The root cause: #450 changed ExternalPlugin binding lambdas from `const py::array` to `py::object`, which broke pybind11's overload resolution between the audio `process`/`__call__` and MIDI `renderMIDIMessages` overloads
- When instrument plugins were called with MIDI messages (e.g. `plugin(notes, 5.0, sr, reset=False)`), the `py::object` audio overload matched first, causing `ensureArrayLike()` to fail on non-array MIDI message lists with: `TypeError: Pedalboard only supports 32-bit and 64-bit floating point audio for processing.`
- The fix restores `const py::array` as the parameter type in the ExternalPlugin binding lambdas (AbstractExternalPlugin, VST3Plugin, AudioUnitPlugin) so pybind11 correctly rejects non-array inputs and falls through to the MIDI overload
- The base `Plugin` class and standalone `process()` function retain `py::object` since they have no MIDI overloads to conflict with
- pybind11 still auto-converts array-like objects (torch tensors, JAX arrays, etc.) to `py::array` via the buffer protocol and `__array__` interface during argument dispatch

Based on @psobot's work in #450.

## Test plan

- [ ] Linux tests should continue to pass (no instrument plugins, so no MIDI dispatch)
- [ ] macOS tests with instrument plugins (Magical8BitPlug2) should now pass — MIDI messages correctly route to `renderMIDIMessages` instead of the audio `process` path
- [ ] Windows tests with instrument plugins should similarly pass
- [ ] ArrayLike support (torch tensors, etc.) still works for audio processing via the base Plugin class and standalone `process()` function

🤖 Generated with [Claude Code](https://claude.com/claude-code)