### PR TITLE
docs: add missing Convolution import in README live-audio example

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ an <code class="docutils literal"><span class="pre">AudioStream</span></code> ob
 allowing for real-time manipulation of audio by adding effects in Python.
 
 ```python
-from pedalboard import Pedalboard, Chorus, Compressor, Delay, Gain, Reverb, Phaser, Convolution
+from pedalboard import Pedalboard, Chorus, Convolution, Compressor, Delay, Gain, Reverb, Phaser
 from pedalboard.io import AudioStream
 
 # Open up an audio stream:

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ an <code class="docutils literal"><span class="pre">AudioStream</span></code> ob
 allowing for real-time manipulation of audio by adding effects in Python.
 
 ```python
-from pedalboard import Pedalboard, Chorus, Compressor, Delay, Gain, Reverb, Phaser
+from pedalboard import Pedalboard, Chorus, Compressor, Delay, Gain, Reverb, Phaser, Convolution
 from pedalboard.io import AudioStream
 
 # Open up an audio stream:


### PR DESCRIPTION
## Summary

Fixes #412.

The **Running Pedalboard on Live Audio** section of the README uses `Convolution("./guitar_amp.wav", 1.0)` in the effect chain, but `Convolution` is not included in the example's import statement. Copying and running the snippet as-is raises `NameError: name 'Convolution' is not defined`.

This adds `Convolution` to the import line so the example runs as written.

## Test plan

- [x] Verified the snippet references `Convolution` but did not import it.
- [x] Single-line docs change; no code/behavior impact.
