### PR TITLE
Allow the Convolution impulse response to be replaced after construction

### DIFF
--- a/pedalboard/plugins/Convolution.h
+++ b/pedalboard/plugins/Convolution.h
@@ -43,9 +43,11 @@ public:
 
   double getMix() const noexcept { return mix; }
 
-  void setImpulseResponseFilename(std::string &filename) {
+  void setImpulseResponseFilename(const std::string &filename) {
     impulseResponseFilename = filename;
   }
+
+  void clearImpulseResponseFilename() { impulseResponseFilename.reset(); }
 
   const std::optional<std::string> &getImpulseResponseFilename() const {
     return impulseResponseFilename;
@@ -55,8 +57,10 @@ public:
     impulseResponse = {std::move(ir)};
   }
 
+  void clearImpulseResponse() { impulseResponse.reset(); }
+
   const std::optional<juce::AudioBuffer<float>> &getImpulseResponse() const {
-    return {impulseResponse};
+    return impulseResponse;
   }
 
   void setSampleRate(double sr) { sampleRate = {sr}; }
@@ -91,6 +95,62 @@ private:
   std::optional<double> sampleRate;
 };
 
+/**
+ * Load an impulse response into an existing ConvolutionWithMix from a file on
+ * disk. Also records the file's sample rate, so the impulse response can later
+ * be replaced with a NumPy array without re-specifying the sample rate. The
+ * caller is responsible for releasing the GIL, as this reads from disk.
+ */
+inline void loadImpulseResponseFromFile(ConvolutionWithMix &dsp,
+                                        const std::string &filename) {
+  auto inputFile = juce::File(filename);
+
+  // Test opening the file before passing it to loadImpulseResponse (which
+  // reloads it in the background) so that errors surface immediately:
+  {
+    juce::FileInputStream stream(inputFile);
+    if (!stream.openedOk()) {
+      throw std::runtime_error("Unable to load impulse response: " + filename);
+    }
+  }
+
+  // Capture the source sample rate so a later NumPy-array assignment can reuse
+  // it. This is best-effort: if the format has no reader, the sample rate is
+  // simply left unset.
+  juce::AudioFormatManager formatManager;
+  formatManager.registerBasicFormats();
+  if (std::unique_ptr<juce::AudioFormatReader> reader{
+          formatManager.createReaderFor(inputFile)}) {
+    dsp.setSampleRate(reader->sampleRate);
+  }
+
+  dsp.getConvolution().loadImpulseResponse(
+      inputFile, juce::dsp::Convolution::Stereo::yes,
+      juce::dsp::Convolution::Trim::no, 0);
+  dsp.setImpulseResponseFilename(filename);
+  // The filename is now the source of truth; drop any cached array so that
+  // ``impulse_response_filename`` and ``impulse_response`` stay consistent.
+  dsp.clearImpulseResponse();
+}
+
+/**
+ * Load an impulse response into an existing ConvolutionWithMix from a NumPy
+ * array at the given sample rate.
+ */
+inline void loadImpulseResponseFromArray(
+    ConvolutionWithMix &dsp,
+    const py::array_t<float, py::array::c_style> &inputArray,
+    double sampleRate) {
+  dsp.getConvolution().loadImpulseResponse(
+      std::move(copyPyArrayIntoJuceBuffer(inputArray)), sampleRate,
+      juce::dsp::Convolution::Stereo::yes, juce::dsp::Convolution::Trim::no,
+      juce::dsp::Convolution::Normalise::yes);
+  dsp.setImpulseResponse(copyPyArrayIntoJuceBuffer(inputArray));
+  dsp.setSampleRate(sampleRate);
+  // A raw array has no filename; clear any stale one.
+  dsp.clearImpulseResponseFilename();
+}
+
 inline void init_convolution(py::module &m) {
   py::class_<JucePlugin<ConvolutionWithMix>, Plugin,
              std::shared_ptr<JucePlugin<ConvolutionWithMix>>>(
@@ -100,8 +160,13 @@ inline void init_convolution(py::module &m) {
       "The convolution impulse response can be specified either by filename or "
       "as a 32-bit floating point NumPy array. If a NumPy array is provided, "
       "the ``sample_rate`` argument must also be provided to indicate the "
-      "sample rate of the impulse response.\n\n*Support for passing NumPy "
-      "arrays as impulse responses introduced in v0.9.10.*")
+      "sample rate of the impulse response.\n\n"
+      "The impulse response can also be replaced after construction by "
+      "assigning to the ``impulse_response_filename`` or ``impulse_response`` "
+      "properties.\n\n*Support for passing NumPy "
+      "arrays as impulse responses introduced in v0.9.10. Support for "
+      "replacing the impulse response after construction introduced in "
+      "v0.9.18.*")
       .def(py::init([](std::variant<std::string,
                                     py::array_t<float, py::array::c_style>>
                            impulseResponse,
@@ -111,24 +176,8 @@ inline void init_convolution(py::module &m) {
              if (auto *impulseResponseFilename =
                      std::get_if<std::string>(&impulseResponse)) {
                py::gil_scoped_release release;
-               // Load the IR file on construction, to handle errors
-               auto inputFile = juce::File(*impulseResponseFilename);
-               // Test opening the file before we pass it to
-               // loadImpulseResponse, which reloads it in the background:
-               {
-                 juce::FileInputStream stream(inputFile);
-                 if (!stream.openedOk()) {
-                   throw std::runtime_error(
-                       "Unable to load impulse response: " +
-                       *impulseResponseFilename);
-                 }
-               }
-
-               plugin->getDSP().getConvolution().loadImpulseResponse(
-                   inputFile, juce::dsp::Convolution::Stereo::yes,
-                   juce::dsp::Convolution::Trim::no, 0);
-               plugin->getDSP().setImpulseResponseFilename(
-                   *impulseResponseFilename);
+               loadImpulseResponseFromFile(plugin->getDSP(),
+                                           *impulseResponseFilename);
              } else if (auto *inputArray =
                             std::get_if<py::array_t<float, py::array::c_style>>(
                                 &impulseResponse)) {
@@ -137,15 +186,8 @@ inline void init_convolution(py::module &m) {
                      "sample_rate must be provided when passing a numpy array "
                      "as an impulse response.");
                }
-               plugin->getDSP().getConvolution().loadImpulseResponse(
-                   std::move(copyPyArrayIntoJuceBuffer(*inputArray)),
-                   *sampleRate, juce::dsp::Convolution::Stereo::yes,
-                   juce::dsp::Convolution::Trim::no,
-                   juce::dsp::Convolution::Normalise::yes);
-
-               plugin->getDSP().setImpulseResponse(
-                   copyPyArrayIntoJuceBuffer(*inputArray));
-               plugin->getDSP().setSampleRate(*sampleRate);
+               loadImpulseResponseFromArray(plugin->getDSP(), *inputArray,
+                                            *sampleRate);
              }
              plugin->getDSP().setMix(mix);
              return plugin;
@@ -173,12 +215,19 @@ inline void init_convolution(py::module &m) {
              ss << ">";
              return ss.str();
            })
-      .def_property_readonly(
+      .def_property(
           "impulse_response_filename",
           [](JucePlugin<ConvolutionWithMix> &plugin) {
             return plugin.getDSP().getImpulseResponseFilename();
-          })
-      .def_property_readonly(
+          },
+          [](JucePlugin<ConvolutionWithMix> &plugin,
+             const std::string &filename) {
+            py::gil_scoped_release release;
+            loadImpulseResponseFromFile(plugin.getDSP(), filename);
+          },
+          "The path to an audio file to use as the impulse response. Assigning "
+          "a new filename replaces the impulse response in place.")
+      .def_property(
           "impulse_response",
           [](JucePlugin<ConvolutionWithMix> &plugin)
               -> std::optional<py::array_t<float, py::array::c_style>> {
@@ -189,7 +238,23 @@ inline void init_convolution(py::module &m) {
             } else {
               return {};
             }
-          })
+          },
+          [](JucePlugin<ConvolutionWithMix> &plugin,
+             py::array_t<float, py::array::c_style> array) {
+            auto sampleRate = plugin.getDSP().getSampleRate();
+            if (!sampleRate) {
+              throw std::runtime_error(
+                  "Cannot set impulse_response as a NumPy array without a "
+                  "known sample rate. Construct this Convolution with a "
+                  "sample_rate, or assign to impulse_response_filename "
+                  "instead.");
+            }
+            loadImpulseResponseFromArray(plugin.getDSP(), array, *sampleRate);
+          },
+          "The impulse response as a 32-bit floating point NumPy array, or "
+          "``None`` if the impulse response was loaded from a file. Assigning "
+          "a NumPy array replaces the impulse response in place, reusing the "
+          "existing sample rate.")
       .def_property(
           "mix",
           [](JucePlugin<ConvolutionWithMix> &plugin) {

--- a/pedalboard_native/__init__.pyi
+++ b/pedalboard_native/__init__.pyi
@@ -313,7 +313,9 @@ class Convolution(Plugin):
 
     The convolution impulse response can be specified either by filename or as a 32-bit floating point NumPy array. If a NumPy array is provided, the ``sample_rate`` argument must also be provided to indicate the sample rate of the impulse response.
 
-    *Support for passing NumPy arrays as impulse responses introduced in v0.9.10.*
+    The impulse response can also be replaced after construction by assigning to the ``impulse_response_filename`` or ``impulse_response`` properties.
+
+    *Support for passing NumPy arrays as impulse responses introduced in v0.9.10. Support for replacing the impulse response after construction introduced in v0.9.18.*
     """
 
     def __init__(
@@ -331,10 +333,16 @@ class Convolution(Plugin):
     ) -> typing.Optional[NDArray[float32]]:
         """ """
 
+    @impulse_response.setter
+    def impulse_response(self, arg1: NDArray[float32]) -> None:
+        pass
     @property
     def impulse_response_filename(self) -> typing.Optional[str]:
         """ """
 
+    @impulse_response_filename.setter
+    def impulse_response_filename(self, arg1: str) -> None:
+        pass
     @property
     def mix(self) -> float:
         """ """

--- a/tests/test_native_module.py
+++ b/tests/test_native_module.py
@@ -167,6 +167,41 @@ def test_convolution_impulse_response_storage():
     np.testing.assert_allclose(conv.impulse_response, ir)
 
 
+def test_convolution_set_impulse_response_filename(sr=44100, duration=1):
+    noise = np.random.rand(sr * duration).astype(np.float32)
+    # Start from a NumPy-array impulse response, then swap in a file in place.
+    conv = Convolution(np.random.rand(2, 128).astype(np.float32), 0.5, sr)
+    conv.impulse_response_filename = IMPULSE_RESPONSE_PATH
+    assert conv.impulse_response_filename == IMPULSE_RESPONSE_PATH
+    # The filename is now the source of truth, so the array is cleared.
+    assert conv.impulse_response is None
+    expected = Convolution(IMPULSE_RESPONSE_PATH, 0.5)(noise, sr)
+    np.testing.assert_allclose(conv(noise, sr), expected, atol=0.0001)
+
+
+def test_convolution_set_impulse_response_array(sr=44100, duration=1):
+    noise = np.random.rand(sr * duration).astype(np.float32)
+    with AudioFile(IMPULSE_RESPONSE_PATH) as f:
+        ir = f.read(f.frames)
+    # Start from a file, then swap in an array. The sample rate captured when
+    # the file was loaded is reused, so no sample_rate argument is needed.
+    conv = Convolution(IMPULSE_RESPONSE_PATH, 0.5)
+    conv.impulse_response = ir
+    assert conv.impulse_response_filename is None
+    assert conv.impulse_response is not None
+    expected = Convolution(ir, 0.5, sample_rate=sr)(noise, sr)
+    np.testing.assert_allclose(conv(noise, sr), expected, atol=0.0001)
+
+
+def test_convolution_swapping_impulse_response_changes_output(sr=44100, duration=1):
+    noise = np.random.rand(sr * duration).astype(np.float32)
+    conv = Convolution(IMPULSE_RESPONSE_PATH, 1.0)
+    before = conv(noise, sr)
+    conv.impulse_response = np.random.rand(2, 512).astype(np.float32)
+    after = conv(noise, sr)
+    assert not np.allclose(before, after, atol=0.01)
+
+
 @pytest.mark.parametrize("gain_db", [-12, -6, 0, 1.1, 6, 12, 24, 48, 96])
 @pytest.mark.parametrize("shape", [(44100,), (44100, 1), (44100, 2), (1, 44100), (2, 44100)])
 def test_distortion(gain_db, shape, sr=44100):


### PR DESCRIPTION
## What

Makes `Convolution.impulse_response` and `Convolution.impulse_response_filename` settable, so an impulse response can be swapped in place without constructing a new `Convolution`:

```python
conv = pedalboard.Convolution("room.wav", mix=0.5)
conv.impulse_response_filename = "hall.wav"   # reload from a different file
conv.impulse_response = my_ir_array           # or from a float32 NumPy array
```

Previously both were read-only and the IR could only be set at construction time.

## Why

Swapping IRs on an existing instance is handy for A/B-ing cabinets/rooms, batch rendering, and automation, without paying to reconstruct (and re-`prepare`) the plugin each time. `mix` is already settable; this brings the impulse response in line.

## Details

- The **filename setter** loads the new file (mirroring the constructor) and records the file's sample rate, so a subsequent NumPy-array assignment can reuse it without re-specifying `sample_rate`.
- The **array setter** reloads from a `float32` array using the known sample rate, and raises a clear error if none is known.
- Assigning one source clears the other, so the two properties stay consistent (a filename source reports `impulse_response is None`, matching existing construction behaviour).
- The constructor's load logic is factored into two small helpers reused by the setters, so there is no duplicated loading path.
- Fixes a latent bug in `getImpulseResponse()`, which returned a reference to a temporary (`return {impulseResponse};`).

## Tests

Adds tests to `tests/test_native_module.py` covering: swapping to a file, swapping to an array (reusing the captured sample rate), and that swapping the IR changes the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
