### PR TITLE
fix: raise TypeError for unrecognised MIDI messages in normalize_midi_messages

### DIFF
--- a/pedalboard/midi_utils.py
+++ b/pedalboard/midi_utils.py
@@ -45,7 +45,7 @@ def normalize_midi_messages(_input) -> List[Tuple[bytes, float]]:
     into a juce::MidiBuffer on the C++ side.
     """
     output = []
-    for message in _input:
+    for i, message in enumerate(_input):
         if hasattr(message, "bytes") and hasattr(message, "time"):
             output.append((bytes(message.bytes()), message.time))
         elif (isinstance(message, tuple) or isinstance(message, list)) and len(message) == 2:
@@ -57,6 +57,11 @@ def normalize_midi_messages(_input) -> List[Tuple[bytes, float]]:
             elif not isinstance(message, bytes):
                 message = bytes(message)
             output.append((message, time))
+        else:
+            raise TypeError(
+                f"MIDI message at index {i} could not be interpreted: {message!r}. "
+                "Expected a (bytes, float) tuple or an object with .bytes() and .time attributes."
+            )
 
     # Detect the case in which the provided timestamps
     # are likely delta values rather than absolute values:

--- a/tests/test_midi_utils.py
+++ b/tests/test_midi_utils.py
@@ -36,3 +36,25 @@ from pedalboard.midi_utils import normalize_midi_messages
 )
 def test_mido_normalization(_input, expected: List[Tuple[bytes, float]]):
     assert normalize_midi_messages(_input) == expected
+
+
+@pytest.mark.parametrize(
+    "bad_message,expected_index",
+    [
+        # 1-tuple: timestamp accidentally omitted
+        ((bytes([0x90, 60, 64]),), 1),
+        # 3-tuple: extra unexpected field
+        ((bytes([0x90, 60, 64]), 0.0, "extra"), 0),
+        # raw bytes with no timestamp
+        (bytes([0x90, 60, 64]), 0),
+        # bare integer
+        (42, 0),
+        # None
+        (None, 0),
+    ],
+)
+def test_normalize_midi_messages_raises_on_malformed(bad_message, expected_index):
+    valid = (bytes([0x90, 60, 64]), 0.0)
+    messages = [valid] * expected_index + [bad_message]
+    with pytest.raises(TypeError, match=f"index {expected_index}"):
+        normalize_midi_messages(messages)


### PR DESCRIPTION
Fixes #489.

`normalize_midi_messages()` used an `if / elif` chain with no `else` branch, so any message that did not match the expected `(bytes, float)` tuple shape or a duck-typed `mido.Message` was silently dropped. The caller received a shorter output list with no indication that events were lost — wrong tuple length, missing timestamp, raw `bytes`, `None`, etc. all vanished without error.

**Change:**
- Switched the `for` loop to `enumerate()` to track the message index.
- Added an `else` branch that raises `TypeError` with the offending index and value.

**Test:**
Added `test_normalize_midi_messages_raises_on_malformed` in `tests/test_midi_utils.py`, covering five malformed shapes: 1-tuple (missing timestamp), 3-tuple (extra field), raw `bytes`, bare integer, and `None`.