### PR TITLE
Add MonoToMulti plugin wrapper for per-channel processing

### DIFF
--- a/pedalboard/plugin_templates/FixedBlockSize.h
+++ b/pedalboard/plugin_templates/FixedBlockSize.h
@@ -251,9 +251,6 @@ private:
   unsigned int samplesProcessed = 0;
 };
 
-// TODO: Add plugin wrappers to make mono plugins stereo (and/or multichannel),
-// or to mixdown to mono.
-
 /**
  * A test plugin used to verify the behaviour of the FixedBlockSize wrapper.
  */

--- a/pedalboard/plugin_templates/MonoToMulti.h
+++ b/pedalboard/plugin_templates/MonoToMulti.h
@@ -1,0 +1,126 @@
+/*
+ * pedalboard
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the GNU Public License, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "../JuceHeader.h"
+#include "../Plugin.h"
+#include <vector>
+
+#include "../plugins/AddLatency.h"
+
+namespace Pedalboard {
+
+/**
+ * A template class that wraps a mono Pedalboard plugin and runs an
+ * independent instance of it on each channel of a multichannel signal.
+ * This is the inverse of ForceMono: instead of mixing down to mono,
+ * it fans out each channel to its own plugin copy.
+ */
+template <typename T, typename SampleType = float>
+class MonoToMulti : public Plugin {
+public:
+  virtual ~MonoToMulti(){};
+
+  virtual void prepare(const juce::dsp::ProcessSpec &spec) {
+    juce::dsp::ProcessSpec monoSpec = spec;
+    monoSpec.numChannels = 1;
+
+    while (plugins.size() < spec.numChannels) {
+      plugins.push_back(std::make_unique<T>());
+    }
+
+    for (size_t i = 0; i < spec.numChannels; i++) {
+      plugins[i]->prepare(monoSpec);
+    }
+
+    lastSpec = spec;
+  }
+
+  virtual int
+  process(const juce::dsp::ProcessContextReplacing<SampleType> &context) {
+    auto ioBlock = context.getOutputBlock();
+    int samplesProcessed = 0;
+
+    for (size_t c = 0; c < ioBlock.getNumChannels(); c++) {
+      juce::dsp::AudioBlock<SampleType> monoBlock =
+          ioBlock.getSingleChannelBlock(c);
+      juce::dsp::ProcessContextReplacing<SampleType> monoContext(monoBlock);
+      int result = plugins[c]->process(monoContext);
+      if (c == 0) {
+        samplesProcessed = result;
+      }
+    }
+
+    return samplesProcessed;
+  }
+
+  virtual void reset() {
+    for (auto &p : plugins) {
+      p->reset();
+    }
+  }
+
+  T &getNestedPlugin(size_t channel = 0) { return *plugins[channel]; }
+
+private:
+  std::vector<std::unique_ptr<T>> plugins;
+};
+
+/**
+ * A test plugin used to verify the behaviour of the MonoToMulti wrapper.
+ * Reuses ExpectsMono from ForceMono.h to assert each channel is processed
+ * as mono independently.
+ */
+class ExpectsMonoPerChannel : public AddLatency {
+public:
+  virtual ~ExpectsMonoPerChannel(){};
+
+  virtual void prepare(const juce::dsp::ProcessSpec &spec) {
+    if (spec.numChannels != 1) {
+      throw std::runtime_error("Expected mono input!");
+    }
+    AddLatency::prepare(spec);
+  }
+
+  virtual int
+  process(const juce::dsp::ProcessContextReplacing<float> &context) {
+    if (context.getInputBlock().getNumChannels() != 1) {
+      throw std::runtime_error("Expected mono input!");
+    }
+    return AddLatency::process(context);
+  }
+};
+
+using MonoToMultiTestPlugin = MonoToMulti<ExpectsMonoPerChannel>;
+
+inline void init_mono_to_multi_test_plugin(py::module &m) {
+  py::class_<MonoToMultiTestPlugin, Plugin,
+             std::shared_ptr<MonoToMultiTestPlugin>>(m,
+                                                     "MonoToMultiTestPlugin")
+      .def(py::init(
+          []() { return std::make_unique<MonoToMultiTestPlugin>(); }))
+      .def("__repr__", [](const MonoToMultiTestPlugin &plugin) {
+        std::ostringstream ss;
+        ss << "<pedalboard.MonoToMultiTestPlugin";
+        ss << " at " << &plugin;
+        ss << ">";
+        return ss.str();
+      });
+}
+
+} // namespace Pedalboard

--- a/pedalboard/python_bindings.cpp
+++ b/pedalboard/python_bindings.cpp
@@ -36,6 +36,7 @@ namespace py = pybind11;
 
 #include "plugin_templates/FixedBlockSize.h"
 #include "plugin_templates/ForceMono.h"
+#include "plugin_templates/MonoToMulti.h"
 #include "plugin_templates/PrimeWithSilence.h"
 #include "plugin_templates/Resample.h"
 
@@ -243,6 +244,7 @@ If the number of samples and the number of channels are the same, each
   init_resample_with_latency(internal);
   init_fixed_size_block_test_plugin(internal);
   init_force_mono_test_plugin(internal);
+  init_mono_to_multi_test_plugin(internal);
 
   // I/O helpers and utilities:
   py::module io = m.def_submodule("io");

--- a/tests/test_mono_to_multi.py
+++ b/tests/test_mono_to_multi.py
@@ -1,0 +1,62 @@
+#! /usr/bin/env python
+#
+# Copyright 2021 Spotify AB
+#
+# Licensed under the GNU Public License, Version 3.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.gnu.org/licenses/gpl-3.0.html
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import numpy as np
+import pytest
+
+from pedalboard_native._internal import MonoToMultiTestPlugin  # type: ignore
+
+NUM_SECONDS = 1.0
+
+
+@pytest.mark.parametrize("sample_rate", [22050, 44100])
+@pytest.mark.parametrize("buffer_size", [1, 16, 128, 8192])
+def test_mono_to_multi_stereo(sample_rate, buffer_size):
+    """Each stereo channel should be processed independently."""
+    stereo_noise = np.stack(
+        [
+            np.random.rand(int(NUM_SECONDS * sample_rate)),
+            np.random.rand(int(NUM_SECONDS * sample_rate)),
+        ]
+    ).astype(np.float32)
+    output = MonoToMultiTestPlugin().process(
+        stereo_noise, sample_rate, buffer_size=buffer_size
+    )
+    assert output.shape == stereo_noise.shape
+    assert not np.allclose(output[0], output[1]), (
+        "Channels should differ when inputs differ"
+    )
+
+
+@pytest.mark.parametrize("sample_rate", [22050, 44100])
+@pytest.mark.parametrize("buffer_size", [1, 16, 128, 8192])
+def test_mono_to_multi_on_mono(sample_rate, buffer_size):
+    """Mono input should pass through normally."""
+    mono_noise = np.random.rand(int(NUM_SECONDS * sample_rate)).astype(np.float32)
+    output = MonoToMultiTestPlugin().process(
+        mono_noise, sample_rate, buffer_size=buffer_size
+    )
+    assert output.shape == mono_noise.shape
+
+
+@pytest.mark.parametrize("sample_rate", [22050, 44100])
+def test_mono_to_multi_identical_channels_produce_identical_output(sample_rate):
+    """If both channels have the same input, both outputs should match."""
+    mono = np.random.rand(int(NUM_SECONDS * sample_rate)).astype(np.float32)
+    stereo = np.stack([mono, mono])
+    output = MonoToMultiTestPlugin().process(stereo, sample_rate)
+    np.testing.assert_allclose(output[0], output[1])


### PR DESCRIPTION
## Problem

Pedalboard has `ForceMono<T>` for mixing multichannel audio down to mono before processing, but no inverse — a wrapper that takes a mono-only plugin and runs it independently on each channel of a multichannel signal. This was noted as a TODO in `FixedBlockSize.h:254`, added in #76.

## Solution

Add `MonoToMulti<T>` template in `plugin_templates/MonoToMulti.h`. It allocates one instance of the wrapped plugin per channel using `unique_ptr` (plugins are non-copyable due to `std::mutex`), prepares each with a mono `ProcessSpec`, and processes each channel through its own instance. Includes a test plugin registered in `_internal`.

## Result

Mono plugins can now be used in stereo or multichannel contexts without cross-channel interference. `ForceMono` (mixdown) and `MonoToMulti` (fan-out) are now complementary wrappers. The TODO is resolved.