### PR TITLE
docs: update copyright year in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ To cite via BibTeX:
 ```
 
 ## License
-`pedalboard` is Copyright 2021-2025 Spotify AB.
+`pedalboard` is Copyright 2021-2026 Spotify AB.
 
 `pedalboard` is licensed under the [GNU General Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html). `pedalboard` includes a number of libraries that are statically compiled, and which carry the following licenses:
 


### PR DESCRIPTION
Closes #498

Problem

The README states pedalboard is Copyright 2021-2025 Spotify AB, but the repo has ongoing 2026 activity (commits, releases), making the year range stale.

Solution

Updated the copyright year range from 2021-2025 to 2021-2026.

Result

The License section of the README now reflects the current year.