### PR TITLE
Raise TypeError on malformed MIDI messages instead of silently dropping them

### DIFF
--- a/pedalboard/midi_utils.py
+++ b/pedalboard/midi_utils.py
@@ -45,7 +45,7 @@ def normalize_midi_messages(_input) -> List[Tuple[bytes, float]]:
     into a juce::MidiBuffer on the C++ side.
     """
     output = []
-    for message in _input:
+    for index, message in enumerate(_input):
         if hasattr(message, "bytes") and hasattr(message, "time"):
             output.append((bytes(message.bytes()), message.time))
         elif (isinstance(message, tuple) or isinstance(message, list)) and len(message) == 2:
@@ -57,6 +57,13 @@ def normalize_midi_messages(_input) -> List[Tuple[bytes, float]]:
             elif not isinstance(message, bytes):
                 message = bytes(message)
             output.append((message, time))
+        else:
+            raise TypeError(
+                f"Unable to interpret MIDI message at index {index}: {message!r}. "
+                "MIDI messages must either be objects with `bytes` and `time` attributes "
+                "(like mido.Message) or (message, timestamp) tuples, where timestamp is "
+                "the number of seconds from the start of the returned audio buffer."
+            )
 
     # Detect the case in which the provided timestamps
     # are likely delta values rather than absolute values:

--- a/tests/test_midi_utils.py
+++ b/tests/test_midi_utils.py
@@ -36,3 +36,29 @@ from pedalboard.midi_utils import normalize_midi_messages
 )
 def test_mido_normalization(_input, expected: List[Tuple[bytes, float]]):
     assert normalize_midi_messages(_input) == expected
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        pytest.param((bytes([0x90, 60, 64]),), id="one_tuple_missing_timestamp"),
+        pytest.param((bytes([0x90, 60, 64]), 0.0, 99), id="three_tuple_extra_element"),
+        pytest.param(bytes([0x90, 60, 64]), id="bare_bytes_without_timestamp"),
+        pytest.param(None, id="none"),
+        pytest.param(42, id="bare_int"),
+    ],
+)
+def test_malformed_messages_raise(malformed):
+    """Malformed messages must raise rather than being silently dropped."""
+    messages = [
+        (bytes([0x90, 60, 64]), 0.0),
+        malformed,
+        (bytes([0x80, 60, 64]), 1.0),
+    ]
+    with pytest.raises(TypeError, match="index 1"):
+        normalize_midi_messages(messages)
+
+
+def test_valid_messages_are_unaffected():
+    messages = [(bytes([0x90, 60, 64]), 0.0), (bytes([0x80, 60, 64]), 1.0)]
+    assert normalize_midi_messages(messages) == messages


### PR DESCRIPTION
Fixes #489.

## The problem

`normalize_midi_messages()` iterates with `if` / `elif` and no `else`, so any message it can't interpret is skipped:

```python
for message in _input:
    if hasattr(message, "bytes") and hasattr(message, "time"):
        ...
    elif (isinstance(message, tuple) or isinstance(message, list)) and len(message) == 2:
        ...
    # anything else falls through silently
```

The caller gets a shorter list back with no indication events were lost. In practice this surfaces much later as missing notes in the rendered audio, with no traceback to debug from.

Reproduced on `master` before the fix — every one of these silently loses a message:

```
1-tuple (missing timestamp)      in=3 out=2  -> 1 silently dropped
3-tuple (extra field)            in=2 out=1  -> 1 silently dropped
bare bytes (no timestamp)        in=2 out=1  -> 1 silently dropped
None element                     in=2 out=1  -> 1 silently dropped
bare int                         in=2 out=1  -> 1 silently dropped
```

## The change

An `else` branch that raises `TypeError` naming the offending index and value:

```
TypeError: Unable to interpret MIDI message at index 1: (b'\x90<@',). MIDI messages
must either be objects with `bytes` and `time` attributes (like mido.Message) or
(message, timestamp) tuples, where timestamp is the number of seconds from the start
of the returned audio buffer.
```

Plus tests for the five shapes that were previously dropped, and one asserting valid input is unaffected.

## Note on compatibility

This turns previously-silent behavior into an exception, so it's technically a behavior change — code passing malformed messages today gets an error instead of quietly wrong audio. That seemed like the intent of the issue, but happy to switch it to a `warnings.warn()` instead if you'd rather keep it non-breaking for a release cycle.

## Test log

```
$ pytest tests/test_midi_utils.py -q      # on master, with the new tests, WITHOUT the fix
FAILED tests/test_midi_utils.py::test_malformed_messages_raise[one_tuple_missing_timestamp]
FAILED tests/test_midi_utils.py::test_malformed_messages_raise[three_tuple_extra_element]
FAILED tests/test_midi_utils.py::test_malformed_messages_raise[bare_bytes_without_timestamp]
FAILED tests/test_midi_utils.py::test_malformed_messages_raise[none]
FAILED tests/test_midi_utils.py::test_malformed_messages_raise[bare_int]
5 failed, 2 passed in 0.11s

$ pytest tests/test_midi_utils.py -q      # with the fix
.......                                                                  [100%]
7 passed in 0.05s

$ ruff format --check pedalboard/midi_utils.py tests/test_midi_utils.py
2 files already formatted

$ flake8 pedalboard/midi_utils.py tests/test_midi_utils.py
(clean)
```

`ruff check` reports the same 12 pre-existing findings before and after this change; I left those alone to keep the diff focused.

---

Disclosure: I used an AI assistant while working on this. I reviewed the change, verified the failing/passing behavior locally, and can speak to any line of it.