### PR TITLE
build: Make USE_PORTABLE_SIMD build baseline binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,11 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # Debug/Release configuration
 option(DEBUG "Build with debug symbols" OFF)
 
+set(USE_PORTABLE_SIMD OFF)
+if(DEFINED ENV{USE_PORTABLE_SIMD} AND NOT "$ENV{USE_PORTABLE_SIMD}" STREQUAL "")
+    set(USE_PORTABLE_SIMD ON)
+endif()
+
 if(DEBUG)
     add_compile_definitions(DEBUG=1 _DEBUG=1)
     add_compile_options(-O0 -g)
@@ -195,19 +200,15 @@ elseif(UNIX AND NOT APPLE)
     include_directories(${FREETYPE_INCLUDE_DIRS})
     list(APPEND PLATFORM_LIBRARIES ${FREETYPE_LIBRARIES} ${ALSA_LIBRARIES})
     
-    # Processor-specific optimizations (x86 vs ARM)
-    if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
-        add_compile_definitions(HAVE_NEON=1)
-    else()
-        # Use -march=native for local builds to optimize for the current CPU,
-        # but use a portable baseline for CI builds to avoid "Illegal instruction" errors
-        # when ccache restores objects built on different runner hardware.
-        if(DEFINED ENV{USE_PORTABLE_SIMD})
-            add_compile_options(-mavx)
+    if(NOT USE_PORTABLE_SIMD)
+        # Processor-specific optimizations (x86 vs ARM)
+        if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
+            add_compile_definitions(HAVE_NEON=1)
         else()
+            # Use -march=native for local builds to optimize for the current CPU.
             add_compile_options(-march=native)
+            add_compile_definitions(HAVE_AVX)
         endif()
-        add_compile_definitions(HAVE_AVX)
     endif()
     
     # Additional Linux flags
@@ -309,8 +310,14 @@ function(collect_sources)
         # Exclude files depending on architecture
         if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
             list(FILTER FFTW_SOURCES EXCLUDE REGEX ".*(avx|/sse).*")
+            if(USE_PORTABLE_SIMD)
+                list(FILTER FFTW_SOURCES EXCLUDE REGEX ".*neon.*")
+            endif()
         else()
             list(FILTER FFTW_SOURCES EXCLUDE REGEX ".*neon.*")
+            if(USE_PORTABLE_SIMD)
+                list(FILTER FFTW_SOURCES EXCLUDE REGEX ".*(avx|/sse).*")
+            endif()
         endif()
         
         # Exclude unused FFTW components

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ from subprocess import check_output
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
 DEBUG = bool(int(os.environ.get("DEBUG", 0)))
+USE_PORTABLE_SIMD = bool(os.environ.get("USE_PORTABLE_SIMD"))
 
 # C or C++ flags:
 BASE_CPP_FLAGS = [
@@ -171,29 +172,30 @@ elif platform.system() == "Linux":
     # On ARM, ignore the X86-specific SIMD code:
     if "arm" in platform.processor() or "aarch64" in platform.processor():
         fftw_paths = ignore_files_matching(fftw_paths, "avx", "/sse")
-        ALL_CFLAGS.append("-DHAVE_NEON=1")
+        if USE_PORTABLE_SIMD:
+            fftw_paths = ignore_files_matching(fftw_paths, "neon")
+        else:
+            ALL_CFLAGS.append("-DHAVE_NEON=1")
     else:
         # And on x86, ignore the ARM-specific SIMD code (and KCVI; not GCC or Clang compatible).
         fftw_paths = ignore_files_matching(fftw_paths, "neon")
-        # Use -march=native for local builds to optimize for the current CPU,
-        # but use a portable baseline for CI builds to avoid "Illegal instruction" errors
-        # when ccache restores objects built on different runner hardware.
-        if os.getenv("USE_PORTABLE_SIMD"):
-            ALL_CFLAGS.append("-mavx")
+        if USE_PORTABLE_SIMD:
+            fftw_paths = ignore_files_matching(fftw_paths, "avx", "/sse")
         else:
+            # Use -march=native for local builds to optimize for the current CPU.
             ALL_CFLAGS.append("-march=native")
-        # Enable SIMD instructions:
-        ALL_CFLAGS.extend(
-            [
-                # "-DHAVE_SSE2",
-                "-DHAVE_AVX",  # Testing shows this is all we need!
-                # "-DHAVE_AVX_128_FMA", # AMD only
-                # "-DHAVE_AVX2",
-                # "-DHAVE_AVX512", # No measurable speed difference
-                # "-DHAVE_GENERIC_SIMD128", # Crashes!
-                # "-DHAVE_GENERIC_SIMD256", # Also crashes!
-            ]
-        )
+            # Enable SIMD instructions:
+            ALL_CFLAGS.extend(
+                [
+                    # "-DHAVE_SSE2",
+                    "-DHAVE_AVX",  # Testing shows this is all we need!
+                    # "-DHAVE_AVX_128_FMA", # AMD only
+                    # "-DHAVE_AVX2",
+                    # "-DHAVE_AVX512", # No measurable speed difference
+                    # "-DHAVE_GENERIC_SIMD128", # Crashes!
+                    # "-DHAVE_GENERIC_SIMD256", # Also crashes!
+                ]
+            )
 
     ALL_SOURCE_PATHS += fftw_paths
 


### PR DESCRIPTION
Problem

USE_PORTABLE_SIMD is currently not truly portable. On x86 it replaces -march=native with -mavx, while both build systems still define HAVE_AVX and compile FFTW's AVX codelets. Wheels or distro packages built that way can run AVX instructions on older CPUs and fail with Illegal instruction. ARM builds have the same generic distribution concern when HAVE_NEON is enabled.

Solution

Keep the optimized local-build behavior by default. When USE_PORTABLE_SIMD is set, stop passing -mavx, -march=native, and the AVX/NEON feature macros. Also filter AVX, SSE, and NEON FFTW SIMD sources from the CMake and legacy setup.py build paths.

Result

USE_PORTABLE_SIMD now produces a baseline binary suitable for distro packaging and CI distribution. Future work can add runtime SIMD feature detection and select AVX or NEON implementations only when the running CPU supports them.