### PR TITLE
Add support for Python 3.15

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -28,9 +28,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: actions/checkout@v4
       - name: Install Ruff
+        # Pinned deliberately: Ruff 0.16.0 enables 413 rules by default, up from 59.
+        # We don't set `lint.select` in pyproject.toml, so an unpinned upgrade silently
+        # widened the rule set and surfaced 90 pre-existing findings. Bumping this pin
+        # means adopting (or explicitly selecting away) the newer defaults first.
+        # See: https://astral.sh/blog/ruff-v0.16.0
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          pip install 'ruff==0.15.22'
       - name: Lint Python code
         run: ruff check ${{ github.workspace }}/pedalboard
       - name: Check Python formatting

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -546,6 +546,13 @@ jobs:
               cxx: "ccache clang++",
             }
           - {
+              os: macos-15-intel,
+              python-version: "3.15",
+              compiler: "clang",
+              cc: "ccache clang",
+              cxx: "ccache clang++",
+            }
+          - {
               os: ubuntu-24.04,
               python-version: "3.10",
               compiler: "gcc",
@@ -581,6 +588,13 @@ jobs:
               cxx: "ccache g++",
             }
           - {
+              os: ubuntu-24.04,
+              python-version: "3.15",
+              compiler: "gcc",
+              cc: "ccache gcc",
+              cxx: "ccache g++",
+            }
+          - {
               os: windows-latest,
               python-version: "3.10",
               compiler: "msvc",
@@ -611,6 +625,13 @@ jobs:
           - {
               os: windows-latest,
               python-version: "3.14",
+              compiler: "msvc",
+              cc: "msvc",
+              cxx: "msvc",
+            }
+          - {
+              os: windows-latest,
+              python-version: "3.15",
               compiler: "msvc",
               cc: "msvc",
               cxx: "msvc",
@@ -621,6 +642,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          # Required while the newest Python in the matrix is still a release candidate:
+          allow-prereleases: true
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -750,7 +773,7 @@ jobs:
     needs: [prime-asan-build-caches]
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
         os: ["ubuntu-24.04"]
     name: Test with Python ${{ matrix.python-version }} + Address Sanitizer
     steps:
@@ -758,6 +781,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          # Required while the newest Python in the matrix is still a release candidate:
+          allow-prereleases: true
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -850,6 +875,8 @@ jobs:
           - { os: macos-15-intel, build: cp313-macosx_arm64 }
           - { os: macos-15-intel, build: cp314-macosx_arm64 }
           - { os: macos-15-intel, build: cp314t-macosx_arm64 }
+          - { os: macos-15-intel, build: cp315-macosx_arm64 }
+          - { os: macos-15-intel, build: cp315t-macosx_arm64 }
           # - { os: macos-15-intel, build: pp38-macosx_x86_64 }
           # - { os: macos-15-intel, build: pp39-macosx_x86_64 }
           - { os: windows-latest, build: cp310-win_amd64 }
@@ -857,6 +884,7 @@ jobs:
           - { os: windows-latest, build: cp312-win_amd64 }
           - { os: windows-latest, build: cp313-win_amd64 }
           - { os: windows-latest, build: cp314-win_amd64 }
+          - { os: windows-latest, build: cp315-win_amd64 }
           # - { os: windows-latest, build: cp312-win32 }
           - { os: "ubuntu-24.04", build: cp310-manylinux_x86_64 }
           - { os: "ubuntu-24.04-arm", build: cp310-manylinux_aarch64 }
@@ -877,6 +905,9 @@ jobs:
           - { os: "ubuntu-24.04", build: cp314-manylinux_x86_64 }
           - { os: "ubuntu-24.04-arm", build: cp314-manylinux_aarch64 }
           - { os: "ubuntu-24.04-arm", build: cp314t-manylinux_aarch64 }
+          - { os: "ubuntu-24.04", build: cp315-manylinux_x86_64 }
+          - { os: "ubuntu-24.04-arm", build: cp315-manylinux_aarch64 }
+          - { os: "ubuntu-24.04-arm", build: cp315t-manylinux_aarch64 }
     name: Build wheel for ${{ matrix.build }}
     steps:
       - uses: actions/checkout@v4
@@ -887,7 +918,9 @@ jobs:
         with:
           python-version: "3.13"
       - name: Install cibuildwheel
-        run: python -m pip install 'cibuildwheel>=3.0,<4'
+        # cibuildwheel 4.2.0 is the first release to build CPython 3.15 wheels by
+        # default (using 3.15.0rc1, which is ABI-compatible with the final release).
+        run: python -m pip install 'cibuildwheel>=4.2,<5'
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you are new to Python, follow [INSTALLATION.md](https://github.com/spotify/pe
 
 ### Compatibility
 
-`pedalboard` is thoroughly tested with Python 3.10, 3.11, 3.12, 3.13, and 3.14.
+`pedalboard` is thoroughly tested with Python 3.10, 3.11, 3.12, 3.13, 3.14, and 3.15.
 
 - Linux
   - Tested heavily in production use cases at Spotify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ archs = ["x86_64", "arm64", "universal2"]
 
 [tool.cibuildwheel.windows]
 archs = ["auto"]
+# cibuildwheel 4.0 made delvewheel the default repair step on Windows. Pedalboard
+# links its dependencies statically, so keep the pre-4.0 behaviour of not repairing.
+repair-wheel-command = ""
 
 [[tool.cibuildwheel.overrides]]
 # Use apk instead of yum when building on Alpine Linux
@@ -50,6 +53,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
 ]
 dependencies = ["numpy"]
 version = "0.9.24"

--- a/setup.py
+++ b/setup.py
@@ -493,6 +493,7 @@ setup(
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3.14",
+        "Programming Language :: Python :: 3.15",
     ],
     ext_modules=[pedalboard_cpp],
     install_requires=["numpy"],

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,7 +9,10 @@ pip>22; python_version > '3.6'
 pip>21; python_version < '3.7'
 wheel
 
-numpy>=2.1.0rc1; python_version>="3.13"
+# NumPy 2.5.2 is the first release with CPython 3.15 wheels; without this floor,
+# pip could silently fall back to building an older NumPy from source on 3.15.
+numpy>=2.5.2; python_version>="3.15"
+numpy>=2.1.0rc1; python_version>="3.13" and python_version<"3.15"
 numpy>=2; python_version>="3.9" and python_version<"3.13"
 numpy<2; python_version<="3.8"
 tqdm


### PR DESCRIPTION
Testing Py 3.15 wheels now that NumPy ships 3.15 support.