### PR TITLE
Fix libexecinfo includes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,8 @@ if(DEFINED ENV{CIBW_BUILD} AND "$ENV{CIBW_BUILD}" MATCHES "musllinux")
         _NL_IDENTIFICATION_LANGUAGE=0x42
         _NL_IDENTIFICATION_TERRITORY=0x43
     )
+    # musl doesn't provide execinfo.h; use our stub in vendors/
+    include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/vendors)
 endif()
 
 # Rubber Band library flags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,7 @@ if(DEFINED ENV{CIBW_BUILD} AND "$ENV{CIBW_BUILD}" MATCHES "musllinux")
     add_compile_definitions(
         _NL_IDENTIFICATION_LANGUAGE=0x42
         _NL_IDENTIFICATION_TERRITORY=0x43
+        _LARGEFILE64_SOURCE
     )
     # musl doesn't provide execinfo.h; use our stub in vendors/
     include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/vendors)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ archs = ["auto"]
 # Use apk instead of yum when building on Alpine Linux
 # (Note: this is experimental, as most VSTs require glibc and thus Alpine Linux isn't that useful)
 select = "*-musllinux*"
-before-all = "apk add libsndfile libx11-dev libxrandr-dev libxinerama-dev libxrender-dev libxcomposite-dev libxinerama-dev libxcursor-dev freetype-dev libexecinfo-dev alsa-lib-dev"
+before-all = "apk add libsndfile libx11-dev libxrandr-dev libxinerama-dev libxrender-dev libxcomposite-dev libxinerama-dev libxcursor-dev freetype-dev alsa-lib-dev"
 
 [project]
 name = "pedalboard"


### PR DESCRIPTION
The new musllinux Docker images (required by cibuildwheel) don't support `libexecinfo-dev`, which we required; but as it turns out, we have our own stub in `vendors/` that was just not being compiled in.