### PR TITLE
Use HTTP for submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/timothytylee/libgsm.git
 [submodule "vendors/pybind11"]
 	path = vendors/pybind11
-	url = git@github.com:pybind/pybind11.git
+	url = https://github.com/pybind/pybind11.git


### PR DESCRIPTION
A single submodule's URL was set to use SSH. Anyone attempting to clone or build this project needed to set up SSH along with an SSH key in the build environment, and then register that key with GitHub.

The repository is public, and does not require authentication.

Use HTTPS to clone this submodule.

References: https://github.com/spotify/pedalboard/issues/478