### PR TITLE
Fix documentation typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ Use [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) for C++ code,
 
 ## Issues
 
-When creating an issue please try to ahere to the following format:
+When creating an issue please try to adhere to the following format:
 
     module-name: One line summary of the issue (less than 72 characters)
 


### PR DESCRIPTION
## Summary
I fix spelling mistakes in documentation and changelog text.

Changed files:
- `CONTRIBUTING.md`

## Testing
I run `git diff --check`.
