### PR TITLE
ExternalPlugin: Add playhead tracking for external plugins

### DIFF
--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -720,10 +720,10 @@ public:
     // parameter state synchronization until the audio processing callback,
     // so without this flush, getPreset() may return stale parameter values.
     if (pluginInstance) {
-      int numChannels = std::max(
-          pluginInstance->getTotalNumInputChannels(),
-          pluginInstance->getTotalNumOutputChannels());
-      if (numChannels < 1) numChannels = 2;
+      int numChannels = std::max(pluginInstance->getTotalNumInputChannels(),
+                                 pluginInstance->getTotalNumOutputChannels());
+      if (numChannels < 1)
+        numChannels = 2;
 
       // Only prepare if the plugin hasn't been prepared yet.
       bool wasPrepared = (lastSpec.numChannels != 0);

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -1325,7 +1325,7 @@ public:
       std::memset((void *)outputArrayPointer, 0,
                   sizeof(float) * numChannels * outputSampleCount);
 
-      juce::AudioBuffer<float> emptyBuffer(channelPointers.size(), 0);
+      juce::AudioBuffer<float> emptyBuffer(numChannels, 0);
       juce::MidiBuffer emptyMidiBuffer;
 
       currentPositionInfo.isPlaying = true;

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -529,6 +529,21 @@ public:
     // Without this, we get an assert(false) from JUCE at runtime
     juce::MessageManager::getInstance();
 
+    // Initialize currentPositionInfo to sensible defaults before any plugin
+    // loading, as plugins may query the playhead during initialization.
+    currentPositionInfo.bpm = 120.0;
+    currentPositionInfo.timeSigNumerator = 4;
+    currentPositionInfo.timeSigDenominator = 4;
+    currentPositionInfo.timeInSamples = 0;
+    currentPositionInfo.timeInSeconds = 0.0;
+    currentPositionInfo.ppqPosition = 0.0;
+    currentPositionInfo.ppqPositionOfLastBarStart = 0.0;
+    currentPositionInfo.isPlaying = false;
+    currentPositionInfo.isRecording = false;
+    currentPositionInfo.isLooping = false;
+    currentPositionInfo.editOriginTime = 0.0;
+    currentPositionInfo.frameRate = juce::AudioPlayHead::fpsUnknown;
+
     pluginFormatManager.addDefaultFormats();
     pluginFormatManager.addFormat(new juce::PatchedVST3PluginFormat());
 

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -1241,6 +1241,12 @@ public:
       currentPositionInfo.isPlaying = true;
       pluginInstance->processBlock(audioBuffer, emptyMidiBuffer);
       currentPositionInfo.isPlaying = false;
+
+      // Pump the processBlock callback to tell the VST that we've stopped
+      // playing:
+      juce::AudioBuffer<float> emptyBuffer(channelPointers.size(), 0);
+      pluginInstance->processBlock(emptyBuffer, emptyMidiBuffer);
+
       samplesProvided += outputBlock.getNumSamples();
       currentPositionInfo.timeInSamples += outputBlock.getNumSamples();
 

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -1242,13 +1242,13 @@ public:
       pluginInstance->processBlock(audioBuffer, emptyMidiBuffer);
       currentPositionInfo.isPlaying = false;
 
+      samplesProvided += outputBlock.getNumSamples();
+      currentPositionInfo.timeInSamples += outputBlock.getNumSamples();
+
       // Pump the processBlock callback to tell the VST that we've stopped
       // playing:
       juce::AudioBuffer<float> emptyBuffer(channelPointers.size(), 0);
       pluginInstance->processBlock(emptyBuffer, emptyMidiBuffer);
-
-      samplesProvided += outputBlock.getNumSamples();
-      currentPositionInfo.timeInSamples += outputBlock.getNumSamples();
 
       // To compensate for any latency added by the plugin,
       // only tell Pedalboard to use the last _n_ samples.
@@ -1325,6 +1325,11 @@ public:
       std::memset((void *)outputArrayPointer, 0,
                   sizeof(float) * numChannels * outputSampleCount);
 
+      juce::AudioBuffer<float> emptyBuffer(channelPointers.size(), 0);
+      juce::MidiBuffer emptyMidiBuffer;
+
+      currentPositionInfo.isPlaying = true;
+
       for (unsigned long i = 0; i < outputSampleCount; i += bufferSize) {
         unsigned long chunkSampleCount =
             std::min((unsigned long)bufferSize, outputSampleCount - i);
@@ -1342,12 +1347,14 @@ public:
 
         juce::MidiBuffer midiChunk;
         midiChunk.addEvents(midiInputBuffer, i, chunkSampleCount, -i);
-
-        currentPositionInfo.isPlaying = true;
         pluginInstance->processBlock(audioChunk, midiChunk);
-        currentPositionInfo.isPlaying = false;
         currentPositionInfo.timeInSamples += chunkSampleCount;
       }
+
+      currentPositionInfo.isPlaying = false;
+      // Pump the processBlock callback to tell the VST that we've stopped
+      // playing:
+      pluginInstance->processBlock(emptyBuffer, emptyMidiBuffer);
     }
 
     return outputArray;

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -516,7 +516,7 @@ public:
 };
 
 template <typename ExternalPluginType>
-class ExternalPlugin : public AbstractExternalPlugin {
+class ExternalPlugin : public AbstractExternalPlugin, juce::AudioPlayHead {
 public:
   ExternalPlugin(
       std::string &_pathToPluginFile,
@@ -630,6 +630,10 @@ public:
   ~ExternalPlugin() {
     {
       std::lock_guard<std::mutex> lock(EXTERNAL_PLUGIN_MUTEX);
+      if (pluginInstance) {
+        pluginInstance->setPlayHead(nullptr);
+      }
+
       pluginInstance.reset();
       NUM_ACTIVE_EXTERNAL_PLUGINS--;
 
@@ -732,6 +736,9 @@ public:
       {
         std::lock_guard<std::mutex> lock(EXTERNAL_PLUGIN_MUTEX);
         // Delete the plugin instance itself:
+        if (pluginInstance) {
+          pluginInstance->setPlayHead(nullptr);
+        }
         pluginInstance.reset();
         NUM_ACTIVE_EXTERNAL_PLUGINS--;
       }
@@ -751,6 +758,7 @@ public:
                                      loadError.toStdString());
       }
 
+      pluginInstance->setPlayHead(this);
       pluginInstance->enableAllBuses();
 
       auto mainInputBus = pluginInstance->getBus(true, 0);
@@ -760,6 +768,9 @@ public:
         auto exception = std::invalid_argument(
             "Plugin '" + pluginInstance->getName().toStdString() +
             "' does not produce audio output.");
+        if (pluginInstance) {
+          pluginInstance->setPlayHead(nullptr);
+        }
         pluginInstance.reset();
         throw exception;
       }
@@ -778,6 +789,7 @@ public:
                                          pathToPluginFile.toStdString() + ": " +
                                          loadError.toStdString());
           }
+          pluginInstance->setPlayHead(this);
         }
       }
 
@@ -949,7 +961,10 @@ public:
     juce::AudioBuffer<float> audioBuffer(numOutputChannels, bufferSize);
     audioBuffer.clear();
 
+    currentPositionInfo.isPlaying = true;
     pluginInstance->processBlock(audioBuffer, emptyNoteBuffer);
+    currentPositionInfo.isPlaying = false;
+    currentPositionInfo.timeInSamples += bufferSize;
     auto noiseFloor = audioBuffer.getMagnitude(0, bufferSize);
 
     audioBuffer.clear();
@@ -959,7 +974,10 @@ public:
     // the messages in a MidiBuffer get erased every time we call processBlock!
     {
       juce::MidiBuffer noteOnBuffer(noteOn);
+      currentPositionInfo.isPlaying = true;
       pluginInstance->processBlock(audioBuffer, noteOnBuffer);
+      currentPositionInfo.isPlaying = false;
+      currentPositionInfo.timeInSamples += bufferSize;
     }
 
     // Then keep pumping the message thread until we get some louder output:
@@ -982,8 +1000,11 @@ public:
 
       audioBuffer.clear();
       {
+        currentPositionInfo.isPlaying = true;
         juce::MidiBuffer noteOnBuffer(noteOn);
         pluginInstance->processBlock(audioBuffer, noteOnBuffer);
+        currentPositionInfo.isPlaying = false;
+        currentPositionInfo.timeInSamples += bufferSize;
       }
 
       if (juce::Time::currentTimeMillis() >= endTime)
@@ -995,8 +1016,12 @@ public:
     audioBuffer.clear();
     {
       juce::MidiBuffer allNotesOffBuffer(allNotesOff);
+      currentPositionInfo.isPlaying = true;
       pluginInstance->processBlock(audioBuffer, allNotesOffBuffer);
+      currentPositionInfo.isPlaying = false;
+      currentPositionInfo.timeInSamples += bufferSize;
     }
+    currentPositionInfo.timeInSamples = 0;
     pluginInstance->reset();
     pluginInstance->releaseResources();
 
@@ -1114,6 +1139,7 @@ public:
       // Force prepare() to be called again later by invalidating lastSpec:
       lastSpec.maximumBlockSize = 0;
       samplesProvided = 0;
+      currentPositionInfo.timeInSamples = 0;
     }
   }
 
@@ -1139,6 +1165,8 @@ public:
 
       pluginInstance->setNonRealtime(true);
       pluginInstance->prepareToPlay(spec.sampleRate, spec.maximumBlockSize);
+      currentPositionInfo.timeInSamples = 0;
+      currentPositionInfo.isPlaying = false;
 
       lastSpec = spec;
     }
@@ -1210,8 +1238,11 @@ public:
                                            channelPointers.size(),
                                            outputBlock.getNumSamples());
 
+      currentPositionInfo.isPlaying = true;
       pluginInstance->processBlock(audioBuffer, emptyMidiBuffer);
+      currentPositionInfo.isPlaying = false;
       samplesProvided += outputBlock.getNumSamples();
+      currentPositionInfo.timeInSamples += outputBlock.getNumSamples();
 
       // To compensate for any latency added by the plugin,
       // only tell Pedalboard to use the last _n_ samples.
@@ -1306,7 +1337,10 @@ public:
         juce::MidiBuffer midiChunk;
         midiChunk.addEvents(midiInputBuffer, i, chunkSampleCount, -i);
 
+        currentPositionInfo.isPlaying = true;
         pluginInstance->processBlock(audioChunk, midiChunk);
+        currentPositionInfo.isPlaying = false;
+        currentPositionInfo.timeInSamples += chunkSampleCount;
       }
     }
 
@@ -1382,6 +1416,11 @@ public:
   ExternalPluginReloadType reloadType = ExternalPluginReloadType::Unknown;
   juce::PluginDescription foundPluginDescription;
 
+  bool getCurrentPosition(CurrentPositionInfo &result) override {
+    result = currentPositionInfo;
+    return true;
+  }
+
 private:
   std::unique_ptr<juce::AudioPluginInstance>
   createPluginInstance(const juce::PluginDescription &foundPluginDescription,
@@ -1416,6 +1455,7 @@ private:
   juce::String pathToPluginFile;
   juce::AudioPluginFormatManager pluginFormatManager;
   std::unique_ptr<juce::AudioPluginInstance> pluginInstance;
+  juce::AudioPlayHead::CurrentPositionInfo currentPositionInfo;
 
   long samplesProvided = 0;
   float initializationTimeout = DEFAULT_INITIALIZATION_TIMEOUT_SECONDS;

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -714,7 +714,33 @@ public:
     }
   };
 
-  void getPreset(juce::MemoryBlock &dest) const {
+  void getPreset(juce::MemoryBlock &dest) {
+    // Flush any pending parameter changes to the plugin's internal state
+    // by calling processBlock with a small buffer. Some VST3 plugins defer
+    // parameter state synchronization until the audio processing callback,
+    // so without this flush, getPreset() may return stale parameter values.
+    if (pluginInstance) {
+      int numChannels = std::max(
+          pluginInstance->getTotalNumInputChannels(),
+          pluginInstance->getTotalNumOutputChannels());
+      if (numChannels < 1) numChannels = 2;
+
+      // Only prepare if the plugin hasn't been prepared yet.
+      bool wasPrepared = (lastSpec.numChannels != 0);
+      if (!wasPrepared) {
+        pluginInstance->prepareToPlay(44100.0, 1);
+      }
+
+      juce::AudioBuffer<float> flushBuffer(numChannels, 1);
+      flushBuffer.clear();
+      juce::MidiBuffer emptyMidi;
+      pluginInstance->processBlock(flushBuffer, emptyMidi);
+
+      if (!wasPrepared) {
+        pluginInstance->releaseResources();
+      }
+    }
+
     // Get the plugin state's .vstpreset representation if possible.
     GetPresetVisitor visitor(dest);
     pluginInstance->getExtensions(visitor);
@@ -1255,15 +1281,9 @@ public:
 
       currentPositionInfo.isPlaying = true;
       pluginInstance->processBlock(audioBuffer, emptyMidiBuffer);
-      currentPositionInfo.isPlaying = false;
 
       samplesProvided += outputBlock.getNumSamples();
       currentPositionInfo.timeInSamples += outputBlock.getNumSamples();
-
-      // Pump the processBlock callback to tell the VST that we've stopped
-      // playing:
-      juce::AudioBuffer<float> emptyBuffer(channelPointers.size(), 0);
-      pluginInstance->processBlock(emptyBuffer, emptyMidiBuffer);
 
       // To compensate for any latency added by the plugin,
       // only tell Pedalboard to use the last _n_ samples.
@@ -1743,7 +1763,7 @@ example: a Windows VST3 plugin bundle will not load on Linux or macOS.)
            py::arg("preset_file_path"))
       .def_property(
           "preset_data",
-          [](const ExternalPlugin<juce::PatchedVST3PluginFormat> &plugin) {
+          [](ExternalPlugin<juce::PatchedVST3PluginFormat> &plugin) {
             juce::MemoryBlock presetData;
             plugin.getPreset(presetData);
             return py::bytes((const char *)presetData.getData(),

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -233,11 +233,21 @@ atexit.register(delete_installed_plugins)
 if os.environ.get("ENABLE_TESTING_WITH_LOCAL_PLUGINS", False):
     for plugin_class in pedalboard._AVAILABLE_PLUGIN_CLASSES:
         for plugin_path in plugin_class.installed_plugins:
+            if os.environ.get("LOCAL_PLUGIN_NAMES", "").lower() not in plugin_path.lower():
+                continue
+            if any(
+                x in plugin_path.lower()
+                for x in os.environ.get("NOT_LOCAL_PLUGIN_NAMES", "").lower().split(",")
+            ):
+                continue
             try:
                 load_test_plugin(plugin_path)
                 AVAILABLE_EFFECT_PLUGINS_IN_TEST_ENVIRONMENT.append(plugin_path)
             except Exception as e:
                 print(f"Tried to load {plugin_path} for local testing, but failed with: {e}")
+                import traceback
+
+                traceback.print_exception(e)
 
             # Even if the plugin failed to load, add it to
             # the list of known container plugins if necessary:


### PR DESCRIPTION
## Summary

- Adds playhead position tracking (`currentPositionInfo`) for external VST3/AU plugins, reporting the current time in samples during processing
- Reports time position for both audio and MIDI plugin processing paths
- Notifies plugins when rendering has stopped

This is a rebased version of @psobot's PR #301. All credit for the implementation goes to @psobot.

Fixes #295

## Test plan

- [ ] Verify external plugins receive correct playhead position during audio processing
- [ ] Verify MIDI plugins also receive time position information
- [ ] Run existing external plugin test suite (`tests/test_external_plugins.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)