### PR TITLE
fix: raise TypeError for unrecognised messages in normalize_midi_messages

### DIFF
--- a/pedalboard/midi_utils.py
+++ b/pedalboard/midi_utils.py
@@ -43,9 +43,19 @@ def normalize_midi_messages(_input) -> List[Tuple[bytes, float]]:
     Given a duck-typed Python input, usually an iterable of MIDI messages,
     normalize the input to a list of tuples of bytes which can be converted
     into a juce::MidiBuffer on the C++ side.
+
+    Each element of ``_input`` must be one of:
+
+    * An object with ``bytes()`` and ``time`` attributes (e.g. ``mido.Message``).
+    * A 2-tuple/list of ``(message, timestamp)`` where *message* is ``bytes``,
+      a ``list`` of byte values, or another bytes-like object, and *timestamp*
+      is a ``float`` in seconds.
+
+    Raises ``TypeError`` if an element cannot be interpreted as a MIDI message,
+    so callers receive a clear error rather than silently losing events.
     """
     output = []
-    for message in _input:
+    for index, message in enumerate(_input):
         if hasattr(message, "bytes") and hasattr(message, "time"):
             output.append((bytes(message.bytes()), message.time))
         elif (isinstance(message, tuple) or isinstance(message, list)) and len(message) == 2:
@@ -57,6 +67,12 @@ def normalize_midi_messages(_input) -> List[Tuple[bytes, float]]:
             elif not isinstance(message, bytes):
                 message = bytes(message)
             output.append((message, time))
+        else:
+            raise TypeError(
+                f"Could not interpret MIDI message at index {index}: {message!r}. "
+                "Expected an object with 'bytes()' and 'time' attributes (e.g. mido.Message), "
+                "or a 2-element tuple/list of (message_bytes, timestamp_seconds)."
+            )
 
     # Detect the case in which the provided timestamps
     # are likely delta values rather than absolute values:

--- a/tests/test_midi_utils.py
+++ b/tests/test_midi_utils.py
@@ -36,3 +36,41 @@ from pedalboard.midi_utils import normalize_midi_messages
 )
 def test_mido_normalization(_input, expected: List[Tuple[bytes, float]]):
     assert normalize_midi_messages(_input) == expected
+
+@pytest.mark.parametrize(
+    "bad_message,expected_index",
+    [
+        # 1-tuple — timestamp accidentally omitted
+        ([(bytes([0x90, 60, 64]),)], 0),
+        # 3-tuple — extra unexpected field
+        ([(bytes([0x90, 60, 64]), 0.0, "extra")], 0),
+        # bare bytes — no timestamp provided
+        ([bytes([0x90, 60, 64])], 0),
+        # bare integer — not a message at all
+        ([(bytes([0x90, 60, 64]), 0.0), 42], 1),
+        # None
+        ([None], 0),
+    ],
+)
+def test_malformed_message_raises_type_error(bad_message, expected_index):
+    """Malformed messages must raise TypeError, not be silently dropped."""
+    with pytest.raises(TypeError, match=f"index {expected_index}"):
+        normalize_midi_messages(bad_message)
+
+
+def test_malformed_message_error_contains_repr():
+    """The TypeError message must include the offending value's repr."""
+    bad = (bytes([0x90, 60, 64]),)  # 1-tuple
+    with pytest.raises(TypeError, match=r"b'\\x90<@'"):
+        normalize_midi_messages([bad])
+
+
+def test_valid_messages_unaffected_by_fix():
+    """The happy path must still work correctly after the fix."""
+    result = normalize_midi_messages([
+        (bytes([0x90, 60, 64]), 0.0),
+        (bytes([0x80, 60, 64]), 1.0),
+    ])
+    assert len(result) == 2
+    assert result[0] == (bytes([0x90, 60, 64]), 0.0)
+    assert result[1] == (bytes([0x80, 60, 64]), 1.0)


### PR DESCRIPTION
## What this PR does

Fixes the silent data-loss bug in `normalize_midi_messages()` where
unrecognised MIDI messages (wrong tuple length, bare bytes, unknown type,
etc.) were silently dropped from the output list.

## Changes

- `pedalboard/midi_utils.py` — Added `else` branch that raises `TypeError`
  with the index and repr of the offending element, so callers get an
  immediate, actionable error instead of a shorter-than-expected list.
- `tests/test_midi_utils.py` — Added parametrized regression tests covering
  1-tuples, 3-tuples, bare bytes, bare integers, and `None`.

## Closes

Closes #489

## How to test

```bash
pytest tests/test_midi_utils.py -v
```

All new tests should pass. The existing `test_mido_normalization` test is
unaffected.

## Before / After

**Before:**
```python
result = normalize_midi_messages([(bytes([0x90, 60, 64]),)])
print(result)  # [] — silently dropped, no error
```

**After:**
```python
result = normalize_midi_messages([(bytes([0x90, 60, 64]),)])
# TypeError: Could not interpret MIDI message at index 0: (b'\x90<@',).
# Expected an object with 'bytes()' and 'time' attributes (e.g. mido.Message),
# or a 2-element tuple/list of (message_bytes, timestamp_seconds).
```