### PR TITLE
Raise TypeError for malformed MIDI messages

### DIFF
--- a/pedalboard/midi_utils.py
+++ b/pedalboard/midi_utils.py
@@ -45,7 +45,7 @@ def normalize_midi_messages(_input) -> List[Tuple[bytes, float]]:
     into a juce::MidiBuffer on the C++ side.
     """
     output = []
-    for message in _input:
+    for index, message in enumerate(_input):
         if hasattr(message, "bytes") and hasattr(message, "time"):
             output.append((bytes(message.bytes()), message.time))
         elif (isinstance(message, tuple) or isinstance(message, list)) and len(message) == 2:
@@ -57,6 +57,10 @@ def normalize_midi_messages(_input) -> List[Tuple[bytes, float]]:
             elif not isinstance(message, bytes):
                 message = bytes(message)
             output.append((message, time))
+        else:
+            raise TypeError(
+                f"Unable to interpret MIDI message at index {index}: {message!r}"
+            )
 
     # Detect the case in which the provided timestamps
     # are likely delta values rather than absolute values:

--- a/tests/test_midi_utils.py
+++ b/tests/test_midi_utils.py
@@ -36,3 +36,18 @@ from pedalboard.midi_utils import normalize_midi_messages
 )
 def test_mido_normalization(_input, expected: List[Tuple[bytes, float]]):
     assert normalize_midi_messages(_input) == expected
+
+
+def test_malformed_message_raises_type_error():
+    messages = [
+        (bytes([0x90, 60, 64]), 0.0),
+        (bytes([0x90, 62, 64]),),
+        (bytes([0x80, 60, 64]), 1.0),
+    ]
+    with pytest.raises(TypeError, match=r"index 1"):
+        normalize_midi_messages(messages)
+
+
+def test_bare_bytes_message_raises_type_error():
+    with pytest.raises(TypeError, match=r"index 0"):
+        normalize_midi_messages([bytes([0x90, 60, 64])])


### PR DESCRIPTION
Fixes #489

Malformed MIDI events were dropped with no error. The caller just got a shorter list.

normalize_midi_messages now raises TypeError with the index and the bad value.

## Tests
* One element tuple missing a timestamp
* Bare bytes
