### PR TITLE
Fix VST3 effect plugins rendering dry audio on Windows

### DIFF
--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -1137,7 +1137,11 @@ public:
         setNumChannels(spec.numChannels);
       }
 
-      pluginInstance->setNonRealtime(true);
+      // Some VST3 effects behave differently, or pass audio through
+      // unchanged, when the host forces offline rendering mode.
+      // Use realtime mode for normal processing so effect plugins behave
+      // consistently across platforms, especially on Windows.
+      pluginInstance->setNonRealtime(false);
       pluginInstance->prepareToPlay(spec.sampleRate, spec.maximumBlockSize);
 
       lastSpec = spec;

--- a/tests/test_external_plugins.py
+++ b/tests/test_external_plugins.py
@@ -1005,6 +1005,24 @@ def test_external_plugin_latency_compensation(buffer_size: int, oversampling: in
     np.testing.assert_allclose(output, noise, atol=0.05)
 
 
+@pytest.mark.skipif(not plugin_named("CHOWTapeModel"), reason="Missing CHOWTapeModel plugin.")
+@pytest.mark.parametrize("buffer_size", [16, 65536])
+def test_external_effect_plugin_changes_audio(buffer_size: int):
+    """
+    Regression test for VST3 effects that expose parameters successfully but
+    still render dry audio instead of applying processing.
+    """
+    sample_rate = 48000
+    noise = np.random.rand(sample_rate).astype(np.float32) * 2.0 - 1.0
+
+    plugin = load_test_plugin(plugin_named("CHOWTapeModel"), disable_caching=True)
+    plugin.bypass = False
+
+    output = plugin.process(noise, sample_rate, buffer_size=buffer_size)
+    assert output.shape == noise.shape
+    assert not np.allclose(output, noise, atol=1e-4)
+
+
 @pytest.mark.skipif(platform.system() == "Windows", reason="Windows subprocess handling")
 @pytest.mark.parametrize("plugin_filename", ONE_AVAILABLE_TEST_PLUGIN)
 def test_show_editor(plugin_filename: str):


### PR DESCRIPTION
Fixes a Windows-specific VST3 hosting issue where effect plugins could load and expose parameters but still render dry audio. This switches normal external-plugin processing to realtime mode and adds a regression test to verify that a non-bypassed VST3 effect actually changes the signal.