### PR TITLE
Raise a descriptive error when unscaled integer audio is passed (fixes #407)

### DIFF
--- a/pedalboard/process.h
+++ b/pedalboard/process.h
@@ -21,6 +21,9 @@
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 
+#include <cmath>
+#include <sstream>
+
 #include "BufferUtils.h"
 #include "Plugin.h"
 #include "PluginContainer.h"
@@ -28,6 +31,64 @@
 namespace py = pybind11;
 
 namespace Pedalboard {
+
+/**
+ * Detect the common mistake of passing integer PCM audio (for example, 16-bit
+ * data with a range of [-32768, 32767]) that has been converted to a
+ * floating-point data type without being rescaled into the [-1.0, 1.0] range
+ * that Pedalboard expects. Some plugins (like Reverb or Delay) are roughly
+ * scale-invariant and appear to work with such data, while others (like
+ * Compressor, Limiter, or PitchShift) fail in confusing ways, so we raise a
+ * descriptive error up front.
+ *
+ * This is effectively a no-op for real audio: as soon as a single fractional
+ * (or non-finite) sample is found, the check bails out, so the common case
+ * adds only a handful of instructions.
+ */
+inline void throwErrorIfBufferLooksLikeUnscaledIntegerData(
+    const py::array_t<float, py::array::c_style> &inputArray) {
+  py::buffer_info inputInfo = inputArray.request();
+  const float *data = static_cast<const float *>(inputInfo.ptr);
+  if (data == nullptr)
+    return;
+
+  size_t numSamples = 1;
+  for (auto dimension : inputInfo.shape)
+    numSamples *= static_cast<size_t>(dimension);
+  if (numSamples == 0)
+    return;
+
+  float maxMagnitude = 0.0f;
+  for (size_t i = 0; i < numSamples; i++) {
+    float sample = data[i];
+    // Real-world floating-point audio almost always contains fractional sample
+    // values; as soon as we see one (or any non-finite value) we know this is
+    // not unscaled integer data and can stop scanning.
+    if (!std::isfinite(sample) || sample != std::floor(sample))
+      return;
+    float magnitude = std::fabs(sample);
+    if (magnitude > maxMagnitude)
+      maxMagnitude = magnitude;
+  }
+
+  // Every sample was an exact integer. Values within the [-1.0, 1.0] range
+  // (such as digital silence or a full-scale square wave) are still valid
+  // audio, so only raise if the peak is outside of the expected range.
+  if (maxMagnitude > 1.0f) {
+    std::ostringstream ss;
+    ss << "The audio buffer provided to Pedalboard contains only "
+          "integer-valued samples, with a peak value of "
+       << maxMagnitude
+       << ", which is outside the expected range of [-1.0, 1.0]. This usually "
+          "indicates that integer PCM audio (for example, 16-bit data ranging "
+          "from -32768 to 32767) was converted to a floating-point data type "
+          "without being rescaled into the [-1.0, 1.0] range that Pedalboard "
+          "expects. To fix this, divide your audio by the maximum value of its "
+          "original integer type before processing (for example: "
+          "`audio.astype(numpy.float32) / 32768`).";
+    throw py::value_error(ss.str());
+  }
+}
 
 inline int process(juce::AudioBuffer<float> &ioBuffer,
                    juce::dsp::ProcessSpec spec,
@@ -290,6 +351,8 @@ py::array_t<float> process(py::array inputArray, double sampleRate,
     throw py::type_error("Pedalboard only supports 32-bit and 64-bit floating "
                          "point audio for processing.");
   }
+
+  throwErrorIfBufferLooksLikeUnscaledIntegerData(float32InputArray);
 
   return processFloat32(float32InputArray, sampleRate, plugins, bufferSize,
                         reset);

--- a/tests/test_integer_input_validation.py
+++ b/tests/test_integer_input_validation.py
@@ -1,0 +1,89 @@
+#! /usr/bin/env python
+#
+# Copyright 2025 Spotify AB
+#
+# Licensed under the GNU Public License, Version 3.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.gnu.org/licenses/gpl-3.0.html
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import numpy as np
+import pytest
+
+import pedalboard
+from pedalboard import Gain, Pedalboard
+
+from .utils import generate_sine_at
+
+SAMPLE_RATE = 44100
+
+
+def _int16_scaled_as_float(dtype) -> np.ndarray:
+    """A sine wave that was scaled to the int16 range but left as floating point.
+
+    This mimics the most common version of this mistake: calling something like
+    ``(audio * 32767).astype(np.int16).astype(np.float32)`` and passing the
+    result straight into Pedalboard without rescaling back to [-1.0, 1.0].
+    """
+    sine_wave = generate_sine_at(SAMPLE_RATE, num_seconds=0.1)
+    return (sine_wave * 32767).astype(np.int16).astype(dtype)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_unscaled_integer_input_raises_descriptive_error(dtype):
+    unscaled = _int16_scaled_as_float(dtype)
+    with pytest.raises(ValueError, match="integer-valued"):
+        Pedalboard([Gain()])(unscaled, SAMPLE_RATE)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_unscaled_integer_input_raises_on_single_plugin(dtype):
+    unscaled = _int16_scaled_as_float(dtype)
+    with pytest.raises(ValueError, match=r"\[-1.0, 1.0\]"):
+        Gain().process(unscaled, SAMPLE_RATE)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_unscaled_integer_input_raises_on_process_function(dtype):
+    unscaled = _int16_scaled_as_float(dtype)
+    with pytest.raises(ValueError, match="rescaled"):
+        pedalboard.process(unscaled, SAMPLE_RATE, [Gain()])
+
+
+@pytest.mark.parametrize("num_channels", [1, 2])
+def test_correctly_scaled_integer_input_is_accepted(num_channels):
+    sine_wave = generate_sine_at(SAMPLE_RATE, num_seconds=0.1, num_channels=num_channels)
+    # The correct way to use int16 data: rescale back into [-1.0, 1.0].
+    rescaled = (sine_wave * 32767).astype(np.int16).astype(np.float32) / 32768.0
+    output = Pedalboard([Gain()])(rescaled, SAMPLE_RATE)
+    assert np.all(np.isfinite(output))
+
+
+@pytest.mark.parametrize(
+    "signal",
+    [
+        pytest.param(generate_sine_at(SAMPLE_RATE, num_seconds=0.1).astype(np.float32), id="sine"),
+        pytest.param(np.zeros(1024, dtype=np.float32), id="silence"),
+        pytest.param(np.ones(1024, dtype=np.float32), id="full_scale_dc"),
+        pytest.param(
+            np.sign(generate_sine_at(SAMPLE_RATE, num_seconds=0.1)).astype(np.float32),
+            id="full_scale_square_wave",
+        ),
+        pytest.param(
+            (generate_sine_at(SAMPLE_RATE, num_seconds=0.1) * 3.5 + 0.1).astype(np.float32),
+            id="hot_non_integer_signal",
+        ),
+        pytest.param(np.zeros(0, dtype=np.float32), id="empty"),
+    ],
+)
+def test_legitimate_float_audio_is_not_flagged(signal):
+    output = Pedalboard([Gain()])(signal, SAMPLE_RATE)
+    assert np.all(np.isfinite(output))


### PR DESCRIPTION
## Summary

Fixes #407.

In several reported cases (#406, #390, #369), users passed integer PCM data (e.g. `int16`) that had been converted to `float32`/`float64` **without** rescaling it into the `[-1.0, 1.0]` range that Pedalboard expects. Scale-invariant plugins (Reverb, Delay) appear to work, while others (Compressor, Limiter, PitchShift) fail in confusing ways.

This adds a small check in the shared C++ `process()` entry point in `pedalboard/process.h` — the single code path used by `pedalboard.process(...)`, `Plugin.process(...)`/`Plugin.__call__`, and `Pedalboard.__call__` (via `Chain`). If **every** sample is an exact integer **and** the peak magnitude exceeds `1.0`, it raises a `ValueError` explaining the likely cause and the fix.

## Behavior

- Raises a descriptive `ValueError` for buffers that look like unscaled integer PCM data (e.g. `(audio * 32767).astype(np.int16).astype(np.float32)`).
- Does **not** affect legitimate float audio. The check returns on the first fractional or non-finite sample, so for real-world audio it adds only a handful of instructions and never allocates.
- In-range integer-valued buffers (digital silence, a full-scale `±1.0` square wave, DC at `1.0`) are still accepted, since those are valid audio.

## Why this location

`process()` in `process.h` is the single chokepoint that all Python-facing processing entry points route through, so the validation covers every case (`Pedalboard`, individual plugins, and the module-level `process` function) with one implementation. The check runs while the GIL is still held, before the heavy processing begins.

## Notes on testing

I validated the detection heuristic numerically against the released `pedalboard` wheel across many signal types (sine waves, random noise, silence, full-scale DC/square waves, hot non-integer signals, empty and stereo buffers): zero false positives, and the documented `int16`-as-`float32` case is caught (its peak of ~29490 otherwise reaches the Limiter).

`tests/test_integer_input_validation.py` is added to cover:
- `int16`-as-`float32` and `-as-float64` raising `ValueError` via `Pedalboard`, a single `Plugin`, and `pedalboard.process`.
- Correctly-rescaled integer data being accepted.
- A range of legitimate float signals not being flagged.

I was unable to compile the native extension locally (no C++ toolchain on my machine), so I have not run the compiled test suite end-to-end — CI will build and run the new tests. `ruff`, `black` (line length 100), and `flake8` all pass on the new test file.