### PR TITLE
docs: fix outdated Python version and typo in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We'd love to get patches from you!
 
 To compile Pedalboard from scratch, the following packages will need to be installed:
 
-- [Python 3.8](https://www.python.org/downloads/) or higher.
+- [Python 3.10](https://www.python.org/downloads/) or higher.
 - A C++ compiler, e.g. `gcc`, `clang`, etc.
   - On macOS, a working Xcode installation should provide this.
 - On Linux:
@@ -91,7 +91,7 @@ Use [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) for C++ code,
 
 ## Issues
 
-When creating an issue please try to ahere to the following format:
+When creating an issue please try to adhere to the following format:
 
     module-name: One line summary of the issue (less than 72 characters)
 


### PR DESCRIPTION
Problem

CONTRIBUTING.md lists Python 3.8 as the minimum required version to build pedalboard from source. This is outdated. The README states pedalboard is tested with Python 3.10–3.14, and the v0.9.16 changelog confirms Python 3.8 support was dropped. New contributors following CONTRIBUTING.md could be misled about the correct minimum version. Separately, there's a typo ("ahere") in the Issues section.

Solution

Updated the minimum Python version in the Prerequisites section from 3.8 to 3.10, matching the README and changelog. Changed "ahere" to "adhere".

Result

CONTRIBUTING.md now correctly states the supported minimum Python version, and the typo is corrected.