### PR TITLE
noise-gate: Reject ratios below 1.0, as Compressor already does

### DIFF
--- a/pedalboard/plugins/NoiseGate.h
+++ b/pedalboard/plugins/NoiseGate.h
@@ -26,7 +26,11 @@ namespace Pedalboard {
 template <typename SampleType>
 class NoiseGate : public JucePlugin<juce::dsp::NoiseGate<SampleType>> {
   DEFINE_DSP_SETTER_AND_GETTER(SampleType, Threshold, {});
-  DEFINE_DSP_SETTER_AND_GETTER(SampleType, Ratio, {});
+  DEFINE_DSP_SETTER_AND_GETTER(SampleType, Ratio, {
+    if (value < 1.0) {
+      throw std::range_error("Noise gate ratio must be a value >= 1.0.");
+    }
+  });
   DEFINE_DSP_SETTER_AND_GETTER(SampleType, Attack, {});
   DEFINE_DSP_SETTER_AND_GETTER(SampleType, Release, {});
 };

--- a/tests/test_native_module.py
+++ b/tests/test_native_module.py
@@ -114,6 +114,24 @@ def test_throw_on_invalid_compressor_ratio(sr=44100):
         Compressor(ratio=0.1)
 
 
+@pytest.mark.parametrize("ratio", [0.5, 0.0, -2.0])
+def test_throw_on_invalid_noise_gate_ratio(ratio: float, sr=44100):
+    quiet_noise = (np.random.rand(sr, 1).astype(np.float32) - 0.5) * 0.2
+
+    # Should work:
+    output = process(quiet_noise, sr, [NoiseGate(threshold_db=-6.0, ratio=1.0)])
+    assert np.all(np.abs(output) <= 1.0)
+
+    # Should fail; below 1.0, the gate applies gain instead of attenuation:
+    with pytest.raises(ValueError):
+        NoiseGate(ratio=ratio)
+
+    gate = NoiseGate()
+    with pytest.raises(ValueError):
+        gate.ratio = ratio
+    assert gate.ratio == 10.0
+
+
 def test_convolution_file_exists():
     """
     A meta-test - if this fails, we can't find the file, so the following two tests will fail!


### PR DESCRIPTION
## Problem

`NoiseGate`'s `ratio` setter is declared with an empty validation block, so any
value reaches `juce::dsp::NoiseGate::setRatio`. JUCE guards that only with
`jassert(newRatio >= 1.0)`, compiled out of the release builds we ship. Below
the threshold, `processSample` computes the VCA gain as
`pow(env / threshold, ratio - 1)`, so a ratio under 1.0 makes the exponent
negative and the gate boosts quiet signal instead of attenuating it. Measured on
the released 0.9.24 wheel, 4410 frames of seeded noise at an input peak of
0.09999 through `NoiseGate(threshold_db=-6.0)`:

```
ratio= 10.0 -> output peak 4.72228e-08
ratio=  1.0 -> output peak 0.0999928
ratio=  0.5 -> output peak 0.368421
ratio=  0.0 -> output peak 3.77424
ratio= -2.0 -> output peak 564090
```

A -20 dBFS input comes back 135 dB hot with no error and no warning, and
`ratio=0.0` already leaves `[-1, 1]`. The constructor kwarg and the `.ratio`
property both accept it. `Compressor` guards the same JUCE precondition.

## Solution

Mirror `Compressor.h` and throw `std::range_error` below 1.0.
`DEFINE_DSP_SETTER_AND_GETTER` runs the check before the member assignment and
before the JUCE call, so one block covers both entry points.

## Result

`NoiseGate(ratio=0.5)` and `gate.ratio = 0.5` now raise `ValueError`. Ratios of
1.0 and up are unchanged, so the default of 10 and the gentle-expander use the
docstring mentions still work. Three parametrized cases added to
`tests/test_native_module.py`.

Full suite, excluding `test_audio_stream.py` and `test_external_plugins.py`
(audio device, plugin downloads). Against the released 0.9.24 binary:
`4 failed, 26556 passed, 2 skipped`. Against a build of this branch:
`26560 passed, 2 skipped`. Three of those four failures are the new tests; the
fourth is `test_read_from_bytes_io_memoryview_without_gil`, a threads-versus-
serial timing test that passes on both builds when run on its own.
`clang-format 14 -style=LLVM`, `ruff 0.15.22 check` and `ruff format --check`
report no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
